### PR TITLE
JMS #25: Added support for help flags

### DIFF
--- a/app.go
+++ b/app.go
@@ -32,19 +32,22 @@ func (a *App) Run(arguments []string) {
 	// append help to commands
 	a.Commands = append(a.Commands, helpCommand)
 	// append version to flags
-	a.Flags = append(a.Flags, BoolFlag{"version", "print the version"})
+	a.Flags = append(
+		a.Flags,
+		BoolFlag{"version", "print the version"},
+		helpFlag{"show help"},
+	)
 
 	// parse flags
 	set := flagSet(a.Name, a.Flags)
-	set.Parse(arguments[1:])
+	err := set.Parse(arguments[1:])
+	if err != nil {
+		os.Exit(1)
+	}
 
 	context := NewContext(a, set, set)
-
-	// check version
-	if context.GlobalBool("version") {
-		showVersion(context)
-		return
-	}
+	checkHelp(context)
+	checkVersion(context)
 
 	args := context.Args()
 	if len(args) > 0 {

--- a/context.go
+++ b/context.go
@@ -62,7 +62,7 @@ func (c *Context) lookupInt(name string, set *flag.FlagSet) int {
 		}
 		return val
 	}
-	
+
 	return 0
 }
 
@@ -71,7 +71,7 @@ func (c *Context) lookupString(name string, set *flag.FlagSet) string {
 	if f != nil {
 		return f.Value.String()
 	}
-	
+
 	return ""
 }
 
@@ -84,6 +84,6 @@ func (c *Context) lookupBool(name string, set *flag.FlagSet) bool {
 		}
 		return val
 	}
-	
+
 	return false
 }

--- a/context_test.go
+++ b/context_test.go
@@ -2,8 +2,8 @@ package cli_test
 
 import (
 	"flag"
-	"testing"
 	"github.com/codegangsta/cli"
+	"testing"
 )
 
 func TestNewContext(t *testing.T) {

--- a/flag.go
+++ b/flag.go
@@ -9,7 +9,7 @@ type Flag interface {
 }
 
 func flagSet(name string, flags []Flag) *flag.FlagSet {
-	set := flag.NewFlagSet(name, flag.ExitOnError)
+	set := flag.NewFlagSet(name, flag.ContinueOnError)
 	for _, f := range flags {
 		f.Apply(set)
 	}
@@ -55,4 +55,17 @@ func (f IntFlag) String() string {
 
 func (f IntFlag) Apply(set *flag.FlagSet) {
 	set.Int(f.Name, f.Value, f.Usage)
+}
+
+type helpFlag struct {
+	Usage string
+}
+
+func (f helpFlag) String() string {
+	return fmt.Sprintf("--help, -h\t%v", f.Usage)
+}
+
+func (f helpFlag) Apply(set *flag.FlagSet) {
+	set.Bool("h", false, f.Usage)
+	set.Bool("help", false, f.Usage)
 }

--- a/help.go
+++ b/help.go
@@ -51,28 +51,34 @@ var helpCommand = Command{
 	Action: func(c *Context) {
 		args := c.Args()
 		if len(args) > 0 {
-			showCommandHelp(c)
+			ShowCommandHelp(c, args[0])
 		} else {
-			showAppHelp(c)
+			ShowAppHelp(c)
 		}
 	},
 }
 
-func showAppHelp(c *Context) {
+// Prints help for the App
+func ShowAppHelp(c *Context) {
 	printHelp(AppHelpTemplate, c.App)
 }
 
-func showCommandHelp(c *Context) {
-	name := c.Args()[0]
+// Prints help for the given command
+func ShowCommandHelp(c *Context, command string) {
 	for _, c := range c.App.Commands {
-		if c.HasName(name) {
+		if c.HasName(command) {
 			printHelp(CommandHelpTemplate, c)
 			return
 		}
 	}
 
-	fmt.Printf("No help topic for '%v'\n", name)
+	fmt.Printf("No help topic for '%v'\n", command)
 	os.Exit(1)
+}
+
+// Prints the version number of the App
+func ShowVersion(c *Context) {
+	fmt.Printf("%v version %v\n", c.App.Name, c.App.Version)
 }
 
 func printHelp(templ string, data interface{}) {
@@ -82,6 +88,16 @@ func printHelp(templ string, data interface{}) {
 	w.Flush()
 }
 
-func showVersion(c *Context) {
-	fmt.Printf("%v version %v\n", c.App.Name, c.App.Version)
+func checkVersion(c *Context) {
+	if c.GlobalBool("version") {
+		ShowVersion(c)
+		os.Exit(0)
+	}
+}
+
+func checkHelp(c *Context) {
+	if c.GlobalBool("h") || c.GlobalBool("help") {
+		ShowAppHelp(c)
+		os.Exit(0)
+	}
 }


### PR DESCRIPTION
## Help Flags Support

cli.go now supports help flags "-h/--help" for showing help. I also exposed a couple new methods to the Public interface for showing help and version, `ShowVersion`, `ShowAppHelp`, and `ShowCommandHelp`.

This PR is in reference to issue #25 
@SJD I am going to keep this PR up for the better part of today in case you want to eyeball it, after some time I will land it.

closes #25 
