### PR TITLE
Flag tweaks

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -22,7 +22,7 @@ type BoolFlag struct {
 }
 
 func (f BoolFlag) String() string {
-	return fmt.Sprintf("-%v\t%v", f.Name, f.Usage)
+	return fmt.Sprintf("%s%v\t%v", prefixFor(f.Name), f.Name, f.Usage)
 }
 
 func (f BoolFlag) Apply(set *flag.FlagSet) {
@@ -36,7 +36,7 @@ type StringFlag struct {
 }
 
 func (f StringFlag) String() string {
-	return fmt.Sprintf("--%v '%v'\t%v", f.Name, f.Value, f.Usage)
+	return fmt.Sprintf("%s%v '%v'\t%v", prefixFor(f.Name), f.Name, f.Value, f.Usage)
 }
 
 func (f StringFlag) Apply(set *flag.FlagSet) {
@@ -50,7 +50,7 @@ type IntFlag struct {
 }
 
 func (f IntFlag) String() string {
-	return fmt.Sprintf("--%v '%v'\t%v", f.Name, f.Value, f.Usage)
+	return fmt.Sprintf("%s%v '%v'\t%v", prefixFor(f.Name), f.Name, f.Value, f.Usage)
 }
 
 func (f IntFlag) Apply(set *flag.FlagSet) {
@@ -68,4 +68,14 @@ func (f helpFlag) String() string {
 func (f helpFlag) Apply(set *flag.FlagSet) {
 	set.Bool("h", false, f.Usage)
 	set.Bool("help", false, f.Usage)
+}
+
+func prefixFor(name string) (prefix string) {
+	if len(name) == 1 {
+		prefix = "-"
+	} else {
+		prefix = "--"
+	}
+
+	return
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -1,0 +1,67 @@
+package cli_test
+
+import (
+	"github.com/codegangsta/cli"
+	"testing"
+)
+
+var boolFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"help", "--help\t"},
+	{"h", "-h\t"},
+}
+
+func TestBoolFlagHelpOutput(t *testing.T) {
+
+	for _, test := range boolFlagTests {
+		flag := cli.BoolFlag{Name: test.name}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+var stringFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"help", "--help ''\t"},
+	{"h", "-h ''\t"},
+}
+
+func TestStringFlagHelpOutput(t *testing.T) {
+
+	for _, test := range stringFlagTests {
+		flag := cli.StringFlag{Name: test.name}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}
+
+
+var intFlagTests = []struct {
+	name     string
+	expected string
+}{
+	{"help", "--help '0'\t"},
+	{"h", "-h '0'\t"},
+}
+
+func TestIntFlagHelpOutput(t *testing.T) {
+
+	for _, test := range intFlagTests {
+		flag := cli.IntFlag{Name: test.name}
+		output := flag.String()
+
+		if output != test.expected {
+			t.Errorf("%s does not match %s", output, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
Make flag output prefix "-" vs "--" a little more idiomatic with Unix standards for single letter flags.
