### PR TITLE
Allow for flags being passed in after arguments

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -62,3 +62,25 @@ func TestApp_Command(t *testing.T) {
 		expect(t, app.Command(test.name) != nil, test.expected)
 	}
 }
+
+func TestApp_CommandWithArgBeforeFlags(t *testing.T) {
+	var parsedOption, firstArg string
+
+	app := cli.NewApp()
+	command := cli.Command{
+		Name: "cmd",
+		Flags: []cli.Flag{
+			cli.StringFlag{"option", "", "some option"},
+		},
+		Action: func(c *cli.Context) {
+			parsedOption = c.String("option")
+			firstArg = c.Args()[0]
+		},
+	}
+	app.Commands = []cli.Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "--option", "my-option"})
+
+	expect(t, parsedOption, "my-option")
+	expect(t, firstArg, "my-arg")
+}

--- a/command.go
+++ b/command.go
@@ -1,18 +1,19 @@
 package cli
 
 import (
-	"io/ioutil"
 	"os"
 	"fmt"
+	"io/ioutil"
+	"strings"
 )
 
 type Command struct {
-	Name        string
-	ShortName   string
-	Usage       string
-	Description string
-	Action      func(context *Context)
-	Flags       []Flag
+	Name          string
+	ShortName     string
+	Usage         string
+	Description   string
+	Action      func (context *Context)
+	Flags         []Flag
 }
 
 func (c Command) Run(ctx *Context) {
@@ -24,7 +25,23 @@ func (c Command) Run(ctx *Context) {
 
 	set := flagSet(c.Name, c.Flags)
 	set.SetOutput(ioutil.Discard)
-	err := set.Parse(ctx.Args()[1:])
+
+	firstFlagIndex := -1
+	for index, arg := range ctx.Args() {
+		if strings.HasPrefix(arg, "-") {
+			firstFlagIndex = index
+			break
+		}
+	}
+
+	var err error
+	if firstFlagIndex > -1 {
+		args := ctx.Args()[1:firstFlagIndex]
+		flags := ctx.Args()[firstFlagIndex:]
+		err = set.Parse(append(flags, args...))
+	} else {
+		err = set.Parse(ctx.Args()[1:])
+	}
 
 	if err != nil {
 		fmt.Println("Incorrect Usage.\n")


### PR DESCRIPTION
For the Cloud Foundry CLI we need the ability to have flags being passed after other arguments, for example:

```
cf push app --option some-value
```

This commit should allow for both ways to work, but not the mix of the two: flags before and after other arguments won't work.
