### PR TITLE
string slice flag option formatting

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -54,7 +54,7 @@ type StringSliceFlag struct {
 }
 
 func (f StringSliceFlag) String() string {
-	return fmt.Sprintf("%s '%v'\t%v", prefixFor(f.Name), f.Name, "-"+f.Name+" option -"+f.Name+" option", f.Usage)
+	return fmt.Sprintf("%s%s %v\t`%v` %s", prefixFor(f.Name), f.Name, f.Value, "-"+f.Name+" option -"+f.Name+" option", f.Usage)
 }
 
 func (f StringSliceFlag) Apply(set *flag.FlagSet) {


### PR DESCRIPTION
Used to output:

```
-- 'name'          -name option -name option%!(EXTRA string=Usage text)
```

Now:

```
--name []          `-name option -name option` Usage text
```

In this case the `[]` denotes that the default is an empty list.
