### PR TITLE
Allow flags to omit their default value in String()

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -135,10 +135,15 @@ type StringFlag struct {
 	Name  string
 	Value string
 	Usage string
+	OmitDefaultValue bool
 }
 
 func (f StringFlag) String() string {
-	return fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage)
+	if f.OmitDefaultValue {
+		return fmt.Sprintf("%s \t%v", prefixedNames(f.Name), f.Usage)
+	} else {
+		return fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage)
+	}
 }
 
 func (f StringFlag) Apply(set *flag.FlagSet) {
@@ -155,10 +160,15 @@ type IntFlag struct {
 	Name  string
 	Value int
 	Usage string
+	OmitDefaultValue bool
 }
 
 func (f IntFlag) String() string {
-	return fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage)
+	if f.OmitDefaultValue {
+		return fmt.Sprintf("%s \t%v", prefixedNames(f.Name), f.Usage)
+	} else {
+		return fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage)
+	}
 }
 
 func (f IntFlag) Apply(set *flag.FlagSet) {
@@ -175,10 +185,15 @@ type Float64Flag struct {
 	Name  string
 	Value float64
 	Usage string
+	OmitDefaultValue bool
 }
 
 func (f Float64Flag) String() string {
-	return fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage)
+	if f.OmitDefaultValue {
+		return fmt.Sprintf("%s \t%v", prefixedNames(f.Name), f.Usage)
+	} else {
+		return fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage)
+	}
 }
 
 func (f Float64Flag) Apply(set *flag.FlagSet) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -134,3 +134,33 @@ func TestParseMultiBool(t *testing.T) {
 	}
 	a.Run([]string{"run", "--serve"})
 }
+
+func TestStringFlagWithoutDefaultValue(t *testing.T) {
+	flag := cli.StringFlag{Name: "help", Usage: "Show help", OmitDefaultValue: true}
+	output := flag.String()
+
+	if output != "--help \tShow help" {
+		t.Errorf("string without default value should omit default value")
+	}
+}
+
+func TestIntFlagWithoutDefaultValue(t *testing.T) {
+	flag := cli.IntFlag{Name: "help", Usage: "Prints number of help topics", OmitDefaultValue: true}
+	output := flag.String()
+	expected:= "--help \tPrints number of help topics"
+
+	if output != expected {
+		t.Errorf("expected '%s' to equal '%s", output, expected)
+	}
+}
+
+func TestFloatFlagWithoutDefaultValue(t *testing.T) {
+	flag := cli.Float64Flag{Name: "help", Usage: "Prints floating help topics", OmitDefaultValue: true}
+	output := flag.String()
+	expected:= "--help \tPrints floating help topics"
+
+	if output != expected {
+		t.Errorf("expected '%s' to equal '%s", output, expected)
+	}
+}
+


### PR DESCRIPTION
This feature allows users to have a very clean and simple output for flags in --help output. I encountered this in a CLI tool I'm working on, where several string flags have no default value (ie: their actual default value is an empty string), and the resulting output for --help is a little ugly.

In order to accomplish this, I added a bool to some Flag structs, namely `OmitDefaultValue`. As a result of this, the default constructor for StringFlag, IntFlag, and Float64Flag. From what I can tell, few people in the Go community tend to use the default struct constructors without named parameters, but I wanted to point out that this is a breaking change.

With that said, I'm open to any suggestions to improve this PR. I had considered creating my own flags in my app with a custom `String()` func, but that seemed difficult for us to maintain, and I had hoped that other people might find this useful as well.

Example of the existing behavior:

``` shell
>my-cool-app something --help
NAME:
   something - Does something really important, probably

USAGE:
   my-cool-app something [-b Blubber] [-c CLIs] [-d Detroit] [-e Everything]
               [-f Frumpy] [-g Grapes] [-h Hankering] [-i Indigo] [-j Jallopies]

OPTIONS:
   -b ''        Blubber and Bales
   -c ''        Cranky CLIs
   -d ''        Destruction of Detroit
   -e ''        Everything And More
   -f ''        Frumpy Flags are Fruitful
   -g ''        Great Grapes
   -h ''        Headache Hankering
   -i ''        Indigo Iodine 
   -j ''        Jumping Jallopies
```

Desired behavior:

``` shell
>my-cool-app something --help
NAME:
   something - Does something really important, probably

USAGE:
   my-cool-app something [-b Blubber] [-c CLIs] [-d Detroit] [-e Everything]
               [-f Frumpy] [-g Grapes] [-h Hankering] [-i Indigo] [-j Jallopies]

OPTIONS:
   -b       Blubber and Bales
   -c       Cranky CLIs
   -d       Destruction of Detroit
   -e       Everything And More
   -f       Frumpy Flags are Fruitful
   -g       Great Grapes
   -h       Headache Hankering
   -i       Indigo Iodine 
   -j       Jumping Jallopies
```
