### PR TITLE
Add BoolTFlag type

### DIFF
--- a/context.go
+++ b/context.go
@@ -38,6 +38,11 @@ func (c *Context) Bool(name string) bool {
 	return lookupBool(name, c.flagSet)
 }
 
+// Looks up the value of a local boolT flag, returns false if no bool flag exists
+func (c *Context) BoolT(name string) bool {
+	return lookupBoolT(name, c.flagSet)
+}
+
 // Looks up the value of a local string flag, returns "" if no string flag exists
 func (c *Context) String(name string) string {
 	return lookupString(name, c.flagSet)
@@ -185,6 +190,19 @@ func lookupBool(name string, set *flag.FlagSet) bool {
 		val, err := strconv.ParseBool(f.Value.String())
 		if err != nil {
 			return false
+		}
+		return val
+	}
+
+	return false
+}
+
+func lookupBoolT(name string, set *flag.FlagSet) bool {
+	f := set.Lookup(name)
+	if f != nil {
+		val, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return true
 		}
 		return val
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -37,6 +37,13 @@ func TestContext_Bool(t *testing.T) {
 	expect(t, c.Bool("myflag"), false)
 }
 
+func TestContext_BoolT(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", true, "doc")
+	c := cli.NewContext(nil, set, set)
+	expect(t, c.BoolT("myflag"), true)
+}
+
 func TestContext_Args(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("myflag", false, "doc")

--- a/flag.go
+++ b/flag.go
@@ -131,6 +131,25 @@ func (f BoolFlag) getName() string {
 	return f.Name
 }
 
+type BoolTFlag struct {
+	Name  string
+	Usage string
+}
+
+func (f BoolTFlag) String() string {
+	return fmt.Sprintf("%s\t%v", prefixedNames(f.Name), f.Usage)
+}
+
+func (f BoolTFlag) Apply(set *flag.FlagSet) {
+	eachName(f.Name, func(name string) {
+		set.Bool(name, true, f.Usage)
+	})
+}
+
+func (f BoolTFlag) getName() string {
+	return f.Name
+}
+
 type StringFlag struct {
 	Name  string
 	Value string


### PR DESCRIPTION
Compared to BoolFlag type, BoolTFlag treats 'true' as the default value
for the flag.

Without it, we have to use --no-action flag if we set the action is done
in default. But sometimes it is bad to maintain flags with negative meanings.
And it will be painful if we change the default value for the flag.

As this implementation, it keeps all existing functionality. So it
is compatible with old versions.

Thanks for this great project! :)
