### PR TITLE
Make Command accessible from Context

### DIFF
--- a/command.go
+++ b/command.go
@@ -70,6 +70,7 @@ func (c Command) Run(ctx *Context) error {
 	if checkCommandHelp(context, c.Name) {
 		return nil
 	}
+	context.Command = c
 	c.Action(context)
 	return nil
 }

--- a/context.go
+++ b/context.go
@@ -13,6 +13,7 @@ import (
 // parsed command-line options.
 type Context struct {
 	App       *App
+	Command   Command
 	flagSet   *flag.FlagSet
 	globalSet *flag.FlagSet
 	setFlags  map[string]bool
@@ -20,7 +21,7 @@ type Context struct {
 
 // Creates a new context. For use in when invoking an App or Command action.
 func NewContext(app *App, set *flag.FlagSet, globalSet *flag.FlagSet) *Context {
-	return &Context{app, set, globalSet, nil}
+	return &Context{App: app, flagSet: set, globalSet: globalSet}
 }
 
 // Looks up the value of a local int flag, returns 0 if no int flag exists

--- a/context_test.go
+++ b/context_test.go
@@ -11,9 +11,12 @@ func TestNewContext(t *testing.T) {
 	set.Int("myflag", 12, "doc")
 	globalSet := flag.NewFlagSet("test", 0)
 	globalSet.Int("myflag", 42, "doc")
+	command := cli.Command{Name: "mycommand"}
 	c := cli.NewContext(nil, set, globalSet)
+	c.Command = command
 	expect(t, c.Int("myflag"), 12)
 	expect(t, c.GlobalInt("myflag"), 42)
+	expect(t, c.Command.Name, "mycommand")
 }
 
 func TestContext_Int(t *testing.T) {


### PR DESCRIPTION
In a project I'm working on, I've created a graceful way to recover from failed arguments with a nice message for the user, such as this:

``` go
func requireArguments(c *cli.Context) {
  // argument tests
  if err {
    fmt.Println("For more information, run: binary " + c.Command.Name + " --help") 
    os.Exit(1)
  }
}
```

I believe Context should have access to the Command that was called by the user.  This is a pull request implements this in a simple style I saw possible.  Cheers! Chris
