### PR TITLE
Customizable command not found function

### DIFF
--- a/app.go
+++ b/app.go
@@ -25,6 +25,8 @@ type App struct {
 	Before func(context *Context) error
 	// The action to execute when no subcommands are specified
 	Action func(context *Context)
+	// Execute this function if the proper command cannot be found
+	CommandNotFound func(context *Context, command string)
 	// Compilation date
 	Compiled time.Time
 	// Author

--- a/app_test.go
+++ b/app_test.go
@@ -278,3 +278,26 @@ func TestAppHelpPrinter(t *testing.T) {
 		t.Errorf("Help printer expected to be called, but was not")
 	}
 }
+
+func TestAppCommandNotFound(t *testing.T) {
+	beforeRun, subcommandRun := false, false
+	app := cli.NewApp()
+
+	app.CommandNotFound = func(c *cli.Context, command string) {
+		beforeRun = true
+	}
+
+	app.Commands = []cli.Command{
+		cli.Command{
+			Name: "bar",
+			Action: func(c *cli.Context) {
+				subcommandRun = true
+			},
+		},
+	}
+
+	app.Run([]string{"command", "foo"})
+
+	expect(t, beforeRun, true)
+	expect(t, subcommandRun, false)
+}

--- a/help.go
+++ b/help.go
@@ -73,7 +73,11 @@ func ShowCommandHelp(c *Context, command string) {
 		}
 	}
 
-	fmt.Printf("No help topic for '%v'\n", command)
+	if c.App.CommandNotFound != nil {
+		c.App.CommandNotFound(c, command)
+	} else {
+		fmt.Printf("No help topic for '%v'\n", command)
+	}
 }
 
 // Prints the version number of the App


### PR DESCRIPTION
When building CLI tools, I like to make it as easy as possible for people to discover functionality.  The default message when a command is not found is not always helpful: `No help topic for '%v'\n`.  With this pull request, you can create a custom command not found function with the app:

```
app := cli.NewApp()
app.CommandNotFound := func(c * cli.Context, command string) {
  // Insert much more helpful functionality, like: Your command is not 
  // found.  Perhaps you meant: command foo
}
```

I was looking for the quickest path to make this functional.  Please makes recommendations / reject as needed.  Cheers, Chris
