### PR TITLE
remove quotes for empty StringFlags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -157,7 +157,16 @@ type StringFlag struct {
 }
 
 func (f StringFlag) String() string {
-	return fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage)
+	var fmtString string
+	fmtString = "%s %v\t%v"
+
+	if len(f.Value) > 0 {
+		fmtString = "%s '%v'\t%v"
+	} else {
+		fmtString = "%s %v\t%v"
+	}
+
+	return fmt.Sprintf(fmtString, prefixedNames(f.Name), f.Value, f.Usage)
 }
 
 func (f StringFlag) Apply(set *flag.FlagSet) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -28,16 +28,19 @@ func TestBoolFlagHelpOutput(t *testing.T) {
 
 var stringFlagTests = []struct {
 	name     string
+	value    string
 	expected string
 }{
-	{"help", "--help ''\t"},
-	{"h", "-h ''\t"},
+	{"help", "", "--help \t"},
+	{"h", "", "-h \t"},
+	{"h", "", "-h \t"},
+	{"test", "Something", "--test 'Something'\t"},
 }
 
 func TestStringFlagHelpOutput(t *testing.T) {
 
 	for _, test := range stringFlagTests {
-		flag := cli.StringFlag{Name: test.name}
+		flag := cli.StringFlag{Name: test.name, Value: test.value}
 		output := flag.String()
 
 		if output != test.expected {


### PR DESCRIPTION
As discussed in #71, this removes quotes if the `f.Value` is empty for a StringField
