### PR TITLE
Add SkipFlagParsing option to Command

### DIFF
--- a/command.go
+++ b/command.go
@@ -22,6 +22,8 @@ type Command struct {
 	Action func(context *Context)
 	// List of flags to parse
 	Flags []Flag
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
 }
 
 // Invokes the command given the context, parses ctx.Args() to generate command-specific flags
@@ -48,7 +50,7 @@ func (c Command) Run(ctx *Context) error {
 	}
 
 	var err error
-	if firstFlagIndex > -1 {
+	if firstFlagIndex > -1 && !c.SkipFlagParsing{
 		args := ctx.Args()
 		regularArgs := args[1:firstFlagIndex]
 		flagArgs := args[firstFlagIndex:]

--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,48 @@
+package cli_test
+
+import (
+	"flag"
+	"github.com/codegangsta/cli"
+	"testing"
+)
+
+func TestCommandDoNotIgnoreFlags(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	test := []string{"blah", "blah", "-break"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, set)
+
+	command := cli.Command {
+		Name: "test-cmd",
+		ShortName: "tc",
+		Usage: "this is for testing",
+		Description: "testing",
+		Action: func(_ *cli.Context) { },
+	}
+	err := command.Run(c)
+
+	expect(t, err.Error(), "flag provided but not defined: -break")
+}
+
+func TestCommandIgnoreFlags(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	test := []string{"blah", "blah"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, set)
+
+	command := cli.Command {
+		Name: "test-cmd",
+		ShortName: "tc",
+		Usage: "this is for testing",
+		Description: "testing",
+		Action: func(_ *cli.Context) { },
+		SkipFlagParsing: true,
+	}
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}


### PR DESCRIPTION
We would like to be able to have command arguments that begin with a dash, but that currently triggers the flag parsing and results in an error that our flag was not defined.

We solved this problem by adding an optional Command option called SkipFlagParsing which, if present, disables all flag parsing and allows "normal" (e.g. non-flag) arguments to begin with a dash.
