### PR TITLE
Generic parsers as flag types

### DIFF
--- a/context.go
+++ b/context.go
@@ -197,7 +197,7 @@ func lookupIntSlice(name string, set *flag.FlagSet) []int {
 func lookupGeneric(name string, set *flag.FlagSet) interface{} {
 	f := set.Lookup(name)
 	if f != nil {
-		return (f.Value.(Generic)).Value()
+		return f.Value
 	}
 	return nil
 }

--- a/flag.go
+++ b/flag.go
@@ -41,7 +41,6 @@ func eachName(longName string, fn func(string)) {
 type Generic interface {
 	Set(value string) error
 	String() string
-	Value() interface{}
 }
 
 // GenericFlag is the flag type for types implementing Generic

--- a/flag_test.go
+++ b/flag_test.go
@@ -176,10 +176,6 @@ func (p *Parser) String() string {
 	return fmt.Sprintf("%s,%s", p[0], p[1])
 }
 
-func (p *Parser) Value() interface{} {
-	return p
-}
-
 func TestParseGeneric(t *testing.T) {
 	a := cli.App{
 		Flags: []cli.Flag{


### PR DESCRIPTION
Can now parse any data type as a flag as long as it implements Generic
