### PR TITLE
Can now change these default flags in other applications

### DIFF
--- a/app.go
+++ b/app.go
@@ -74,8 +74,8 @@ func (a *App) Run(arguments []string) error {
 	if a.EnableBashCompletion {
 		a.appendFlag(BashCompletionFlag)
 	}
-	a.appendFlag(BoolFlag{"version, v", "print the version"})
-	a.appendFlag(BoolFlag{"help, h", "show help"})
+	a.appendFlag(VersionFlag)
+	a.appendFlag(HelpFlag)
 
 	// parse flags
 	set := flagSet(a.Name, a.Flags)
@@ -144,7 +144,7 @@ func (a *App) RunAsSubcommand(ctx *Context) error {
 	if a.EnableBashCompletion {
 		a.appendFlag(BashCompletionFlag)
 	}
-	a.appendFlag(BoolFlag{"help, h", "show help"})
+	a.appendFlag(HelpFlag)
 
 	// parse flags
 	set := flagSet(a.Name, a.Flags)

--- a/command.go
+++ b/command.go
@@ -41,7 +41,7 @@ func (c Command) Run(ctx *Context) error {
 	// append help to flags
 	c.Flags = append(
 		c.Flags,
-		BoolFlag{"help, h", "show help"},
+		HelpFlag,
 	)
 
 	if ctx.App.EnableBashCompletion {
@@ -60,7 +60,7 @@ func (c Command) Run(ctx *Context) error {
 	}
 
 	var err error
-	if firstFlagIndex > -1 && !c.SkipFlagParsing{
+	if firstFlagIndex > -1 && !c.SkipFlagParsing {
 		args := ctx.Args()
 		regularArgs := args[1:firstFlagIndex]
 		flagArgs := args[firstFlagIndex:]

--- a/flag.go
+++ b/flag.go
@@ -10,6 +10,12 @@ import (
 // This flag enables bash-completion for all commands and subcommands
 var BashCompletionFlag = BoolFlag{"generate-bash-completion", ""}
 
+// This flag prints the version for the application
+var VersionFlag = BoolFlag{"version, v", "print the version"}
+
+// This flag prints the help for all commands and subcommands
+var HelpFlag = BoolFlag{"help, h", "show help"}
+
 // Flag is a common interface related to parsing flags in cli.
 // For more advanced flag parsing techniques, it is recomended that
 // this interface be implemented.


### PR DESCRIPTION
I needed to be able to set the -v flag as the log level, but it was also used as the version flag.  So now I can change the VersionFlag to whatever I need it to be in my program.
