### PR TITLE
Allow a writer to be set

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -262,6 +262,50 @@ func TestApp_ParseSliceFlags(t *testing.T) {
 	}
 }
 
+func TestApp_DefaultStdout(t *testing.T) {
+	app := cli.NewApp()
+
+	if app.Stdout != os.Stdout {
+		t.Error("Default output writer not set.")
+	}
+}
+
+type fakeWriter struct {
+	written []byte
+}
+
+func (fw *fakeWriter) Write(p []byte) (n int, err error) {
+	if fw.written == nil {
+		fw.written = p
+	} else {
+		fw.written = append(fw.written, p...)
+	}
+
+	return len(p), nil
+}
+
+func (fw *fakeWriter) GetWritten() (b []byte) {
+	return fw.written
+}
+
+func TestApp_SetStdout(t *testing.T) {
+	mockWriter := &fakeWriter{}
+
+	app := cli.NewApp()
+	app.Name = "test"
+	app.Stdout = mockWriter
+
+	err := app.Run([]string{"help"})
+
+	if err != nil {
+		t.Fatalf("Run error: %s", err)
+	}
+
+	if len(mockWriter.written) == 0 {
+		t.Error("App did not write output to desired writer.")
+	}
+}
+
 func TestApp_BeforeFunc(t *testing.T) {
 	beforeRun, subcommandRun := false, false
 	beforeError := fmt.Errorf("fail")

--- a/command.go
+++ b/command.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"strings"
 )
@@ -70,18 +71,18 @@ func (c Command) Run(ctx *Context) error {
 	}
 
 	if err != nil {
-		fmt.Printf("Incorrect Usage.\n\n")
+		io.WriteString(ctx.App.Stdout, fmt.Sprintf("Incorrect Usage.\n\n"))
 		ShowCommandHelp(ctx, c.Name)
-		fmt.Println("")
+		io.WriteString(ctx.App.Stdout, fmt.Sprintln(""))
 		return err
 	}
 
 	nerr := normalizeFlags(c.Flags, set)
 	if nerr != nil {
-		fmt.Println(nerr)
-		fmt.Println("")
+		io.WriteString(ctx.App.Stdout, fmt.Sprintln(nerr))
+		io.WriteString(ctx.App.Stdout, fmt.Sprintln(""))
 		ShowCommandHelp(ctx, c.Name)
-		fmt.Println("")
+		io.WriteString(ctx.App.Stdout, fmt.Sprintln(""))
 		return nerr
 	}
 	context := NewContext(ctx.App, set, ctx.globalSet)


### PR DESCRIPTION
Allow a writer to be set that represents Stdout so that redirection of App output may occur. This is useful in slightly non-standard usage of the cli library.
