### PR TITLE
Exposing 'VersionPrinter'

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"."
 	"fmt"
 	"os"
 	"testing"

--- a/command_test.go
+++ b/command_test.go
@@ -1,9 +1,10 @@
 package cli_test
 
 import (
-	"."
 	"flag"
 	"testing"
+
+	"github.com/codegangsta/cli"
 )
 
 func TestCommandDoNotIgnoreFlags(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"."
 	"flag"
 	"testing"
 	"time"


### PR DESCRIPTION
Exposing `VersionPrinter` to match the implementation of `HelpPrinter` for the same purpose.

Additionally, I found solidifying tests difficult when `cli` was imported using the full github path (i.e. `github.com/codegangsta/cli`) and therefore changed the import paths to `"."` instead. If this is an issue, feel free to revert it, or let me know and I will.

Cheers,
J
