### PR TITLE
Add Args.Swap command for swapping arguments

### DIFF
--- a/context.go
+++ b/context.go
@@ -140,6 +140,15 @@ func (a Args) Present() bool {
 	return len(a) != 0
 }
 
+// Swaps arguments at the given indexes
+func (a Args) Swap(from, to int) error {
+	if from >= len(a) || to >= len(a) {
+		return errors.New("index out of range")
+	}
+	a[from], a[to] = a[to], a[from]
+	return nil
+}
+
 func lookupInt(name string, set *flag.FlagSet) int {
 	f := set.Lookup(name)
 	if f != nil {


### PR DESCRIPTION
The usecase:
my-cli user `<USERID>` set `<FIELD>` `<VALUE>`

Being able to swap `<USERID>` with `set` argument, we can have nested subcommands while preserving all variable arguments along the way.
