### PR TITLE
Add App and Command argument count checking

### DIFF
--- a/app.go
+++ b/app.go
@@ -39,6 +39,8 @@ type App struct {
 	Author string
 	// Author e-mail
 	Email string
+	// Command argument requirements
+	Requires *Requires
 }
 
 // Tries to find out when this binary was compiled.
@@ -110,6 +112,10 @@ func (a *App) Run(arguments []string) error {
 
 	if checkVersion(context) {
 		return nil
+	}
+
+	if err := context.Satisfies(a.Requires); err != nil {
+		return err
 	}
 
 	if a.Before != nil {
@@ -192,6 +198,10 @@ func (a *App) RunAsSubcommand(ctx *Context) error {
 		if checkCommandHelp(ctx, context.Args().First()) {
 			return nil
 		}
+	}
+
+	if err := context.Satisfies(a.Requires); err != nil {
+		return err
 	}
 
 	if a.Before != nil {

--- a/command.go
+++ b/command.go
@@ -31,6 +31,8 @@ type Command struct {
 	SkipFlagParsing bool
 	// Boolean to hide built-in help command
 	HideHelp bool
+	// Command argument requirements
+	Requires *Requires
 }
 
 // Invokes the command given the context, parses ctx.Args() to generate command-specific flags
@@ -97,6 +99,11 @@ func (c Command) Run(ctx *Context) error {
 	if checkCommandHelp(context, c.Name) {
 		return nil
 	}
+
+	if err := context.Satisfies(c.Requires); err != nil {
+		return err
+	}
+
 	context.Command = c
 	c.Action(context)
 	return nil


### PR DESCRIPTION
This has a bit of a code-smell, whereby the Satisfy method is on the context rather than on the Args object, but I feel that this could be expanded in the future where the context will have some meaningful information for the validation
