### PR TITLE
Add App.RunAndExitOnError shortcut

### DIFF
--- a/app.go
+++ b/app.go
@@ -131,6 +131,14 @@ func (a *App) Run(arguments []string) error {
 	return nil
 }
 
+// Another entry point to the cli app, takes care of passing arguments and error handling
+func (a *App) RunAndExitOnError() {
+	if err := a.Run(os.Args); err != nil {
+		os.Stderr.WriteString(fmt.Sprintln(err))
+		os.Exit(1)
+	}
+}
+
 // Invokes the subcommand given the context, parses ctx.Args() to generate command-specific flags
 func (a *App) RunAsSubcommand(ctx *Context) error {
 	// append help to commands


### PR DESCRIPTION
Since the cli is most likely the whole app you are developing, I am not sure if its worthwhile to leave passing arguments and handling errors to the user.
