### PR TITLE
Copy CommandNotFound into the NewApp for subcommands

### DIFF
--- a/app.go
+++ b/app.go
@@ -151,9 +151,6 @@ func (a *App) RunAsSubcommand(ctx *Context) error {
 		}
 	}
 
-	// add the App's CommandNotFound
-	a.CommandNotFound = ctx.App.CommandNotFound
-
 	// append flags
 	if a.EnableBashCompletion {
 		a.appendFlag(BashCompletionFlag)

--- a/command.go
+++ b/command.go
@@ -118,6 +118,9 @@ func (c Command) startApp(ctx *Context) error {
 		app.Usage = c.Usage
 	}
 
+	// set CommandNotFound
+	app.CommandNotFound = ctx.App.CommandNotFound
+
 	// set the flags and commands
 	app.Commands = c.Subcommands
 	app.Flags = c.Flags


### PR DESCRIPTION
Hi @codegangsta,

I noticed that when a `CommandNotFound` function existed in my appapp, it would never work when I ran it as subcommand. 

```
[kallan@KAlla1ml1:~/go/src/github.com/KAllan357/bootcamp] $ go run cli.go example
NAME:
   test example - example

USAGE:
   test example command [command options] [arguments...]

COMMANDS:
   sub      sub
   help, h  Shows a list of commands or help for one command

OPTIONS:
   --help, -h   show help

[kallan@KAlla1ml1:~/go/src/github.com/KAllan357/bootcamp] $ go run cli.go example foo
No help topic for 'foo'
```

I noticed that in command.go that `NewApp()` is called before a subcommand is executed. I think that the fix here for now (barring say adding a custom CommandNotFound to the Command struct) is to just copy the CommandNotFound down into the subcommand. In most cases, it makes sense that your entire CLI app would want the same behavior when it encounters a command that does not exist.

Here's an example of the output after the change:

```
[kallan@KAlla1ml1:~/go/src/github.com/KAllan357/bootcamp] $ go run cli.go example foo
No help topic for 'foo'
```
