### PR TITLE
Fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ app.Commands = []cli.Command{
         return
       }
       for _, t := range tasks {
-        println(t)
+        fmt.Println(t)
       }
     },
   }


### PR DESCRIPTION
Shell gets completion candidates from stdout but function `println` writes to stderr.
