### PR TITLE
Clarify example in README. Fixes #149

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ Running this already gives you a ton of functionality, plus support for things l
 
 Being a programmer can be a lonely job. Thankfully by the power of automation that is not the case! Let's create a greeter app to fend off our demons of loneliness!
 
+Start by creating a directory named `greet`, and within it, add a file, `greet.go` with the following code in it:
+
 ``` go
-/* greet.go */
 package main
 
 import (
@@ -84,7 +85,7 @@ func main() {
   app.Action = func(c *cli.Context) {
     println("Hello friend!")
   }
-  
+
   app.Run(os.Args)
 }
 ```


### PR DESCRIPTION
The README specifies that the app installed into the `$GOBIN` directory will be named `greet`, but I believe this is only the case if the containing directory is named in that way.
