### PR TITLE
Minor fixes to help flag handling

### DIFF
--- a/app.go
+++ b/app.go
@@ -179,10 +179,11 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	if len(a.Commands) > 0 {
 		if a.Command(helpCommand.Name) == nil && !a.HideHelp {
 			a.Commands = append(a.Commands, helpCommand)
-			if (HelpFlag != BoolFlag{}) {
-				a.appendFlag(HelpFlag)
-			}
 		}
+	}
+
+	if (!a.HideHelp && HelpFlag != BoolFlag{}) {
+		a.appendFlag(HelpFlag)
 	}
 
 	// append flags
@@ -216,6 +217,10 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	}
 
 	if checkCompletions(context) {
+		return nil
+	}
+
+	if checkHelp(context) {
 		return nil
 	}
 

--- a/app.go
+++ b/app.go
@@ -274,9 +274,11 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 
 // Returns the named command on App. Returns nil if the command does not exist
 func (a *App) Command(name string) *Command {
-	for _, c := range a.Commands {
+	for idx := range a.Commands {
+		c := &a.Commands[idx]
+
 		if c.HasName(name) {
-			return &c
+			return c
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -23,8 +23,10 @@ type App struct {
 	Flags []Flag
 	// Boolean to enable bash completion commands
 	EnableBashCompletion bool
-	// Boolean to hide built-in help command
+	// Boolean to hide built-in help command and flag
 	HideHelp bool
+	// Boolean to disable the built-in help commnd
+	DisableHelpCommand bool
 	// Boolean to hide built-in version flag
 	HideVersion bool
 	// An action to execute when the bash-completion flag is set
@@ -83,11 +85,12 @@ func (a *App) Run(arguments []string) (err error) {
 	}
 
 	// append help to commands
-	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
+	if a.Command(helpCommand.Name) == nil && !a.HideHelp && !a.DisableHelpCommand {
 		a.Commands = append(a.Commands, helpCommand)
-		if (HelpFlag != BoolFlag{}) {
-			a.appendFlag(HelpFlag)
-		}
+	}
+
+	if (!a.HideHelp && HelpFlag != BoolFlag{}) {
+		a.appendFlag(HelpFlag)
 	}
 
 	//append version/help flags
@@ -177,7 +180,7 @@ func (a *App) RunAndExitOnError() {
 func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	// append help to commands
 	if len(a.Commands) > 0 {
-		if a.Command(helpCommand.Name) == nil && !a.HideHelp {
+		if a.Command(helpCommand.Name) == nil && !a.HideHelp && !a.DisableHelpCommand {
 			a.Commands = append(a.Commands, helpCommand)
 		}
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -758,7 +758,7 @@ func TestApp_Run_SubcommandFullPath(t *testing.T) {
 	if !strings.Contains(output, "foo bar - does bar things") {
 		t.Errorf("expected full path to subcommand: %s", output)
 	}
-	if !strings.Contains(output, "command foo bar [arguments...]") {
+	if !strings.Contains(output, "command foo bar [command options] [arguments...]") {
 		t.Errorf("expected full path to subcommand: %s", output)
 	}
 }

--- a/command.go
+++ b/command.go
@@ -34,8 +34,10 @@ type Command struct {
 	Flags []Flag
 	// Treat all flags as normal arguments if true
 	SkipFlagParsing bool
-	// Boolean to hide built-in help command
+	// Boolean to hide built-in help command and Flag
 	HideHelp bool
+	// Boolean to disable the built-in help commnd
+	DisableHelpCommand bool
 
 	commandNamePath []string
 }
@@ -166,6 +168,7 @@ func (c Command) startApp(ctx *Context) error {
 	app.Commands = c.Subcommands
 	app.Flags = c.Flags
 	app.HideHelp = c.HideHelp
+	app.DisableHelpCommand = c.DisableHelpCommand
 
 	app.Version = ctx.App.Version
 	app.HideVersion = ctx.App.HideVersion

--- a/help.go
+++ b/help.go
@@ -125,11 +125,9 @@ func ShowCommandHelp(ctx *Context, command string) {
 		return
 	}
 
-	for _, c := range ctx.App.Commands {
-		if c.HasName(command) {
-			HelpPrinter(ctx.App.Writer, CommandHelpTemplate, c)
-			return
-		}
+	if c := ctx.App.Command(command); c != nil {
+		HelpPrinter(ctx.App.Writer, CommandHelpTemplate, c)
+		return
 	}
 
 	if ctx.App.CommandNotFound != nil {


### PR DESCRIPTION
This PR fixes a few minor issues with the automatic handling of help flags and -commands
1. Adds a new DisableHelpCommand flag to App and Command which allows to disable the autogenerated help command while keeping the autogenerated help flag
2. Fixes help flag usage for commands with subcommands --- previously, giving -h / --help to a command would do nothing
3. The autogenerated help flags are now included in the flag list for leaves of the command tree. Previously, the flags were recognized but not included on the help page.

I think that 1. and 2. have no potential for breaking existing code. However, 3. required changing the semantics with which commands are handled, switching from copies to pointers, so there is some potential for breakage in edge cases. I also took the liberty of switching to pointer receivers for all Command methods for reasons of consistency and performance.
