### PR TITLE
Ensure flag "Name" field values are un-stringly-fied

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -614,6 +614,10 @@ func flagNames(f Flag) []string {
 	aliases := flagStringSliceField(f, "Aliases")
 
 	for _, part := range append([]string{name}, aliases...) {
+		// v1 -> v2 migration warning zone:
+		// Strip off anything after the first found comma or space, which
+		// *hopefully* makes it a tiny bit more obvious that unexpected behavior is
+		// caused by using the v1 form of stringly typed "Name".
 		ret = append(ret, commaWhitespace.ReplaceAllString(part, ""))
 	}
 


### PR DESCRIPTION
to (hopefully) help with bug triage & pinpointing usage issues since ripping out
stringly typed "Name".

- Also removed now-unnecessary whitespace trimming of env var names.

Closes #426 