### PR TITLE
Ensure all flag aliases are set when Destination given

### DIFF
--- a/app.go
+++ b/app.go
@@ -164,7 +164,7 @@ func (a *App) Run(arguments []string) (err error) {
 			HandleExitCoder(err)
 			return err
 		}
-		fmt.Fprintf(a.Writer, "%s\n\n", "Incorrect Usage.")
+		fmt.Fprintf(a.Writer, "Incorrect Usage: %s\n\n", err)
 		ShowAppHelp(context)
 		return err
 	}
@@ -273,7 +273,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 			HandleExitCoder(err)
 			return err
 		}
-		fmt.Fprintf(a.Writer, "%s\n\n", "Incorrect Usage.")
+		fmt.Fprintf(a.Writer, "Incorrect Usage: %s\n\n", err)
 		ShowSubcommandHelp(context)
 		return err
 	}

--- a/command.go
+++ b/command.go
@@ -97,7 +97,7 @@ func (c Command) Run(ctx *Context) (err error) {
 			HandleExitCoder(err)
 			return err
 		}
-		fmt.Fprintln(ctx.App.Writer, "Incorrect Usage: %s\n\n", err)
+		fmt.Fprintf(ctx.App.Writer, "Incorrect Usage: %s\n\n", err)
 		fmt.Fprintln(ctx.App.Writer)
 		ShowCommandHelp(ctx, c.Name)
 		return err

--- a/command.go
+++ b/command.go
@@ -97,7 +97,7 @@ func (c Command) Run(ctx *Context) (err error) {
 			HandleExitCoder(err)
 			return err
 		}
-		fmt.Fprintln(ctx.App.Writer, "Incorrect Usage.")
+		fmt.Fprintln(ctx.App.Writer, "Incorrect Usage: %s\n\n", err)
 		fmt.Fprintln(ctx.App.Writer)
 		ShowCommandHelp(ctx, c.Name)
 		return err

--- a/flag.go
+++ b/flag.go
@@ -104,7 +104,7 @@ func (f GenericFlag) Apply(set *flag.FlagSet) {
 	}
 
 	for _, name := range f.Names() {
-		set.Var(f.Value, name, f.Usage)
+		set.Var(val, name, f.Usage)
 	}
 }
 
@@ -349,7 +349,7 @@ func (f BoolFlag) Apply(set *flag.FlagSet) {
 	for _, name := range f.Names() {
 		if f.Destination != nil {
 			set.BoolVar(f.Destination, name, f.Value, f.Usage)
-			return
+			continue
 		}
 		set.Bool(name, f.Value, f.Usage)
 	}
@@ -391,7 +391,7 @@ func (f StringFlag) Apply(set *flag.FlagSet) {
 	for _, name := range f.Names() {
 		if f.Destination != nil {
 			set.StringVar(f.Destination, name, f.Value, f.Usage)
-			return
+			continue
 		}
 		set.String(name, f.Value, f.Usage)
 	}
@@ -437,7 +437,7 @@ func (f IntFlag) Apply(set *flag.FlagSet) {
 	for _, name := range f.Names() {
 		if f.Destination != nil {
 			set.IntVar(f.Destination, name, f.Value, f.Usage)
-			return
+			continue
 		}
 		set.Int(name, f.Value, f.Usage)
 	}
@@ -483,7 +483,7 @@ func (f DurationFlag) Apply(set *flag.FlagSet) {
 	for _, name := range f.Names() {
 		if f.Destination != nil {
 			set.DurationVar(f.Destination, name, f.Value, f.Usage)
-			return
+			continue
 		}
 		set.Duration(name, f.Value, f.Usage)
 	}
@@ -528,7 +528,7 @@ func (f Float64Flag) Apply(set *flag.FlagSet) {
 	for _, name := range f.Names() {
 		if f.Destination != nil {
 			set.Float64Var(f.Destination, name, f.Value, f.Usage)
-			return
+			continue
 		}
 		set.Float64(name, f.Value, f.Usage)
 	}

--- a/flag_test.go
+++ b/flag_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"reflect"
@@ -27,6 +28,17 @@ func TestBoolFlagHelpOutput(t *testing.T) {
 			t.Errorf("%q does not match %q", output, test.expected)
 		}
 	}
+}
+
+func TestBoolFlagApply_SetsAllNames(t *testing.T) {
+	v := false
+	fl := BoolFlag{Name: "wat", Aliases: []string{"W", "huh"}, Destination: &v}
+	set := flag.NewFlagSet("test", 0)
+	fl.Apply(set)
+
+	err := set.Parse([]string{"--wat", "-W", "--huh"})
+	expect(t, err, nil)
+	expect(t, v, true)
 }
 
 var stringFlagTests = []struct {
@@ -72,6 +84,17 @@ func TestStringFlagWithEnvVarHelpOutput(t *testing.T) {
 	}
 }
 
+func TestStringFlagApply_SetsAllNames(t *testing.T) {
+	v := "mmm"
+	fl := StringFlag{Name: "hay", Aliases: []string{"H", "hayyy"}, Destination: &v}
+	set := flag.NewFlagSet("test", 0)
+	fl.Apply(set)
+
+	err := set.Parse([]string{"--hay", "u", "-H", "yuu", "--hayyy", "YUUUU"})
+	expect(t, err, nil)
+	expect(t, v, "YUUUU")
+}
+
 var stringSliceFlagTests = []struct {
 	name     string
 	aliases  []string
@@ -113,6 +136,15 @@ func TestStringSliceFlagWithEnvVarHelpOutput(t *testing.T) {
 	}
 }
 
+func TestStringSliceFlagApply_SetsAllNames(t *testing.T) {
+	fl := StringSliceFlag{Name: "goat", Aliases: []string{"G", "gooots"}}
+	set := flag.NewFlagSet("test", 0)
+	fl.Apply(set)
+
+	err := set.Parse([]string{"--goat", "aaa", "-G", "bbb", "--gooots", "eeeee"})
+	expect(t, err, nil)
+}
+
 var intFlagTests = []struct {
 	name     string
 	expected string
@@ -149,6 +181,17 @@ func TestIntFlagWithEnvVarHelpOutput(t *testing.T) {
 	}
 }
 
+func TestIntFlagApply_SetsAllNames(t *testing.T) {
+	v := 3
+	fl := IntFlag{Name: "banana", Aliases: []string{"B", "banannanana"}, Destination: &v}
+	set := flag.NewFlagSet("test", 0)
+	fl.Apply(set)
+
+	err := set.Parse([]string{"--banana", "1", "-B", "2", "--banannanana", "5"})
+	expect(t, err, nil)
+	expect(t, v, 5)
+}
+
 var durationFlagTests = []struct {
 	name     string
 	expected string
@@ -183,6 +226,17 @@ func TestDurationFlagWithEnvVarHelpOutput(t *testing.T) {
 			t.Errorf("%s does not end with"+expectedSuffix, output)
 		}
 	}
+}
+
+func TestDurationFlagApply_SetsAllNames(t *testing.T) {
+	v := time.Second * 20
+	fl := DurationFlag{Name: "howmuch", Aliases: []string{"H", "whyyy"}, Destination: &v}
+	set := flag.NewFlagSet("test", 0)
+	fl.Apply(set)
+
+	err := set.Parse([]string{"--howmuch", "30s", "-H", "5m", "--whyyy", "30h"})
+	expect(t, err, nil)
+	expect(t, v, time.Hour*30)
 }
 
 var intSliceFlagTests = []struct {
@@ -224,6 +278,15 @@ func TestIntSliceFlagWithEnvVarHelpOutput(t *testing.T) {
 	}
 }
 
+func TestIntSliceFlagApply_SetsAllNames(t *testing.T) {
+	fl := IntSliceFlag{Name: "bits", Aliases: []string{"B", "bips"}}
+	set := flag.NewFlagSet("test", 0)
+	fl.Apply(set)
+
+	err := set.Parse([]string{"--bits", "23", "-B", "3", "--bips", "99"})
+	expect(t, err, nil)
+}
+
 var float64FlagTests = []struct {
 	name     string
 	expected string
@@ -258,6 +321,17 @@ func TestFloat64FlagWithEnvVarHelpOutput(t *testing.T) {
 			t.Errorf("%s does not end with"+expectedSuffix, output)
 		}
 	}
+}
+
+func TestFloat64FlagApply_SetsAllNames(t *testing.T) {
+	v := float64(99.1)
+	fl := Float64Flag{Name: "noodles", Aliases: []string{"N", "nurbles"}, Destination: &v}
+	set := flag.NewFlagSet("test", 0)
+	fl.Apply(set)
+
+	err := set.Parse([]string{"--noodles", "1.3", "-N", "11", "--nurbles", "43.33333"})
+	expect(t, err, nil)
+	expect(t, v, float64(43.33333))
 }
 
 var genericFlagTests = []struct {
@@ -295,6 +369,15 @@ func TestGenericFlagWithEnvVarHelpOutput(t *testing.T) {
 			t.Errorf("%s does not end with"+expectedSuffix, output)
 		}
 	}
+}
+
+func TestGenericFlagApply_SetsAllNames(t *testing.T) {
+	fl := GenericFlag{Name: "orbs", Aliases: []string{"O", "obrs"}, Value: &Parser{}}
+	set := flag.NewFlagSet("test", 0)
+	fl.Apply(set)
+
+	err := set.Parse([]string{"--orbs", "eleventy,3", "-O", "4,bloop", "--obrs", "19,s"})
+	expect(t, err, nil)
 }
 
 func TestParseMultiString(t *testing.T) {


### PR DESCRIPTION
and extend "Incorrect Usage" message to show the error.

Closes #430