### PR TITLE
Switch "printHelp" tabwriter padchar to space

### DIFF
--- a/help.go
+++ b/help.go
@@ -191,7 +191,7 @@ func printHelp(out io.Writer, templ string, data interface{}) {
 		"join": strings.Join,
 	}
 
-	w := tabwriter.NewWriter(out, 0, 8, 1, '\t', 0)
+	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)
 	t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
 	err := t.Execute(w, data)
 	if err != nil {


### PR DESCRIPTION
Using tabs for alignment is troubling if the output is used for anything besides display in a terminal (or if the user's terminal allows for adjustment of the default tab size), as noted by the documentation for `tabwriter` (https://golang.org/pkg/text/tabwriter/#Writer.Init):

> (for correct-looking results, tabwidth must correspond to the tab width in the viewer displaying the result)

The safer solution is to use `' '` as the `padchar`, which only carries the assumption of a fixed-width font (which is a more reasonable assumption than a fixed, constant tab size).

Of course, happy to rebase, amend, and/or adjust as necessary or desired. :+1: