### PR TITLE
Fix ActionFunc signature of ShowAppHelp action

### DIFF
--- a/help.go
+++ b/help.go
@@ -117,8 +117,9 @@ var HelpPrinter helpPrinter = printHelp
 var VersionPrinter = printVersion
 
 // ShowAppHelp is an action that displays the help.
-func ShowAppHelp(c *Context) {
+func ShowAppHelp(c *Context) error {
 	HelpPrinter(c.App.Writer, AppHelpTemplate, c.App)
+	return nil
 }
 
 // DefaultAppComplete prints the list of subcommands as the default app completion method


### PR DESCRIPTION
Often in helper utilities with many subcommands, I use the `ShowAppHelp` action which does not match the new ActionFunc signature introduced in 1.15.0, generating the deprecation notice.