### PR TITLE
fix panic getting visible flags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -512,7 +512,7 @@ func (f Float64Flag) GetName() string {
 func visibleFlags(fl []Flag) []Flag {
 	visible := []Flag{}
 	for _, flag := range fl {
-		if !reflect.ValueOf(flag).FieldByName("Hidden").Bool() {
+		if !reflect.Indirect(reflect.ValueOf(flag)).FieldByName("Hidden").Bool() {
 			visible = append(visible, flag)
 		}
 	}


### PR DESCRIPTION
When using `altsrc` for flags, (e.g. `altsrc.NewStringFlag(cli.StringFlag{...})`) the `cli.Flag` returned is a pointer to an `altsrc` flag type.

When `app.VisibleFlags` is called (often as part of getting help/usage information), the app panics:

```
panic: reflect: call of reflect.Value.FieldByName on ptr Value [recovered]
        panic: reflect: call of reflect.Value.FieldByName on ptr Value
```

This is a simple fix to restore the intended behavior.