### PR TITLE
Allow passing metadata between Before/Action/After

### DIFF
--- a/app.go
+++ b/app.go
@@ -160,6 +160,10 @@ func (a *App) Setup() {
 		a.categories = a.categories.AddCommand(command.Category, command)
 	}
 	sort.Sort(a.categories)
+
+	if a.Metadata == nil {
+		a.Metadata = make(map[string]interface{})
+	}
 }
 
 // Run is the entry point to the cli app. Parses the arguments slice and routes
@@ -438,6 +442,18 @@ func (a *App) appendFlag(flag Flag) {
 	if !a.hasFlag(flag) {
 		a.Flags = append(a.Flags, flag)
 	}
+}
+
+func (a *App) SetMetadata(key string, value interface{}) {
+	a.Metadata[key] = value
+}
+
+func (a *App) GetMetadata(key string) (interface{}, error) {
+	v, ok := a.Metadata[key]
+	if !ok {
+		return nil, fmt.Errorf("Metadata key %q not found", key)
+	}
+	return v, nil
 }
 
 // Author represents someone who has contributed to a cli project.


### PR DESCRIPTION
We have a list of commands and many of them have some kind of common bootstrap logic (initiating connection to APIs etc).

We could obviously create a separate standalone function and call that function inside each `Action`, but `Action` usually contains more complex logic and hence is typically maintained in a separate file/function, whereas `Before` or `After` are (at least in most cases I've seen in the wild) defined as inline functions.

This patch would allow us to do something like this:

```go
func main() {
	app := NewApp()
	app.Commands = []Command{
		{
			Name: "foo",
			Before: func(c *Context) error {
				c.App.SetMetadata("aws", initAWS())
				return nil
			},
			Action: FooCommand,
		},
		{
			Name: "bar",
			Before: func(c *Context) error {
				c.App.SetMetadata("aws", initAWS())
				return nil
			},
			Action: BarCommand,
		},
	}
}

func FooCommand(c *Context) error {
	conn, err := c.App.GetMetadata("aws")
	if err != nil {
		return err
	}

	conn.DoSomethingFancy()

	return nil
}

func BarCommand(c *Context) error {
	conn, err := c.App.GetMetadata("aws")
	if err != nil {
		return err
	}

	conn.DoSomethingElse()

	return nil
}
```

I'm open to alternative/cleaner solutions for the problem described above.