### PR TITLE
Print completion code 

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,10 +787,30 @@ func main() {
 
 #### Enabling
 
-Source the `autocomplete/bash_autocomplete` file in your `.bashrc` file while
-setting the `PROG` variable to the name of your program:
+You can enable bash or zsh completion by using the flag `--bash`,
+respectively `--zsh`. These flags take the name of your program as
+parameter.
 
-`PROG=myprogram source /.../cli/autocomplete/bash_autocomplete`
+To setup for bash (if your program is in your PATH):
+
+```
+eval "`myprogram --bash myprogram`"
+```
+
+If your program is in the current directory:
+
+```
+eval "`./myprogram --bash ./myprogram`"
+```
+
+Alternatively, you can put the completion code in your `.bashrc` file:
+```
+myprogram --bash myprogram >> ~/.bashrc
+```
+
+Note: you have to specify the path of your program because you can define
+your own completion functions. The shell has then to know where your
+program is in order to generate possible completions.
 
 #### Distribution
 

--- a/app.go
+++ b/app.go
@@ -150,6 +150,7 @@ func (a *App) Setup() {
 	if a.EnableBashCompletion {
 		a.appendFlag(GenerateCompletionFlag)
 		a.appendFlag(BashCompletionFlag)
+		a.appendFlag(ZshCompletionFlag)
 	}
 
 	if !a.HideVersion {
@@ -185,6 +186,10 @@ func (a *App) Run(arguments []string) (err error) {
 	}
 
 	if checkBashCompletion(context) {
+		return nil
+	}
+
+	if checkZshCompletion(context) {
 		return nil
 	}
 

--- a/app.go
+++ b/app.go
@@ -149,6 +149,7 @@ func (a *App) Setup() {
 
 	if a.EnableBashCompletion {
 		a.appendFlag(GenerateCompletionFlag)
+		a.appendFlag(BashCompletionFlag)
 	}
 
 	if !a.HideVersion {
@@ -180,6 +181,10 @@ func (a *App) Run(arguments []string) (err error) {
 	}
 
 	if checkCompletions(context) {
+		return nil
+	}
+
+	if checkBashCompletion(context) {
 		return nil
 	}
 

--- a/app.go
+++ b/app.go
@@ -148,7 +148,7 @@ func (a *App) Setup() {
 	}
 
 	if a.EnableBashCompletion {
-		a.appendFlag(BashCompletionFlag)
+		a.appendFlag(GenerateCompletionFlag)
 	}
 
 	if !a.HideVersion {
@@ -278,7 +278,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 
 	// append flags
 	if a.EnableBashCompletion {
-		a.appendFlag(BashCompletionFlag)
+		a.appendFlag(GenerateCompletionFlag)
 	}
 
 	// parse flags

--- a/command.go
+++ b/command.go
@@ -83,7 +83,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	}
 
 	if ctx.App.EnableBashCompletion {
-		c.Flags = append(c.Flags, BashCompletionFlag)
+		c.Flags = append(c.Flags, GenerateCompletionFlag)
 	}
 
 	set := flagSet(c.Name, c.Flags)

--- a/flag.go
+++ b/flag.go
@@ -13,8 +13,8 @@ import (
 
 const defaultPlaceholder = "value"
 
-// BashCompletionFlag enables bash-completion for all commands and subcommands
-var BashCompletionFlag = BoolFlag{
+// GenerateCompletionFlag enables bash-completion for all commands and subcommands
+var GenerateCompletionFlag = BoolFlag{
 	Name:   "generate-bash-completion",
 	Hidden: true,
 }

--- a/flag.go
+++ b/flag.go
@@ -19,6 +19,12 @@ var GenerateCompletionFlag = BoolFlag{
 	Hidden: true,
 }
 
+// BashCompletionFlag prints bash completion code
+var BashCompletionFlag = StringFlag{
+	Name:  "bash",
+	Usage: "print completion code for bash. 'value' is the program name",
+}
+
 // VersionFlag prints the version for the application
 var VersionFlag = BoolFlag{
 	Name:  "version, v",

--- a/flag.go
+++ b/flag.go
@@ -25,6 +25,12 @@ var BashCompletionFlag = StringFlag{
 	Usage: "print completion code for bash. 'value' is the program name",
 }
 
+// ZshCompletionFlag prints zsh completion code
+var ZshCompletionFlag = StringFlag{
+	Name:  "zsh",
+	Usage: "print completion code for bash. 'value' is the program name",
+}
+
 // VersionFlag prints the version for the application
 var VersionFlag = BoolFlag{
 	Name:  "version, v",

--- a/help.go
+++ b/help.go
@@ -249,7 +249,7 @@ func checkSubcommandHelp(c *Context) bool {
 }
 
 func checkCompletions(c *Context) bool {
-	if (c.GlobalBool(BashCompletionFlag.Name) || c.Bool(BashCompletionFlag.Name)) && c.App.EnableBashCompletion {
+	if (c.GlobalBool(GenerateCompletionFlag.Name) || c.Bool(GenerateCompletionFlag.Name)) && c.App.EnableBashCompletion {
 		ShowCompletions(c)
 		return true
 	}
@@ -258,7 +258,7 @@ func checkCompletions(c *Context) bool {
 }
 
 func checkCommandCompletions(c *Context, name string) bool {
-	if c.Bool(BashCompletionFlag.Name) && c.App.EnableBashCompletion {
+	if c.Bool(GenerateCompletionFlag.Name) && c.App.EnableBashCompletion {
 		ShowCommandCompletions(c, name)
 		return true
 	}

--- a/help.go
+++ b/help.go
@@ -265,3 +265,25 @@ func checkCommandCompletions(c *Context, name string) bool {
 
 	return false
 }
+
+func bashCompletionCode(progName string) string {
+	var template = `_cli_bash_autocomplete() {
+     local cur opts base;
+     COMPREPLY=();
+     cur="${COMP_WORDS[COMP_CWORD]}";
+     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion );
+     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) );
+     return 0;
+};
+complete -F _cli_bash_autocomplete %s`
+	return fmt.Sprintf(template, progName)
+}
+
+func checkBashCompletion(c *Context) bool {
+	if c.GlobalIsSet(BashCompletionFlag.Name) && c.App.EnableBashCompletion {
+		fmt.Print(bashCompletionCode(c.GlobalString(BashCompletionFlag.Name)))
+		return true
+	}
+
+	return false
+}

--- a/help.go
+++ b/help.go
@@ -279,9 +279,25 @@ complete -F _cli_bash_autocomplete %s`
 	return fmt.Sprintf(template, progName)
 }
 
+func zshCompletionCode(progName string) string {
+	var template = `autoload -U compinit && compinit;
+autoload -U bashcompinit && bashcompinit;`
+	
+	return template + "\n" + bashCompletionCode(progName)
+}
+
 func checkBashCompletion(c *Context) bool {
 	if c.GlobalIsSet(BashCompletionFlag.Name) && c.App.EnableBashCompletion {
 		fmt.Print(bashCompletionCode(c.GlobalString(BashCompletionFlag.Name)))
+		return true
+	}
+
+	return false
+}
+
+func checkZshCompletion(c *Context) bool {
+	if c.GlobalIsSet(ZshCompletionFlag.Name) && c.App.EnableBashCompletion {
+		fmt.Print(zshCompletionCode(c.GlobalString(BashCompletionFlag.Name)))
 		return true
 	}
 


### PR DESCRIPTION
A proposal to print completion code from the cli.

- User has to manualy supply the program path (as it is already done with shell variable PROG). I tryied to discover the program name/path, but it seems to be hard to handle all corner cases. I then prefer to let the user know what he is doing.

- I didn't test zsh generated code (I don't use zsh). Somenone could please try it? Otherwise, I could remove the commit.