### PR TITLE
Drop testing of go1.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,6 @@ matrix:
   include:
   - go: 1.6.2
     os: osx
-  - go: 1.1.2
-    install: go get -v .
-    before_script: echo skipping gfmxr on $TRAVIS_GO_VERSION
-    script:
-    - ./runtests vet
-    - ./runtests test
 
 before_script:
 - go get github.com/urfave/gfmxr/...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **ATTN**: This project uses [semantic versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Raise minimum tested/supported Go version to 1.2+
 
 ## [1.18.0] - 2016-06-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,18 +60,16 @@ organized, and expressive!
 
 ## Installation
 
-Make sure you have a working Go environment.  Go version 1.1+ is required for
-core cli, whereas use of the [`./altsrc`](./altsrc) input extensions requires Go
-version 1.2+. [See the install
-instructions](http://golang.org/doc/install.html).
+Make sure you have a working Go environment.  Go version 1.2+ is supported.  [See
+the install instructions for Go](http://golang.org/doc/install.html).
 
 To install cli, simply run:
 ```
 $ go get github.com/urfave/cli
 ```
 
-Make sure your `PATH` includes to the `$GOPATH/bin` directory so your commands
-can be easily used:
+Make sure your `PATH` includes the `$GOPATH/bin` directory so your commands can
+be easily used:
 ```
 export PATH=$PATH:$GOPATH/bin
 ```


### PR DESCRIPTION
since it's already a fairly diverged set of tests, and the fact that it passes appears to be causing issues with overall CI build status, which is probably some odd issue that surfaces because we're using `matrix.include`