### PR TITLE
Correctly show help message if `-h` is provided to subcommand

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -908,6 +908,7 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 			Name:        "foo",
 			Description: "descriptive wall of text about how it does foo things",
 			Subcommands: []Command{subCmdBar, subCmdBaz},
+			Action:      func(c *Context) error { return nil },
 		}
 
 		app.Commands = []Command{cmd}

--- a/help.go
+++ b/help.go
@@ -240,7 +240,7 @@ func checkCommandHelp(c *Context, name string) bool {
 }
 
 func checkSubcommandHelp(c *Context) bool {
-	if c.GlobalBool("h") || c.GlobalBool("help") {
+	if c.Bool("h") || c.Bool("help") {
 		ShowSubcommandHelp(c)
 		return true
 	}


### PR DESCRIPTION
Currently, if an action is specified on a subcommand, it ignores the
`-h` and `--help` flags if passed to the subcommand, e.g.:

`foo bar -h`

would call the default action on `bar` rather than show the help
documentation.

Fixes #477 