### PR TITLE
Ignore failed goimports installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 
 before_script:
 - go get github.com/urfave/gfmrun/...
-- go get golang.org/x/tools/cmd/goimports
+- go get golang.org/x/tools/cmd/goimports || true
 - if [ ! -f node_modules/.bin/markdown-toc ] ; then
     npm install markdown-toc ;
   fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ environment:
   PYTHON: C:\Python27-x64
   PYTHON_VERSION: 2.7.x
   PYTHON_ARCH: 64
-  GFMXR_DEBUG: 1
 
 install:
 - set PATH=%GOPATH%\bin;C:\go\bin;%PATH%

--- a/runtests
+++ b/runtests
@@ -71,7 +71,7 @@ def _toc():
 
 def _gen():
     go_version = check_output('go version'.split()).split()[2]
-    if go_version < 'go1.4':
+    if go_version < 'go1.5':
         print('runtests: skip on {}'.format(go_version), file=sys.stderr)
         return
 


### PR DESCRIPTION
since we only use it with go versions >= 1.5 anyway