### PR TITLE
Bump tested go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,18 @@ cache:
   - node_modules
 
 go:
-- 1.2.2
-- 1.3.3
-- 1.4
-- 1.5.4
-- 1.6.2
+- 1.2.x
+- 1.3.x
+- 1.4.x
+- 1.5.x
+- 1.6.x
 - master
 
 matrix:
   allow_failures:
   - go: master
   include:
-  - go: 1.6.2
+  - go: 1.6.x
     os: osx
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 go:
 - 1.2.x
 - 1.3.x
-- 1.4.x
+- 1.4.2
 - 1.5.x
 - 1.6.x
 - master
@@ -23,7 +23,7 @@ matrix:
 
 before_script:
 - go get github.com/urfave/gfmrun/...
-- go get golang.org/x/tools/cmd/goimports || true
+- go get golang.org/x/tools/... || true
 - if [ ! -f node_modules/.bin/markdown-toc ] ; then
     npm install markdown-toc ;
   fi


### PR DESCRIPTION
and (maybe?) take advantage of support for N.x version syntax