### PR TITLE
Refine error handling behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 ### Added
 - Flag type code generation via `go generate`
+- Write to stderr and exit 1 if action returns non-nil error
 
 ### Changed
 - Raise minimum tested/supported Go version to 1.2+

--- a/errors.go
+++ b/errors.go
@@ -93,6 +93,6 @@ func HandleExitCoder(err error) {
 
 	if err.Error() != "" {
 		fmt.Fprintln(ErrWriter, err)
-		OsExiter(1)
 	}
+	OsExiter(1)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -100,7 +100,7 @@ func TestHandleExitCoder_ErrorWithoutMessage(t *testing.T) {
 	err := errors.New("")
 	HandleExitCoder(err)
 
-	expect(t, exitCode, 0)
-	expect(t, called, false)
+	expect(t, exitCode, 1)
+	expect(t, called, true)
 	expect(t, ErrWriter.(*bytes.Buffer).String(), "")
 }


### PR DESCRIPTION
so that exit 1 happens as long as error is non-nil