### PR TITLE
Abstract dependency and test execution with Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,6 @@ matrix:
 
 before_script:
 - $pip_install flake8
-- go get github.com/urfave/gfmrun/... || true
-- go get golang.org/x/tools/... || true
-- if [ ! -f node_modules/.bin/markdown-toc ] ; then
-    npm install markdown-toc ;
-  fi
 - mkdir -p ${GOPATH%%:*}/src/gopkg.in/urfave
 - rm -rvf ${GOPATH%%:*}/src/gopkg.in/urfave/cli.v2
 - rm -rvf ${GOPATH%%:*}/pkg/*/gopkg.in/urfave/cli.v2.a
@@ -38,10 +33,4 @@ before_script:
 
 script:
 - flake8 runtests cli-v1-to-v2 generate-flag-types
-- ./runtests gen
-- ./runtests vet
-- ./runtests test
-- ./runtests gfmrun
-- ./cli-v1-to-v2 --selftest
-- ./runtests migrations
-- ./runtests toc
+- make all

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,37 @@
+default: test
+
+deps:
+	go get golang.org/x/tools/cmd/goimports || true
+	go get github.com/urfave/gfmrun/... || true
+	go list ./... \
+		| xargs go list -f '{{ join .Deps "\n" }}{{ printf "\n" }}{{ join .TestImports "\n" }}' \
+		| grep -v github.com/urfave/cli \
+		| xargs go get
+	@if [ ! -f node_modules/.bin/markdown-toc ]; then \
+		npm install markdown-toc ; \
+	fi
+
+gen: deps
+	./runtests gen
+
+vet:
+	./runtests vet
+
+gfmrun:
+	./runtests gfmrun
+
+v1-to-v2:
+	./cli-v1-to-v2 --selftest
+
+migrations:
+	./runtests migrations
+
+toc:
+	./runtests toc
+
+test: deps
+	./runtests test
+
+all: gen vet test gfmrun v1-to-v2 migrations toc
+
+.PHONY: default gen vet test gfmrun migrations toc v1-to-v2 deps all


### PR DESCRIPTION
Abstract the `runtests` script with a makefile, and update travis tests
to use makefile abstraction.

Not sure if the project is friendly towards `gmake` or not, but if it is
I can re-write the `runtests` script for `make`, or leave as is. Or
remove the makefile altogether, I just found it easier and more friendly
to use :)