### PR TITLE
remove the possiblity of end-user's seeing deprecation warnings

### DIFF
--- a/app.go
+++ b/app.go
@@ -62,10 +62,11 @@ type App struct {
 	// An action to execute after any subcommands are run, but after the subcommand has finished
 	// It is run even if Action() panics
 	After AfterFunc
+
 	// The action to execute when no subcommands are specified
+	// Expects a `cli.ActionFunc` but will accept the *deprecated* signature of `func(*cli.Context) {}`
+	// *Note*: support for the deprecated `Action` signature will be removed in a future version
 	Action interface{}
-	// TODO: replace `Action: interface{}` with `Action: ActionFunc` once some kind
-	// of deprecation period has passed, maybe?
 
 	// Execute this function if the proper command cannot be found
 	CommandNotFound CommandNotFoundFunc
@@ -247,11 +248,12 @@ func (a *App) Run(arguments []string) (err error) {
 	return err
 }
 
-// DEPRECATED: Another entry point to the cli app, takes care of passing arguments and error handling
+// RunAndExitOnError calls .Run() and exits non-zero if an error was returned
+//
+// Deprecated: instead you should return an error that fulfills cli.ExitCoder
+// to cli.App.Run. This will cause the application to exit with the given eror
+// code in the cli.ExitCoder
 func (a *App) RunAndExitOnError() {
-	fmt.Fprintf(a.errWriter(),
-		"DEPRECATED cli.App.RunAndExitOnError.  %s  See %s\n",
-		contactSysadmin, runAndExitOnErrorDeprecationURL)
 	if err := a.Run(os.Args); err != nil {
 		fmt.Fprintln(a.errWriter(), err)
 		OsExiter(1)
@@ -471,7 +473,7 @@ func HandleAction(action interface{}, context *Context) (err error) {
 			// swallowing all panics that may happen when calling an Action func.
 			s := fmt.Sprintf("%v", r)
 			if strings.HasPrefix(s, "reflect: ") && strings.Contains(s, "too many input arguments") {
-				err = NewExitError(fmt.Sprintf("ERROR unknown Action error: %v.  See %s", r, appActionDeprecationURL), 2)
+				err = NewExitError(fmt.Sprintf("ERROR unknown Action error: %v."), 2)
 			} else {
 				panic(r)
 			}
@@ -485,9 +487,6 @@ func HandleAction(action interface{}, context *Context) (err error) {
 	vals := reflect.ValueOf(action).Call([]reflect.Value{reflect.ValueOf(context)})
 
 	if len(vals) == 0 {
-		fmt.Fprintf(ErrWriter,
-			"DEPRECATED Action signature.  Must be `cli.ActionFunc`.  %s  See %s\n",
-			contactSysadmin, appActionDeprecationURL)
 		return nil
 	}
 

--- a/app.go
+++ b/app.go
@@ -473,7 +473,7 @@ func HandleAction(action interface{}, context *Context) (err error) {
 			// swallowing all panics that may happen when calling an Action func.
 			s := fmt.Sprintf("%v", r)
 			if strings.HasPrefix(s, "reflect: ") && strings.Contains(s, "too many input arguments") {
-				err = NewExitError(fmt.Sprintf("ERROR unknown Action error: %v."), 2)
+				err = NewExitError(fmt.Sprintf("ERROR unknown Action error: %v.", r), 2)
 			} else {
 				panic(r)
 			}


### PR DESCRIPTION
Instead use deprecation pattern described in
https://blog.golang.org/godoc-documenting-go-code.

This will reduce the chances that the application developer will notice that
the deprecations, but I can see the argument that @alienscience is making in
 #507 that the current approach is actually an API breakage rather than
a deprecation since the warnings are printed at runtume. More practically, this
has a chance to create a poor user experience for users of applications that
use `cli` if the application developer doesn't notice the warnings.

Fixes #507