### PR TITLE
Update altsrc imports to gopkg.in

### DIFF
--- a/altsrc/flag.go
+++ b/altsrc/flag.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 // FlagInputSourceExtension is an extension interface of cli.Flag that

--- a/altsrc/flag_generated.go
+++ b/altsrc/flag_generated.go
@@ -3,7 +3,7 @@ package altsrc
 import (
 	"flag"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 // WARNING: This file is generated!

--- a/altsrc/flag_test.go
+++ b/altsrc/flag_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 type testApplyInputSource struct {

--- a/altsrc/input_source_context.go
+++ b/altsrc/input_source_context.go
@@ -3,7 +3,7 @@ package altsrc
 import (
 	"time"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 // InputSourceContext is an interface used to allow

--- a/altsrc/json_command_test.go
+++ b/altsrc/json_command_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 const (

--- a/altsrc/json_source_context.go
+++ b/altsrc/json_source_context.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 // NewJSONSourceFromFlagFunc returns a func that takes a cli.Context

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 // MapInputSource implements InputSourceContext to return

--- a/altsrc/toml_command_test.go
+++ b/altsrc/toml_command_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 func TestCommandTomFileTest(t *testing.T) {

--- a/altsrc/toml_file_loader.go
+++ b/altsrc/toml_file_loader.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 
 	"github.com/BurntSushi/toml"
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 type tomlMap struct {

--- a/altsrc/yaml_command_test.go
+++ b/altsrc/yaml_command_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 func TestCommandYamlFileTest(t *testing.T) {

--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 
 	"gopkg.in/yaml.v2"
 )

--- a/generate-flag-types
+++ b/generate-flag-types
@@ -193,6 +193,8 @@ def _write_altsrc_flag_types(outfile, types):
     _fwrite(outfile, """\
         package altsrc
 
+        import "gopkg.in/urfave/cli.v2"
+
         // WARNING: This file is generated!
 
         """)


### PR DESCRIPTION
Updates altsrc imports to use `gopkg.in/urfave/cli.v2`

Fixes: #505