### PR TITLE
Treat all flags which followd behind the last arguments as normal arg…

### DIFF
--- a/command.go
+++ b/command.go
@@ -46,6 +46,8 @@ type Command struct {
 	Flags []Flag
 	// Treat all flags as normal arguments if true
 	SkipFlagParsing bool
+	// Treat the flags as normal arguments if true
+	SkipLastFlagParsing bool
 	// Boolean to hide built-in help command
 	HideHelp bool
 	// Boolean to hide this command from help or completion
@@ -90,6 +92,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	set.SetOutput(ioutil.Discard)
 
 	if !c.SkipFlagParsing {
+		firstFlagAdjust := -1
 		firstFlagIndex := -1
 		terminatorIndex := -1
 		for index, arg := range ctx.Args() {
@@ -101,9 +104,13 @@ func (c Command) Run(ctx *Context) (err error) {
 				continue
 			} else if strings.HasPrefix(arg, "-") && firstFlagIndex == -1 {
 				firstFlagIndex = index
+			} else {
+				firstFlagAdjust = index
 			}
 		}
-
+		if c.SkipLastFlagParsing && firstFlagAdjust < firstFlagIndex {
+			firstFlagIndex = -1
+		}
 		if firstFlagIndex > -1 {
 			args := ctx.Args()
 			regularArgs := make([]string, len(args[1:firstFlagIndex]))


### PR DESCRIPTION
If SkipFlagParsing is not considered,cli treat all words which start by '-' as flag, so when the subcommand has a argument which start by '-', it also will treated as cli' flag, not a argument for subcommand.
e.g.
```
root@ubuntu:~/# runc exec test ls -la    
Incorrect Usage.
```
I think cli should treat all flags which followd behind the last arguments as normal arguments,just like this:
```
root@ubuntu:~/# runc exec test ls -la            
total 44
drwxr-xr-x   12 root     root          4096 Aug 30 06:37 .
drwxr-xr-x   12 root     root          4096 Aug 30 06:37 ..
-rwxr-xr-x    1 root     root             0 Aug 30 02:23 .dockerenv
-rwxr-xr-x    1 root     root             0 Aug 30 02:23 .dockerinit
...
```
https://github.com/opencontainers/runc/issues/752 for details.
Signed-off-by: Shukui Yang <yangshukui@huawei.com>