### PR TITLE
Dereference `Flag`s if they are pointers

### DIFF
--- a/context.go
+++ b/context.go
@@ -79,7 +79,12 @@ func (c *Context) IsSet(name string) bool {
 					return
 				}
 
-				envVarValue := reflect.ValueOf(f).FieldByName("EnvVar")
+				val := reflect.ValueOf(f)
+				if val.Kind() == reflect.Ptr {
+					val = val.Elem()
+				}
+
+				envVarValue := val.FieldByName("EnvVar")
 				if !envVarValue.IsValid() {
 					return
 				}


### PR DESCRIPTION
When checking if environment variables are set.

We don't support pointer flags currently (though this is the default in
the `v2` branch), but this fixes #516