### PR TITLE
Backport no argument reordering as an option

### DIFF
--- a/command.go
+++ b/command.go
@@ -46,6 +46,11 @@ type Command struct {
 	Flags []Flag
 	// Treat all flags as normal arguments if true
 	SkipFlagParsing bool
+	// Skip argument reordering which attempts to move flags before arguments,
+	// but only works if all flags appear after all arguments. This behavior was
+	// removed n version 2 since it only works under specific conditions so we
+	// backport here by exposing it as an option for compatibility.
+	SkipArgReorder bool
 	// Boolean to hide built-in help command
 	HideHelp bool
 	// Boolean to hide this command from help or completion
@@ -89,7 +94,9 @@ func (c Command) Run(ctx *Context) (err error) {
 	set := flagSet(c.Name, c.Flags)
 	set.SetOutput(ioutil.Discard)
 
-	if !c.SkipFlagParsing {
+	if c.SkipFlagParsing {
+		err = set.Parse(append([]string{"--"}, ctx.Args().Tail()...))
+	} else if !c.SkipArgReorder {
 		firstFlagIndex := -1
 		terminatorIndex := -1
 		for index, arg := range ctx.Args() {
@@ -120,10 +127,6 @@ func (c Command) Run(ctx *Context) (err error) {
 			err = set.Parse(append(flagArgs, regularArgs...))
 		} else {
 			err = set.Parse(ctx.Args().Tail())
-		}
-	} else {
-		if c.SkipFlagParsing {
-			err = set.Parse(append([]string{"--"}, ctx.Args().Tail()...))
 		}
 	}
 


### PR DESCRIPTION
In the unreleased version 2, the argument reordering has been removed
(in f585ec7cb8b0d9189ac9016fe83f911f3a360f2e) since it only worked if
all of the arguments appeared before all of the flags, but not if they
were intermixed which was of limited utility and caused some confusion.
This commit allows enabling of this future behavior via SkipArgReorder.

Ideally we'd support complete intermingling of flags and arguments, but
this is unlikely to happen until we switch flag parsers.

Fixes #515