### PR TITLE
Call HandleExitCoder for all members of MultiError.Errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -74,7 +74,7 @@ func (ee *ExitError) ExitCode() int {
 // HandleExitCoder checks if the error fulfills the ExitCoder interface, and if
 // so prints the error to stderr (if it is non-empty) and calls OsExiter with the
 // given exit code.  If the given error is a MultiError, then this func is
-// called on all members of the Errors slice.
+// called on all members of the Errors slice and calls OsExiter with the last exit code.
 func HandleExitCoder(err error) {
 	if err == nil {
 		return

--- a/errors.go
+++ b/errors.go
@@ -86,8 +86,9 @@ func HandleExitCoder(err error) {
 
 	if multiErr, ok := err.(MultiError); ok {
 		for _, merr := range multiErr.Errors {
-			HandleExitCoder(merr)
+			fmt.Fprintln(ErrWriter, merr)
 		}
+		OsExiter(1)
 		return
 	}
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -59,10 +59,11 @@ func TestHandleExitCoder_MultiErrorWithExitCoder(t *testing.T) {
 	defer func() { OsExiter = fakeOsExiter }()
 
 	exitErr := NewExitError("galactic perimeter breach", 9)
-	err := NewMultiError(errors.New("wowsa"), errors.New("egad"), exitErr)
+	exitErr2 := NewExitError("last ExitCoder", 11)
+	err := NewMultiError(errors.New("wowsa"), errors.New("egad"), exitErr, exitErr2)
 	HandleExitCoder(err)
 
-	expect(t, exitCode, 9)
+	expect(t, exitCode, 11)
 	expect(t, called, true)
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -12,8 +12,10 @@ func TestHandleExitCoder_nil(t *testing.T) {
 	called := false
 
 	OsExiter = func(rc int) {
-		exitCode = rc
-		called = true
+		if !called {
+			exitCode = rc
+			called = true
+		}
 	}
 
 	defer func() { OsExiter = fakeOsExiter }()
@@ -29,8 +31,10 @@ func TestHandleExitCoder_ExitCoder(t *testing.T) {
 	called := false
 
 	OsExiter = func(rc int) {
-		exitCode = rc
-		called = true
+		if !called {
+			exitCode = rc
+			called = true
+		}
 	}
 
 	defer func() { OsExiter = fakeOsExiter }()
@@ -46,8 +50,10 @@ func TestHandleExitCoder_MultiErrorWithExitCoder(t *testing.T) {
 	called := false
 
 	OsExiter = func(rc int) {
-		exitCode = rc
-		called = true
+		if !called {
+			exitCode = rc
+			called = true
+		}
 	}
 
 	defer func() { OsExiter = fakeOsExiter }()
@@ -65,8 +71,10 @@ func TestHandleExitCoder_ErrorWithMessage(t *testing.T) {
 	called := false
 
 	OsExiter = func(rc int) {
-		exitCode = rc
-		called = true
+		if !called {
+			exitCode = rc
+			called = true
+		}
 	}
 	ErrWriter = &bytes.Buffer{}
 
@@ -88,8 +96,10 @@ func TestHandleExitCoder_ErrorWithoutMessage(t *testing.T) {
 	called := false
 
 	OsExiter = func(rc int) {
-		exitCode = rc
-		called = true
+		if !called {
+			exitCode = rc
+			called = true
+		}
 	}
 	ErrWriter = &bytes.Buffer{}
 
@@ -123,7 +133,9 @@ func TestHandleExitCoder_ErrorWithFormat(t *testing.T) {
 	called := false
 
 	OsExiter = func(rc int) {
-		called = true
+		if !called {
+			called = true
+		}
 	}
 	ErrWriter = &bytes.Buffer{}
 
@@ -143,7 +155,9 @@ func TestHandleExitCoder_MultiErrorWithFormat(t *testing.T) {
 	called := false
 
 	OsExiter = func(rc int) {
-		called = true
+		if !called {
+			called = true
+		}
 	}
 	ErrWriter = &bytes.Buffer{}
 


### PR DESCRIPTION
[The document of HandleExitCoder](https://godoc.org/github.com/urfave/cli#HandleExitCoder) say:

> If the given error is a MultiError, then this func is called on all members of the Errors slice.

but HandleExitCoder is called only once for the first element of Errors slice.

Because HandleExitCoder which is called in HandleExitCoder will `os.Exit`.

``` go
    if multiErr, ok := err.(MultiError); ok {
        for _, merr := range multiErr.Errors {
            HandleExitCoder(merr) // will exit
        }
        return
    }
```
