### PR TITLE
make shell autocomplete more robust

### DIFF
--- a/app.go
+++ b/app.go
@@ -145,10 +145,6 @@ func (a *App) Setup() {
 		}
 	}
 
-	if a.EnableBashCompletion {
-		a.appendFlag(BashCompletionFlag)
-	}
-
 	if !a.HideVersion {
 		a.appendFlag(VersionFlag)
 	}
@@ -173,6 +169,14 @@ func (a *App) Setup() {
 func (a *App) Run(arguments []string) (err error) {
 	a.Setup()
 
+	// handle the completion flag separately from the flagset since
+	// completion could be attempted after a flag, but before its value was put
+	// on the command line. this causes the flagset to interpret the completion
+	// flag name as the value of the flag before it which is undesirable
+	// note that we can only do this because the shell autocomplete function
+	// always appends the completion flag at the end of the command
+	complete, arguments := checkCompleteFlag(a, arguments)
+
 	// parse flags
 	set := flagSet(a.Name, a.Flags)
 	set.SetOutput(ioutil.Discard)
@@ -184,6 +188,7 @@ func (a *App) Run(arguments []string) (err error) {
 		ShowAppHelp(context)
 		return nerr
 	}
+	context.complete = complete
 
 	if checkCompletions(context) {
 		return nil
@@ -282,11 +287,6 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 		newCmds = append(newCmds, c)
 	}
 	a.Commands = newCmds
-
-	// append flags
-	if a.EnableBashCompletion {
-		a.appendFlag(BashCompletionFlag)
-	}
 
 	// parse flags
 	set := flagSet(a.Name, a.Flags)

--- a/app.go
+++ b/app.go
@@ -175,7 +175,7 @@ func (a *App) Run(arguments []string) (err error) {
 	// flag name as the value of the flag before it which is undesirable
 	// note that we can only do this because the shell autocomplete function
 	// always appends the completion flag at the end of the command
-	complete, arguments := checkCompleteFlag(a, arguments)
+	shellComplete, arguments := checkShellCompleteFlag(a, arguments)
 
 	// parse flags
 	set := flagSet(a.Name, a.Flags)
@@ -188,7 +188,7 @@ func (a *App) Run(arguments []string) (err error) {
 		ShowAppHelp(context)
 		return nerr
 	}
-	context.complete = complete
+	context.shellComplete = shellComplete
 
 	if checkCompletions(context) {
 		return nil

--- a/context.go
+++ b/context.go
@@ -15,7 +15,7 @@ import (
 type Context struct {
 	App           *App
 	Command       Command
-	complete      bool
+	shellComplete bool
 	flagSet       *flag.FlagSet
 	setFlags      map[string]bool
 	parentContext *Context
@@ -26,7 +26,7 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
 	c := &Context{App: app, flagSet: set, parentContext: parentCtx}
 
 	if parentCtx != nil {
-		c.complete = parentCtx.complete
+		c.shellComplete = parentCtx.shellComplete
 	}
 
 	return c

--- a/context.go
+++ b/context.go
@@ -15,6 +15,7 @@ import (
 type Context struct {
 	App           *App
 	Command       Command
+	complete      bool
 	flagSet       *flag.FlagSet
 	setFlags      map[string]bool
 	parentContext *Context
@@ -22,7 +23,13 @@ type Context struct {
 
 // NewContext creates a new context. For use in when invoking an App or Command action.
 func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
-	return &Context{App: app, flagSet: set, parentContext: parentCtx}
+	c := &Context{App: app, flagSet: set, parentContext: parentCtx}
+
+	if parentCtx != nil {
+		c.complete = parentCtx.complete
+	}
+
+	return c
 }
 
 // NumFlags returns the number of flags set

--- a/help.go
+++ b/help.go
@@ -252,7 +252,7 @@ func checkSubcommandHelp(c *Context) bool {
 	return false
 }
 
-func checkCompleteFlag(a *App, arguments []string) (bool, []string) {
+func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
 	if !a.EnableBashCompletion {
 		return false, arguments
 	}
@@ -268,7 +268,7 @@ func checkCompleteFlag(a *App, arguments []string) (bool, []string) {
 }
 
 func checkCompletions(c *Context) bool {
-	if !c.complete {
+	if !c.shellComplete {
 		return false
 	}
 
@@ -285,7 +285,7 @@ func checkCompletions(c *Context) bool {
 }
 
 func checkCommandCompletions(c *Context, name string) bool {
-	if !c.complete {
+	if !c.shellComplete {
 		return false
 	}
 

--- a/help.go
+++ b/help.go
@@ -252,20 +252,43 @@ func checkSubcommandHelp(c *Context) bool {
 	return false
 }
 
-func checkCompletions(c *Context) bool {
-	if (c.GlobalBool(BashCompletionFlag.Name) || c.Bool(BashCompletionFlag.Name)) && c.App.EnableBashCompletion {
-		ShowCompletions(c)
-		return true
+func checkCompleteFlag(a *App, arguments []string) (bool, []string) {
+	if !a.EnableBashCompletion {
+		return false, arguments
 	}
 
-	return false
+	pos := len(arguments) - 1
+	lastArg := arguments[pos]
+
+	if lastArg != "--"+BashCompletionFlag.Name {
+		return false, arguments
+	}
+
+	return true, arguments[:pos]
+}
+
+func checkCompletions(c *Context) bool {
+	if !c.complete {
+		return false
+	}
+
+	if args := c.Args(); args.Present() {
+		name := args.First()
+		if cmd := c.App.Command(name); cmd != nil {
+			// let the command handle the completion
+			return false
+		}
+	}
+
+	ShowCompletions(c)
+	return true
 }
 
 func checkCommandCompletions(c *Context, name string) bool {
-	if c.Bool(BashCompletionFlag.Name) && c.App.EnableBashCompletion {
-		ShowCommandCompletions(c, name)
-		return true
+	if !c.complete {
+		return false
 	}
 
-	return false
+	ShowCommandCompletions(c, name)
+	return true
 }


### PR DESCRIPTION
Lets say you have an app with a flag "a" of type `cli.StringFlag`.

Then this is the command typed:

```bash
$ app -a <tab>
```

The completion system calls this command: `app -a --generate-bash-completion`

Since the "a" flag expects an argument, the string "--generate-bash-completion" is used as its value and the flagset, when parsed, shows that the completion flag was not enabled.

This patch changes the handling of the `BashCompletionFlag`.

`BashCompletionFlag.Name` should only ever exist at the end of the `arguments` list. With this knowledge, we can check for its existence outside the flagset, store its value in `Context` and strip it from the `arguments` seen by the rest of the app.

Some additional reordering of the logic in `Command.Run` (to match that in `App.Run`) was required to prevent invalid usage errors from preempting the completion of commands.