### PR TITLE
allow to load YAML configuration files on Windows

### DIFF
--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
+	"strings"
 
 	"gopkg.in/urfave/cli.v1"
 

--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -81,6 +81,7 @@ func loadDataFrom(filePath string) ([]byte, error) {
 		}
 		return ioutil.ReadFile(filePath)
 	} else if runtime.GOOS == "windows" && strings.Contains(u.String(), "\\") {
+		// on Windows systems u.Path is always empty, so we need to check the string directly.
 		if _, notFoundFileErr := os.Stat(filePath); notFoundFileErr != nil {
 			return nil, fmt.Errorf("Cannot read from file: '%s' because it does not exist.", filePath)
 		}


### PR DESCRIPTION
The function `loadDataFrom` does not take care of Windows users since any of the conditions met and it returns an error.

The change looks for the runtime where it's running and then if the filePath contains a `\`.