### PR TITLE
errorableFlag: scope result of type assertion.

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -76,8 +76,8 @@ func flagSet(name string, flags []Flag) (*flag.FlagSet, error) {
 
 	for _, f := range flags {
 		//TODO remove in v2 when errorableFlag is removed
-		if f, ok := f.(errorableFlag); ok {
-			if err := f.applyWithError(set); err != nil {
+		if ef, ok := f.(errorableFlag); ok {
+			if err := ef.applyWithError(set); err != nil {
 				return nil, err
 			}
 		} else {


### PR DESCRIPTION
Regarding the following (flag.go:78):
```go
    if f, ok := f.(errorableFlag); ok {
      if err := f.applyWithError(set); err != nil {
        return nil, err
      }
    } else {
      f.Apply(set)
    }
```
Will panic on `f.Apply(set)` because `f` is set to `nil` when the type assertion fails.

This PR includes a new scoped variable for the result of the type assertion instead:
```go
    if ef, ok := f.(errorableFlag); ok {
      if err := ef.applyWithError(set); err != nil {
        return nil, err
      }
    } else {
      f.Apply(set)
    }
```

Illustration:

`main.go`
```go
package main

import "fmt"

type T interface {
  Foo()
}

type myT struct{}

func (m myT) Foo() {}

type noT struct{}

func main() {
  r := []interface{}{
    myT{},
    noT{},
  }
  for _, v := range r {
    if v, ok := v.(T); ok {
      fmt.Printf("OK. v = %v\n", v)
    } else {
      fmt.Printf("!OK. v = %v\n", v)
    }
  }
}
```
```
# go run main.go
OK. v = {}
!OK. v = <nil>
```
