### PR TITLE
Allow explicit ActionFuncs in HandleAction

### DIFF
--- a/app.go
+++ b/app.go
@@ -479,7 +479,9 @@ func (a Author) String() string {
 // it's an ActionFunc or a func with the legacy signature for Action, the func
 // is run!
 func HandleAction(action interface{}, context *Context) (err error) {
-	if a, ok := action.(func(*Context) error); ok {
+	if a, ok := action.(ActionFunc); ok { // Support explicit ActionFunc funcs
+		return a(context)
+	} else if a, ok := action.(func(*Context) error); ok {
 		return a(context)
 	} else if a, ok := action.(func(*Context)); ok { // deprecated function signature
 		a(context)

--- a/app_test.go
+++ b/app_test.go
@@ -1620,3 +1620,21 @@ func TestHandleAction_WithUnknownPanic(t *testing.T) {
 	}
 	HandleAction(app.Action, NewContext(app, fs, nil))
 }
+
+func TestHandleAction_WithActionFunc(t *testing.T) {
+	app := NewApp()
+	ctx := NewContext(app, nil, nil)
+
+	var action ActionFunc = func(c *Context) error {
+		return errors.New("ActionFunc is supported")
+	}
+
+	result := HandleAction(action, ctx)
+	if result == nil {
+		t.Fatalf("expected an error but, but got: nil")
+	} else {
+		if errorMsg := result.Error(); errorMsg != "ActionFunc is supported" {
+			t.Fatalf("expected error '%s', but got: %v", "ActionFunc is supported", errorMsg)
+		}
+	}
+}


### PR DESCRIPTION
Hi there! I'm working with `cli` and I'm proposing this patch to address the following use case. 

### Problem 

_This change is related to [this TODO](https://github.com/urfave/cli/blob/0bdeddeeb0f650497d603c4ad7b20cfe685682f6/command.go#L38) and may help to address it in the long term. Supporting the "new" approach is a good first step toward deprecating the old approach. Let me know what you think!_

The TL;DR is, when defining my command-line interface I want to be able to explicitly using the `ActionFunc` function type, rather than having to spell out `func(c *cli.Context) error` every time.

The longer version is, I have a "handler" function type and a map of required fields. I want to be able to combine the handler function and the required fields to generate an action function (`ActionFunc`) which can be attached to the `Action` field of a `cli.Command`. In my code, I have something that looks like this:

```go

// Function type for the actual functions that get called to execute a command
type CLICommand func(*cli.Context)

func makeAction(command CLICommand, requiredFields map[string]string) cli.ActionFunc {
  action := func(c *cli.Context) error {
    // TODO: validate the context by ensuring that the requiredFields are present
    // TODO: execute `command`
  }
  return action
}
```

Without this patch, the code above will raise this error:

```
ERROR invalid Action type. Must be `func(*Context`)` or `func(*Context) error).  This is an error in the application.  Please contact the distributor of this application if this is not you.See https://github.com/urfave/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature
```

The alternative would be to change the function signature to

```go
func makeAction(command CLICommand, requiredFields map[string]string) func(*cli.Context) error {
```

but this is not as clean, in my opinion.

### Changes

`HandleAction` allows functions which have the same signature as
`ActionFunc`, but real `ActionFunc` functions are no supported. This
means that if a user application wants to define actions explicitly
using the `ActionFunc` type, `HandleAction` won't allow it.

This patch adds support for explicitly typed `ActionFunc` functions.