### PR TITLE
Invalidate context.setFlags cache on modification.

### DIFF
--- a/context.go
+++ b/context.go
@@ -39,11 +39,13 @@ func (c *Context) NumFlags() int {
 
 // Set sets a context flag to a value.
 func (c *Context) Set(name, value string) error {
+	c.setFlags = nil
 	return c.flagSet.Set(name, value)
 }
 
 // GlobalSet sets a context flag to a value on the global flagset
 func (c *Context) GlobalSet(name, value string) error {
+	globalContext(c).setFlags = nil
 	return globalContext(c).flagSet.Set(name, value)
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -375,8 +375,10 @@ func TestContext_Set(t *testing.T) {
 	set.Int("int", 5, "an int")
 	c := NewContext(nil, set, nil)
 
+	expect(t, c.IsSet("int"), false)
 	c.Set("int", "1")
 	expect(t, c.Int("int"), 1)
+	expect(t, c.IsSet("int"), true)
 }
 
 func TestContext_GlobalSet(t *testing.T) {
@@ -393,7 +395,9 @@ func TestContext_GlobalSet(t *testing.T) {
 	expect(t, c.Int("int"), 1)
 	expect(t, c.GlobalInt("int"), 5)
 
+	expect(t, c.GlobalIsSet("int"), false)
 	c.GlobalSet("int", "1")
 	expect(t, c.Int("int"), 1)
 	expect(t, c.GlobalInt("int"), 1)
+	expect(t, c.GlobalIsSet("int"), true)
 }


### PR DESCRIPTION
The `Context.IsSet` method caches the set of flags "set" to speed up subsequent queries. Unfortunately if a program calls `IsSet`, but afterwards modifies the flagset via `Set` or `GlobalSet`, the cache will not be invalidated, causing subsequent `IsSet` and `GlobalIsSet` methods to return `false`, even though they have been just set.

I've updated both `TestContext_Set` and `TestContext_GlobalSet` to also test for the "set"-edness of the flag before and after setting it, both of which will produce test failures without the cache invalidation introduced in this PR.