### PR TITLE
Subcommand structure should be correctly passed to application

### DIFF
--- a/command.go
+++ b/command.go
@@ -230,11 +230,9 @@ func (c Command) startApp(ctx *Context) error {
 		app.HelpName = app.Name
 	}
 
-	if c.Description != "" {
-		app.Usage = c.Description
-	} else {
-		app.Usage = c.Usage
-	}
+	app.Usage = c.Usage
+	app.Description = c.Description
+	app.ArgsUsage = c.ArgsUsage
 
 	// set CommandNotFound
 	app.CommandNotFound = ctx.App.CommandNotFound

--- a/help.go
+++ b/help.go
@@ -64,7 +64,7 @@ OPTIONS:
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
 var SubcommandHelpTemplate = `NAME:
-   {{.HelpName}} - {{.Usage}}
+   {{.HelpName}} - {{if .Description}}{{.Description}}{{else}}{{.Usage}}{{end}}
 
 USAGE:
    {{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}


### PR DESCRIPTION
Currently, one can specify a Description, Usage, and ArgsUsage for a subcommand. Currently however, the subcommand's Description is copied into the App's usage (unless the subcommand has no description, then its usage is copied into the App's usage), and the other fields are ignored. This means that if a subcommand specified a custom ArgsUsage, it cannot be used by a help template.

This PR fixes these issues by just copying over the fields as normal (as is currently done with the Flags, HideHelp, Before, After, and Action fields). To preserve the old default behavior, the default SubcommandHelpTemplate now uses the description if provided or falls back to the usage. 

This leads to significantly fewer surprises when creating a custom subcommand help template.