### PR TITLE
Handle slice flag values like slice env values

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -136,7 +136,10 @@ type StringSlice []string
 
 // Set appends the string value to the list of values
 func (f *StringSlice) Set(value string) error {
-	*f = append(*f, value)
+	for _, s := range strings.Split(value, ",") {
+		s = strings.TrimSpace(s)
+		*f = append(*f, s)
+	}
 	return nil
 }
 
@@ -168,11 +171,8 @@ func (f StringSliceFlag) ApplyWithError(set *flag.FlagSet) error {
 			envVar = strings.TrimSpace(envVar)
 			if envVal, ok := syscall.Getenv(envVar); ok {
 				newVal := &StringSlice{}
-				for _, s := range strings.Split(envVal, ",") {
-					s = strings.TrimSpace(s)
-					if err := newVal.Set(s); err != nil {
-						return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
-					}
+				if err := newVal.Set(envVal); err != nil {
+					return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
 				}
 				f.Value = newVal
 				break
@@ -195,11 +195,14 @@ type IntSlice []int
 
 // Set parses the value into an integer and appends it to the list of values
 func (f *IntSlice) Set(value string) error {
-	tmp, err := strconv.Atoi(value)
-	if err != nil {
-		return err
+	for _, s := range strings.Split(value, ",") {
+		s = strings.TrimSpace(s)
+		tmp, err := strconv.Atoi(s)
+		if err != nil {
+			return err
+		}
+		*f = append(*f, tmp)
 	}
-	*f = append(*f, tmp)
 	return nil
 }
 
@@ -231,11 +234,8 @@ func (f IntSliceFlag) ApplyWithError(set *flag.FlagSet) error {
 			envVar = strings.TrimSpace(envVar)
 			if envVal, ok := syscall.Getenv(envVar); ok {
 				newVal := &IntSlice{}
-				for _, s := range strings.Split(envVal, ",") {
-					s = strings.TrimSpace(s)
-					if err := newVal.Set(s); err != nil {
-						return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
-					}
+				if err := newVal.Set(envVal); err != nil {
+					return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
 				}
 				f.Value = newVal
 				break
@@ -258,11 +258,14 @@ type Int64Slice []int64
 
 // Set parses the value into an integer and appends it to the list of values
 func (f *Int64Slice) Set(value string) error {
-	tmp, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		return err
+	for _, s := range strings.Split(value, ",") {
+		s = strings.TrimSpace(s)
+		tmp, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		*f = append(*f, tmp)
 	}
-	*f = append(*f, tmp)
 	return nil
 }
 
@@ -294,11 +297,8 @@ func (f Int64SliceFlag) ApplyWithError(set *flag.FlagSet) error {
 			envVar = strings.TrimSpace(envVar)
 			if envVal, ok := syscall.Getenv(envVar); ok {
 				newVal := &Int64Slice{}
-				for _, s := range strings.Split(envVal, ",") {
-					s = strings.TrimSpace(s)
-					if err := newVal.Set(s); err != nil {
-						return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
-					}
+				if err := newVal.Set(envVal); err != nil {
+					return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
 				}
 				f.Value = newVal
 				break

--- a/flag_test.go
+++ b/flag_test.go
@@ -643,6 +643,20 @@ func TestParseMultiStringSlice(t *testing.T) {
 	}).Run([]string{"run", "-s", "10", "-s", "20"})
 }
 
+func TestParseCommaStringSlice(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			StringSliceFlag{Name: "serve", Value: &StringSlice{}},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.StringSlice("serve"), []string{"10", "20"}) {
+				t.Errorf("main name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "10,20"})
+}
+
 func TestParseMultiStringSliceFromEnv(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("APP_INTERVALS", "20,30,40")
@@ -777,6 +791,20 @@ func TestParseMultiIntSlice(t *testing.T) {
 	}).Run([]string{"run", "-s", "10", "-s", "20"})
 }
 
+func TestParseCommaIntSlice(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			IntSliceFlag{Name: "serve", Value: &IntSlice{}},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.IntSlice("serve"), []int{10, 20}) {
+				t.Errorf("main name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "10,20"})
+}
+
 func TestParseMultiIntSliceFromEnv(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("APP_INTERVALS", "20,30,40")
@@ -832,6 +860,20 @@ func TestParseMultiInt64Slice(t *testing.T) {
 			return nil
 		},
 	}).Run([]string{"run", "-s", "10", "-s", "17179869184"})
+}
+
+func TestParseCommaInt64Slice(t *testing.T) {
+	(&App{
+		Flags: []Flag{
+			Int64SliceFlag{Name: "serve", Value: &Int64Slice{}},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Int64Slice("serve"), []int64{10, 17179869184}) {
+				t.Errorf("main name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "10,17179869184"})
 }
 
 func TestParseMultiInt64SliceFromEnv(t *testing.T) {


### PR DESCRIPTION
Command-line flags and environment variables are parsed differently for
slices. Command-line flags need one value per flag (`--serve 10 --serve 20`)
while environment variables need to use a comma-separated
value (`X_SERVER=10,20`).

This commit makes command-line flags work like environment
variables (`--serve 10,20`). Previous behavior is still
possible (`--serve 10 --serve 20`).

This change can be surprising for users expecting to be able to use
comma for a value.

Related to #549.