### PR TITLE
Fix autocomplete issue when multiple apps run autocomplete from etc/bash_completion.d directory

### DIFF
--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -3,12 +3,14 @@
 : ${PROG:=$(basename ${BASH_SOURCE})}
 
 _cli_bash_autocomplete() {
-     local cur opts base
-     COMPREPLY=()
-     cur="${COMP_WORDS[COMP_CWORD]}"
-     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
-     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-     return 0
- }
-  
- complete -F _cli_bash_autocomplete $PROG
+    local cur opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+}
+
+complete -F _cli_bash_autocomplete $PROG
+
+unset PROG


### PR DESCRIPTION
If there is more than 1 app that uses bash_autocomplete from /etc/bash_completion.d, the first one initialize PROG to it's name.
Then, for the others apps, PROG is already set so it's doesn't complete the right cli app.

I've just unset PROG variable to fix this issue.