### PR TITLE
Return raw slices in Getter impls

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -152,7 +152,7 @@ func (f *StringSlice) Value() []string {
 
 // Get returns the slice of strings set by this flag
 func (f *StringSlice) Get() interface{} {
-	return *f
+	return []string(*f)
 }
 
 // Apply populates the flag given the flag set and environment
@@ -215,7 +215,7 @@ func (f *IntSlice) Value() []int {
 
 // Get returns the slice of ints set by this flag
 func (f *IntSlice) Get() interface{} {
-	return *f
+	return []int(*f)
 }
 
 // Apply populates the flag given the flag set and environment
@@ -278,7 +278,7 @@ func (f *Int64Slice) Value() []int64 {
 
 // Get returns the slice of ints set by this flag
 func (f *Int64Slice) Get() interface{} {
-	return *f
+	return []int64(*f)
 }
 
 // Apply populates the flag given the flag set and environment

--- a/flag_test.go
+++ b/flag_test.go
@@ -62,17 +62,17 @@ func TestFlagsFromEnv(t *testing.T) {
 		{"1.2", 0, IntFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse 1.2 as int value for flag seconds: .*`)},
 		{"foobar", 0, IntFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse foobar as int value for flag seconds: .*`)},
 
-		{"1,2", IntSlice{1, 2}, IntSliceFlag{Name: "seconds", EnvVar: "SECONDS"}, ""},
-		{"1.2,2", IntSlice{}, IntSliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse 1.2,2 as int slice value for flag seconds: .*`)},
-		{"foobar", IntSlice{}, IntSliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse foobar as int slice value for flag seconds: .*`)},
+		{"1,2", []int{1, 2}, IntSliceFlag{Name: "seconds", EnvVar: "SECONDS"}, ""},
+		{"1.2,2", []int{}, IntSliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse 1.2,2 as int slice value for flag seconds: .*`)},
+		{"foobar", []int{}, IntSliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse foobar as int slice value for flag seconds: .*`)},
 
-		{"1,2", Int64Slice{1, 2}, Int64SliceFlag{Name: "seconds", EnvVar: "SECONDS"}, ""},
-		{"1.2,2", Int64Slice{}, Int64SliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse 1.2,2 as int64 slice value for flag seconds: .*`)},
-		{"foobar", Int64Slice{}, Int64SliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse foobar as int64 slice value for flag seconds: .*`)},
+		{"1,2", []int64{1, 2}, Int64SliceFlag{Name: "seconds", EnvVar: "SECONDS"}, ""},
+		{"1.2,2", []int64{}, Int64SliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse 1.2,2 as int64 slice value for flag seconds: .*`)},
+		{"foobar", []int64{}, Int64SliceFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse foobar as int64 slice value for flag seconds: .*`)},
 
 		{"foo", "foo", StringFlag{Name: "name", EnvVar: "NAME"}, ""},
 
-		{"foo,bar", StringSlice{"foo", "bar"}, StringSliceFlag{Name: "names", EnvVar: "NAMES"}, ""},
+		{"foo,bar", []string{"foo", "bar"}, StringSliceFlag{Name: "names", EnvVar: "NAMES"}, ""},
 
 		{"1", uint(1), UintFlag{Name: "seconds", EnvVar: "SECONDS"}, ""},
 		{"1.2", 0, UintFlag{Name: "seconds", EnvVar: "SECONDS"}, fmt.Sprintf(`could not parse 1.2 as uint value for flag seconds: .*`)},


### PR DESCRIPTION
The Getter interface should return the value, not the wrapped value, i.e. `[]string`, not `StringSlice`.