### PR TITLE
Fix can not set flag '-h' for custom

### DIFF
--- a/help.go
+++ b/help.go
@@ -235,7 +235,7 @@ func checkHelp(c *Context) bool {
 }
 
 func checkCommandHelp(c *Context, name string) bool {
-	if c.Bool("h") || c.Bool("help") {
+	if c.Bool("help") {
 		ShowCommandHelp(c, name)
 		return true
 	}
@@ -244,7 +244,7 @@ func checkCommandHelp(c *Context, name string) bool {
 }
 
 func checkSubcommandHelp(c *Context) bool {
-	if c.Bool("h") || c.Bool("help") {
+	if c.Bool("help") {
 		ShowSubcommandHelp(c)
 		return true
 	}


### PR DESCRIPTION
Users may want to set flag '-h' for other usage rather than "help".

But function `checkCommandHelp` and `checkSubcommandHelp` check every command for flag '-h' and '--help'. User-defined flag '-h' will always show help message.

Only keep flag '--help' more reasonable.

Relate to #546 