### PR TITLE
Explicitly fetch `goimports`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
 before_script:
 - go get github.com/urfave/gfmrun/... || true
-- go get golang.org/x/tools/... || true
+- go get golang.org/x/tools/cmd/goimports
 - if [ ! -f node_modules/.bin/markdown-toc ] ; then
     npm install markdown-toc ;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ cache:
   - node_modules
 
 go:
-- 1.2.x
-- 1.3.x
-- 1.4.2
-- 1.5.x
 - 1.6.x
 - 1.7.x
+- 1.8.x
 - master
 
 matrix:
@@ -22,6 +19,8 @@ matrix:
   - go: 1.6.x
     os: osx
   - go: 1.7.x
+    os: osx
+  - go: 1.8.x
     os: osx
 
 before_script:


### PR DESCRIPTION
Fetching the whole tree was failing on some Go versions and we really
only need goimports.