### PR TITLE
Do not double print errors from Before()

### DIFF
--- a/app.go
+++ b/app.go
@@ -240,7 +240,6 @@ func (a *App) Run(arguments []string) (err error) {
 	if a.Before != nil {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
-			fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
 			ShowAppHelp(context)
 			HandleExitCoder(beforeErr)
 			err = beforeErr

--- a/command.go
+++ b/command.go
@@ -197,8 +197,6 @@ func (c Command) Run(ctx *Context) (err error) {
 	if c.Before != nil {
 		err = c.Before(context)
 		if err != nil {
-			fmt.Fprintln(context.App.Writer, err)
-			fmt.Fprintln(context.App.Writer)
 			ShowCommandHelp(context, c.Name)
 			HandleExitCoder(err)
 			return err


### PR DESCRIPTION
They should be handled by `HandleExitCoder()` as `After()` errors are.

I briefly considered checking for `ExitCoder` and still printing the error if
it wasn't implemented to preserve the existing behavior (though it would appear
above rather than below the help message), but decided that then the caller of
`App.Run()` wouldn't be able to determine whether printing the returned `err`
would result in a duplicate message or not (it would in the case of `Before`
when the error is not an `ExitCoder`, but would not in the case that the
`Action` returned a non-`ExitCoder` error).

Fixes #604