### PR TITLE
Allow custom ExitError handler function

### DIFF
--- a/app.go
+++ b/app.go
@@ -468,7 +468,7 @@ func (a *App) appendFlag(flag Flag) {
 	}
 }
 
-func (a *App) handleExitCoder(context *Context, error) {
+func (a *App) handleExitCoder(context *Context, err error) {
 	if a.ExitErrHandler != nil {
 		a.ExitErrHandler(context, err)
 	} else {

--- a/app.go
+++ b/app.go
@@ -83,7 +83,8 @@ type App struct {
 	Writer io.Writer
 	// ErrWriter writes error output
 	ErrWriter io.Writer
-	// Execute this function to handle ExitErrors
+	// Execute this function to handle ExitErrors. If not provided, HandleExitCoder is provided to
+	// function as a default, so this is optional.
 	ExitErrHandler ExitErrHandlerFunc
 	// Other custom info
 	Metadata map[string]interface{}

--- a/app.go
+++ b/app.go
@@ -210,7 +210,7 @@ func (a *App) Run(arguments []string) (err error) {
 	if err != nil {
 		if a.OnUsageError != nil {
 			err := a.OnUsageError(context, err, false)
-			a.handleExitCoder(err)
+			a.handleExitCoder(context, err)
 			return err
 		}
 		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
@@ -245,7 +245,7 @@ func (a *App) Run(arguments []string) (err error) {
 		if beforeErr != nil {
 			fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
 			ShowAppHelp(context)
-			a.handleExitCoder(beforeErr)
+			a.handleExitCoder(context, beforeErr)
 			err = beforeErr
 			return err
 		}
@@ -267,7 +267,7 @@ func (a *App) Run(arguments []string) (err error) {
 	// Run default Action
 	err = HandleAction(a.Action, context)
 
-	a.handleExitCoder(err)
+	a.handleExitCoder(context, err)
 	return err
 }
 
@@ -334,7 +334,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	if err != nil {
 		if a.OnUsageError != nil {
 			err = a.OnUsageError(context, err, true)
-			a.handleExitCoder(err)
+			a.handleExitCoder(context, err)
 			return err
 		}
 		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
@@ -356,7 +356,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 		defer func() {
 			afterErr := a.After(context)
 			if afterErr != nil {
-				a.handleExitCoder(err)
+				a.handleExitCoder(context, err)
 				if err != nil {
 					err = NewMultiError(err, afterErr)
 				} else {
@@ -369,7 +369,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	if a.Before != nil {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
-			a.handleExitCoder(beforeErr)
+			a.handleExitCoder(context, beforeErr)
 			err = beforeErr
 			return err
 		}
@@ -387,7 +387,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	// Run default Action
 	err = HandleAction(a.Action, context)
 
-	a.handleExitCoder(err)
+	a.handleExitCoder(context, err)
 	return err
 }
 
@@ -468,9 +468,9 @@ func (a *App) appendFlag(flag Flag) {
 	}
 }
 
-func (a *App) handleExitCoder(err error) {
+func (a *App) handleExitCoder(context *Context, error) {
 	if a.ExitErrHandler != nil {
-		a.ExitErrHandler(err)
+		a.ExitErrHandler(context, err)
 	} else {
 		HandleExitCoder(err)
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -1661,6 +1661,42 @@ func TestHandleAction_WithInvalidFuncReturnSignature(t *testing.T) {
 	}
 }
 
+func TestHandleExitCoder_Default(t *testing.T) {
+	app := NewApp()
+	fs, err := flagSet(app.Name, app.Flags)
+	if err != nil {
+		t.Errorf("error creating FlagSet: %s", err)
+	}
+
+	ctx := NewContext(app, fs, nil)
+	app.handleExitCoder(ctx, errors.New("Default Behavior Error"))
+
+	output := fakeErrWriter.String()
+	if !strings.Contains(output, "Default") {
+		t.Fatalf("Expected Default Behavior from Error Handler but got: %s", output)
+	}
+}
+
+func TestHandleExitCoder_Custom(t *testing.T) {
+	app := NewApp()
+	fs, err := flagSet(app.Name, app.Flags)
+	if err != nil {
+		t.Errorf("error creating FlagSet: %s", err)
+	}
+
+	app.ExitErrHandler = func(_ *Context, _ error) {
+		fmt.Fprintln(ErrWriter, "I'm a Custom error handler, I print what I want!")
+	}
+
+	ctx := NewContext(app, fs, nil)
+	app.handleExitCoder(ctx, errors.New("Default Behavior Error"))
+
+	output := fakeErrWriter.String()
+	if !strings.Contains(output, "Custom") {
+		t.Fatalf("Expected Custom Behavior from Error Handler but got: %s", output)
+	}
+}
+
 func TestHandleAction_WithUnknownPanic(t *testing.T) {
 	defer func() { refute(t, recover(), nil) }()
 

--- a/app_test.go
+++ b/app_test.go
@@ -1669,7 +1669,7 @@ func TestHandleExitCoder_Default(t *testing.T) {
 	}
 
 	ctx := NewContext(app, fs, nil)
-	app.handleExitCoder(ctx, errors.New("Default Behavior Error"))
+	app.handleExitCoder(ctx, NewExitError("Default Behavior Error", 42))
 
 	output := fakeErrWriter.String()
 	if !strings.Contains(output, "Default") {
@@ -1689,7 +1689,7 @@ func TestHandleExitCoder_Custom(t *testing.T) {
 	}
 
 	ctx := NewContext(app, fs, nil)
-	app.handleExitCoder(ctx, errors.New("Default Behavior Error"))
+	app.handleExitCoder(ctx, NewExitError("Default Behavior Error", 42))
 
 	output := fakeErrWriter.String()
 	if !strings.Contains(output, "Custom") {

--- a/command.go
+++ b/command.go
@@ -167,7 +167,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	if err != nil {
 		if c.OnUsageError != nil {
 			err := c.OnUsageError(context, err, false)
-			HandleExitCoder(err)
+			context.App.handleExitCoder(err)
 			return err
 		}
 		fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
@@ -184,7 +184,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		defer func() {
 			afterErr := c.After(context)
 			if afterErr != nil {
-				HandleExitCoder(err)
+				ctx.App.handleExitCoder(err)
 				if err != nil {
 					err = NewMultiError(err, afterErr)
 				} else {
@@ -198,7 +198,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		err = c.Before(context)
 		if err != nil {
 			ShowCommandHelp(context, c.Name)
-			HandleExitCoder(err)
+			context.App.handleExitCoder(err)
 			return err
 		}
 	}
@@ -210,7 +210,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	err = HandleAction(c.Action, context)
 
 	if err != nil {
-		HandleExitCoder(err)
+		ctx.App.handleExitCoder(err)
 	}
 	return err
 }

--- a/command.go
+++ b/command.go
@@ -167,7 +167,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	if err != nil {
 		if c.OnUsageError != nil {
 			err := c.OnUsageError(context, err, false)
-			context.App.handleExitCoder(err)
+			context.App.handleExitCoder(context, err)
 			return err
 		}
 		fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
@@ -184,7 +184,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		defer func() {
 			afterErr := c.After(context)
 			if afterErr != nil {
-				ctx.App.handleExitCoder(err)
+				context.App.handleExitCoder(context, err)
 				if err != nil {
 					err = NewMultiError(err, afterErr)
 				} else {
@@ -198,7 +198,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		err = c.Before(context)
 		if err != nil {
 			ShowCommandHelp(context, c.Name)
-			context.App.handleExitCoder(err)
+			context.App.handleExitCoder(context, err)
 			return err
 		}
 	}
@@ -210,7 +210,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	err = HandleAction(c.Action, context)
 
 	if err != nil {
-		ctx.App.handleExitCoder(err)
+		context.App.handleExitCoder(context, err)
 	}
 	return err
 }

--- a/funcs.go
+++ b/funcs.go
@@ -29,4 +29,4 @@ type FlagStringFunc func(Flag) string
 
 // ExitErrHandlerFunc is executed if provided in order to handle ExitError values
 // returned by Actions and Before/After functions.
-type ExitErrHandlerFunc func(error)
+type ExitErrHandlerFunc func(context *Context, error)

--- a/funcs.go
+++ b/funcs.go
@@ -29,4 +29,4 @@ type FlagStringFunc func(Flag) string
 
 // ExitErrHandlerFunc is executed if provided in order to handle ExitError values
 // returned by Actions and Before/After functions.
-type ExitErrHandlerFunc func(context *Context, error)
+type ExitErrHandlerFunc func(context *Context, err error)

--- a/funcs.go
+++ b/funcs.go
@@ -26,3 +26,7 @@ type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
 // FlagStringFunc is used by the help generation to display a flag, which is
 // expected to be a single line.
 type FlagStringFunc func(Flag) string
+
+// ExitErrHandlerFunc is executed if provided in order to handle ExitError values
+// returned by Actions and Before/After functions.
+type ExitErrHandlerFunc func(error)


### PR DESCRIPTION
Forgive me if this is already possible, I ready through the code and documentation extensively but couldn't find a way to do what I wanted.

There are a couple of open issues related to not showing the stack traces of errors. Since this is a tricky situation to solve and please all users, I think it makes sense to allow users to just define their own error handler function.

https://github.com/urfave/cli/issues/625
https://github.com/urfave/cli/issues/578

In my case, I like the stack traces, but I want them printed to a file instead of stderr. With this change it's easy for me to do something like this:

```
func main() {
  app := cli.NewApp()
  app.Name = "boom"
  app.Usage = "make an explosive entrance"
  app.Action = func(c *cli.Context) error {
    fmt.Println("boom! I say!")
    return nil
  }

  // of course this is contrived, I would want to print something out to stderr at the same time :)
  app.ExitErrHandler = func(err error) {
    if file, err := os.Create("error-log.txt"); err == nil {
      defer file.Close()
      file.WriteString(fmt.Sprintf("%+v\n", err))
    }
  }

  app.Run(os.Args)
}
```