### PR TITLE
Subcommand OnUsageError should be passed to app

### DIFF
--- a/command.go
+++ b/command.go
@@ -291,6 +291,7 @@ func (c Command) startApp(ctx *Context) error {
 	} else {
 		app.Action = helpSubcommand.Action
 	}
+	app.OnUsageError = c.OnUsageError
 
 	for index, cc := range app.Commands {
 		app.Commands[index].commandNamePath = []string{c.Name, cc.Name}

--- a/command_test.go
+++ b/command_test.go
@@ -178,6 +178,38 @@ func TestCommand_OnUsageError_WithWrongFlagValue(t *testing.T) {
 	}
 }
 
+func TestCommand_OnUsageError_WithSubcommand(t *testing.T) {
+	app := NewApp()
+	app.Commands = []Command{
+		{
+			Name: "bar",
+			Subcommands: []Command{
+				{
+					Name: "baz",
+				},
+			},
+			Flags: []Flag{
+				IntFlag{Name: "flag"},
+			},
+			OnUsageError: func(c *Context, err error, _ bool) error {
+				if !strings.HasPrefix(err.Error(), "invalid value \"wrong\"") {
+					t.Errorf("Expect an invalid value error, but got \"%v\"", err)
+				}
+				return errors.New("intercepted: " + err.Error())
+			},
+		},
+	}
+
+	err := app.Run([]string{"foo", "bar", "--flag=wrong"})
+	if err == nil {
+		t.Fatalf("expected to receive error from Run, got none")
+	}
+
+	if !strings.HasPrefix(err.Error(), "intercepted: invalid value") {
+		t.Errorf("Expect an intercepted error, but got \"%v\"", err)
+	}
+}
+
 func TestCommand_Run_SubcommandsCanUseErrWriter(t *testing.T) {
 	app := NewApp()
 	app.ErrWriter = ioutil.Discard


### PR DESCRIPTION
Similar to #589, not all of the `Command` components were being passed into the `App` created in `startApp()`. This PR fixes the issue by directly passing the command's `OnUsageError`. I came across this issue when trying to use a custom `OnUsageError` in my application. This PR and #627 fix the problems for me.

The only thing to really consider here is if the `App`-level `OnUsageError` should be forwarded if one isn't set in the `Command`. Something like:
```go
if c.OnUsageError != nil {
	app.OnUsageError = c.OnUsageError
} else {
	app.OnUsageError = ctx.App.OnUsageError
}
```
I opted not to do this; nothing like it is done in the `startApp()` command. 