### PR TITLE
altsrc: Parse durations from strings

### DIFF
--- a/altsrc/map_input_source_test.go
+++ b/altsrc/map_input_source_test.go
@@ -1,0 +1,25 @@
+package altsrc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMapDuration(t *testing.T) {
+	inputSource := &MapInputSource{
+		file: "test",
+		valueMap: map[interface{}]interface{}{
+			"duration_of_duration_type": time.Minute,
+			"duration_of_string_type":   "1m",
+			"duration_of_int_type":      1000,
+		},
+	}
+	d, err := inputSource.Duration("duration_of_duration_type")
+	expect(t, time.Minute, d)
+	expect(t, nil, err)
+	d, err = inputSource.Duration("duration_of_string_type")
+	expect(t, time.Minute, d)
+	expect(t, nil, err)
+	d, err = inputSource.Duration("duration_of_int_type")
+	refute(t, nil, err)
+}


### PR DESCRIPTION
Fixes part of #599.
I don't have a good idea (or the requirement) for fixing the other datatypes in that issue; presumably it should show the same leniency with exact types when parsing from weakly-typed data sources.