### PR TITLE
Fix for gitlab.com/ayufan/golang-cli-helpers

### DIFF
--- a/structhelpers_test.go
+++ b/structhelpers_test.go
@@ -1,0 +1,36 @@
+package cli_test
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+	"gitlab.com/ayufan/golang-cli-helpers"
+	"testing"
+)
+
+func TestStructHelperForArray(t *testing.T) {
+	app := cli.NewApp()
+
+	m := &cmd{}
+	app.Commands = []cli.Command{
+		cli.Command{
+			Name:   "hi",
+			Action: m.Run,
+			Flags:  clihelpers.GetFlagsFromStruct(m),
+		},
+	}
+
+	if err := app.Run([]string{"main.go", "hi", "--test", "1", "--test", "2"}); err != nil {
+		fmt.Println(err)
+	}
+
+	assert.Equal(t, []string{"1", "2"}, m.Test, "Expect results to match passed flags")
+}
+
+type cmd struct {
+	Test []string `short:"t" long:"test" description:"Hi"`
+}
+
+func (m *cmd) Run(c *cli.Context) error {
+	return nil
+}


### PR DESCRIPTION
The library `gitlab.com/ayufan/golang-cli-helpers` creates cli flags from struct fields. Flags with multiple names all map to the same struct field value. `copyFlag` on `context.go:239` calls `*flag.FlagSet.Set(name, value string) error`. This calls `clihelpers.StructFieldValue.Set(val string) error` (which matches the `flag.Value` API). For slices, this appends the new value to the slice. The end result is `normalizeFlags -> copyFlag -> FlagSet.Set -> StructFieldValue.Set` results in something like `["a", "b", "c", "[a, b, c]"]`, which is clearly undesired. To combat this, I added `flagsAreIdentical`, which checks to see if all of the (string) values of the named flags are identical; and I modified `normalizeFlags` to skip a flag if all of its aliases already have identical values. There's no reason to normalize values if they're all already the same.