### PR TITLE
WIP: Fix error where app name would be used instead of command help name

### DIFF
--- a/command.go
+++ b/command.go
@@ -241,7 +241,7 @@ func (c Command) startApp(ctx *Context) error {
 	app.Metadata = ctx.App.Metadata
 	// set the name and usage
 	app.Name = fmt.Sprintf("%s %s", ctx.App.Name, c.Name)
-	if c.HelpName == "" {
+	if c.HelpName != "" {
 		app.HelpName = c.HelpName
 	} else {
 		app.HelpName = app.Name


### PR DESCRIPTION
This should fix the issue #557 

Sorry this is WIP. I will update when I'm done.