### PR TITLE
Allow Ignoring Usage Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,7 @@ func main() {
       fmt.Fprintf(c.App.Writer, "WRONG: %#v\n", err)
       return nil
     },
+    IgnoreUsageError: true,
     Action: func(c *cli.Context) error {
       cli.DefaultAppComplete(c)
       cli.HandleExitCoder(errors.New("not an exit coder, though"))

--- a/app.go
+++ b/app.go
@@ -51,6 +51,8 @@ type App struct {
 	Action ActionFunc
 	// Execute this function if the proper command cannot be found
 	CommandNotFound CommandNotFoundFunc
+	// Ignore usage errors to be handled later
+	IgnoreUsageError bool
 	// Execute this function if an usage error occurs
 	OnUsageError OnUsageErrorFunc
 	// Compilation date
@@ -187,7 +189,7 @@ func (a *App) Run(arguments []string) (err error) {
 		}
 	}
 
-	if err != nil {
+	if err != nil && !a.IgnoreUsageError {
 		if a.OnUsageError != nil {
 			err := a.OnUsageError(context, err, false)
 			HandleExitCoder(err)

--- a/app_test.go
+++ b/app_test.go
@@ -1485,3 +1485,24 @@ func TestApp_OnUsageError_WithWrongFlagValue_ForSubcommand(t *testing.T) {
 		t.Errorf("Expect an intercepted error, but got \"%v\"", err)
 	}
 }
+
+func TestApp_IgnoreOnUsageError(t *testing.T) {
+	app := &App{
+		Flags: []Flag{
+			&IntFlag{Name: "flag"},
+		},
+		Action: func(c *Context) error {
+			return nil
+		},
+		OnUsageError: func(c *Context, err error, isSubcommand bool) error {
+			t.Fatalf("Shouldn't throw error")
+			return errors.New("intercepted: " + err.Error())
+		},
+		IgnoreUsageError: true,
+	}
+
+	err := app.Run([]string{"foo", "--wrong-flag"})
+	if err != nil {
+		t.Fatalf("expected to not receive error, but got: \"%v\"", err)
+	}
+}


### PR DESCRIPTION
In some rare cases, it's handy to allow the application to handle
use-case errors in other ways, without requiring an error to be
returned. This allows the application written to handle the usage
error in other ways. Or, allow the application to pass the flags
on to subsequent child processes regardless of the host application's
flag parsing.

```
$ go test -run="TestApp_IgnoreOnUsageError"
PASS
ok      github.com/grubernaut/cli       0.001s
```