### PR TITLE
Allow customization of prefixes and environment variable hints in flag help strings

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -37,6 +37,14 @@ var HelpFlag Flag = BoolFlag{
 // to display a flag.
 var FlagStringer FlagStringFunc = stringifyFlag
 
+// FlagNamePrefixer converts a full flag name and its placeholder into the help
+// message flag prefix. This is used by the default FlagStringer.
+var FlagNamePrefixer FlagNamePrefixFunc = prefixedNames
+
+// FlagEnvHinter annotates flag help message with the environment variable
+// details. This is used by the default FlagStringer.
+var FlagEnvHinter FlagEnvHintFunc = withEnvHint
+
 // FlagsByName is a slice of Flag.
 type FlagsByName []Flag
 
@@ -710,13 +718,13 @@ func stringifyFlag(f Flag) string {
 
 	switch f.(type) {
 	case IntSliceFlag:
-		return withEnvHint(fv.FieldByName("EnvVar").String(),
+		return FlagEnvHinter(fv.FieldByName("EnvVar").String(),
 			stringifyIntSliceFlag(f.(IntSliceFlag)))
 	case Int64SliceFlag:
-		return withEnvHint(fv.FieldByName("EnvVar").String(),
+		return FlagEnvHinter(fv.FieldByName("EnvVar").String(),
 			stringifyInt64SliceFlag(f.(Int64SliceFlag)))
 	case StringSliceFlag:
-		return withEnvHint(fv.FieldByName("EnvVar").String(),
+		return FlagEnvHinter(fv.FieldByName("EnvVar").String(),
 			stringifyStringSliceFlag(f.(StringSliceFlag)))
 	}
 
@@ -744,8 +752,8 @@ func stringifyFlag(f Flag) string {
 
 	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultValueString))
 
-	return withEnvHint(fv.FieldByName("EnvVar").String(),
-		fmt.Sprintf("%s\t%s", prefixedNames(fv.FieldByName("Name").String(), placeholder), usageWithDefault))
+	return FlagEnvHinter(fv.FieldByName("EnvVar").String(),
+		fmt.Sprintf("%s\t%s", FlagNamePrefixer(fv.FieldByName("Name").String(), placeholder), usageWithDefault))
 }
 
 func stringifyIntSliceFlag(f IntSliceFlag) string {
@@ -795,5 +803,5 @@ func stringifySliceFlag(usage, name string, defaultVals []string) string {
 	}
 
 	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultVal))
-	return fmt.Sprintf("%s\t%s", prefixedNames(name, placeholder), usageWithDefault)
+	return fmt.Sprintf("%s\t%s", FlagNamePrefixer(name, placeholder), usageWithDefault)
 }

--- a/funcs.go
+++ b/funcs.go
@@ -26,3 +26,11 @@ type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
 // FlagStringFunc is used by the help generation to display a flag, which is
 // expected to be a single line.
 type FlagStringFunc func(Flag) string
+
+// FlagNamePrefixFunc is used by the default FlagStringFunc to create prefix
+// text for a flag's full name.
+type FlagNamePrefixFunc func(fullName, placeholder string) string
+
+// FlagEnvHintFunc is used by the default FlagStringFunc to annotate flag help
+// with the environment variable details.
+type FlagEnvHintFunc func(envVar, str string) string


### PR DESCRIPTION
This will allow users to customize the prefix section or env hint section of the flag entries in the help menu without having to reimplement the rest of the logic required in defining FlagStringer.

For example, to keep all other defaults, but change placeholder display from:
```
-f value, --flag value	flag description here
```

To only include it once as such:
```
-f, --flag value	flag description here
```

One would currently have to redefine the following unexported functions:
- stringifyFlag (the only current entry point)
- flagValue
- withEnvHint
- stringifyIntSliceFlag
- stringifyInt64SliceFlag
- stringifyStringSliceFlag
- stringifySliceFlag
- unquoteUsage
- prefixedNames

This change should both be backward compatible and allow changing the prefix or environment hint independently, so either of those can be redefined by simple pure functions that don't actually depend on the rest of the `stringifyFlag` logic.

I kept the original function signatures here, but if it makes more sense, for example, for `withEnvHint` to be replaced by something like `func envHint(envVar string) string` to decouple it from the rest of the message at the cost of being able to manipulate that string in other ways, I would be happy to do so.