### PR TITLE
Fix regression of SkipFlagParsing behavior

### DIFF
--- a/command.go
+++ b/command.go
@@ -178,7 +178,7 @@ func (c *Command) parseFlags(args Args) (*flag.FlagSet, error) {
 	set.SetOutput(ioutil.Discard)
 
 	if c.SkipFlagParsing {
-		return set, set.Parse(append([]string{c.Name, "--"}, args...))
+		return set, set.Parse(append([]string{"--"}, args...))
 	}
 
 	if c.UseShortOptionHandling {

--- a/command_test.go
+++ b/command_test.go
@@ -281,3 +281,39 @@ func TestCommandFlagReordering(t *testing.T) {
 		expect(t, args, c.expectedArgs)
 	}
 }
+
+func TestCommandSkipFlagParsing(t *testing.T) {
+	cases := []struct {
+		testArgs     []string
+		expectedArgs []string
+		expectedErr  error
+	}{
+		{[]string{"some-exec", "some-command", "some-arg", "--flag", "foo"}, []string{"some-arg", "--flag", "foo"}, nil},
+		{[]string{"some-exec", "some-command", "some-arg", "--flag=foo"}, []string{"some-arg", "--flag=foo"}, nil},
+	}
+
+	for _, c := range cases {
+		value := ""
+		args := []string{}
+		app := &App{
+			Commands: []Command{
+				{
+					SkipFlagParsing: true,
+					Name:            "some-command",
+					Flags: []Flag{
+						StringFlag{Name: "flag"},
+					},
+					Action: func(c *Context) {
+						fmt.Printf("%+v\n", c.String("flag"))
+						value = c.String("flag")
+						args = c.Args()
+					},
+				},
+			},
+		}
+
+		err := app.Run(c.testArgs)
+		expect(t, err, c.expectedErr)
+		expect(t, args, c.expectedArgs)
+	}
+}


### PR DESCRIPTION
Introduced by df562bf1a8626f2d16f91fcbf7230a5bdca3d592

Was mistakenly prepending the command name.