### PR TITLE
Simplify slice types

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -270,18 +270,18 @@ func (f *Int64Slice) Set(value string) error {
 }
 
 // String returns a readable representation of this value (for usage defaults)
-func (f *Int64Slice) String() string {
-	return fmt.Sprintf("%#v", *f)
+func (f Int64Slice) String() string {
+	return fmt.Sprintf("%#v", []int64(f))
 }
 
 // Value returns the slice of ints set by this flag
-func (f *Int64Slice) Value() []int64 {
-	return *f
+func (f Int64Slice) Value() []int64 {
+	return f
 }
 
 // Get returns the slice of ints set by this flag
-func (f *Int64Slice) Get() interface{} {
-	return *f
+func (f Int64Slice) Get() interface{} {
+	return f
 }
 
 // Apply populates the flag given the flag set and environment

--- a/flag.go
+++ b/flag.go
@@ -148,18 +148,18 @@ func (f *StringSlice) Set(value string) error {
 }
 
 // String returns a readable representation of this value (for usage defaults)
-func (f *StringSlice) String() string {
-	return fmt.Sprintf("%s", *f)
+func (f StringSlice) String() string {
+	return fmt.Sprintf("%s", []string(f))
 }
 
 // Value returns the slice of strings set by this flag
-func (f *StringSlice) Value() []string {
-	return *f
+func (f StringSlice) Value() []string {
+	return f
 }
 
 // Get returns the slice of strings set by this flag
-func (f *StringSlice) Get() interface{} {
-	return *f
+func (f StringSlice) Get() interface{} {
+	return f
 }
 
 // Apply populates the flag given the flag set and environment

--- a/flag.go
+++ b/flag.go
@@ -209,18 +209,18 @@ func (f *IntSlice) Set(value string) error {
 }
 
 // String returns a readable representation of this value (for usage defaults)
-func (f *IntSlice) String() string {
-	return fmt.Sprintf("%#v", *f)
+func (f IntSlice) String() string {
+	return fmt.Sprintf("%#v", []int(f))
 }
 
 // Value returns the slice of ints set by this flag
-func (f *IntSlice) Value() []int {
-	return *f
+func (f IntSlice) Value() []int {
+	return f
 }
 
 // Get returns the slice of ints set by this flag
-func (f *IntSlice) Get() interface{} {
-	return *f
+func (f IntSlice) Get() interface{} {
+	return f
 }
 
 // Apply populates the flag given the flag set and environment


### PR DESCRIPTION
- Pass by value when we just forward to another function.
- Convert to bare `[]int64` when calling `Sprintf` to simplify `Sprintf` work.