### PR TITLE
Fix args reordering when bool flags are present

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -329,6 +329,39 @@ func TestApp_CommandWithArgBeforeFlags(t *testing.T) {
 	expect(t, firstArg, "my-arg")
 }
 
+func TestApp_CommandWithArgBeforeBoolFlags(t *testing.T) {
+	var parsedOption, parsedSecondOption, firstArg string
+	var parsedBool, parsedSecondBool bool
+
+	app := NewApp()
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			StringFlag{Name: "option", Value: "", Usage: "some option"},
+			StringFlag{Name: "secondOption", Value: "", Usage: "another option"},
+			BoolFlag{Name: "boolflag", Usage: "some bool"},
+			BoolFlag{Name: "b", Usage: "another bool"},
+		},
+		Action: func(c *Context) error {
+			parsedOption = c.String("option")
+			parsedSecondOption = c.String("secondOption")
+			parsedBool = c.Bool("boolflag")
+			parsedSecondBool = c.Bool("b")
+			firstArg = c.Args().First()
+			return nil
+		},
+	}
+	app.Commands = []Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "--boolflag", "--option", "my-option", "-b", "--secondOption", "fancy-option"})
+
+	expect(t, parsedOption, "my-option")
+	expect(t, parsedSecondOption, "fancy-option")
+	expect(t, parsedBool, true)
+	expect(t, parsedSecondBool, true)
+	expect(t, firstArg, "my-arg")
+}
+
 func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
 	var context *Context
 

--- a/command.go
+++ b/command.go
@@ -213,11 +213,12 @@ func reorderArgs(args []string) []string {
 			break
 		}
 
-		if readFlagValue {
+		if readFlagValue && !strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
 			readFlagValue = false
 			flags = append(flags, arg)
 			continue
 		}
+		readFlagValue = false
 
 		if arg != "-" && strings.HasPrefix(arg, "-") {
 			flags = append(flags, arg)


### PR DESCRIPTION
# Bug description
Args reordering possibly leads to wrong args when `BoolFlags` are present.

# How to reproduce
Define some Command "`cmd`":
```go
Flags: []Flag{
     StringFlag{Name: "option", Value: "", Usage: "some option"},
     BoolFlag{Name: "boolflag", Usage: "some bool"},
}
```
Call the command like the following:
`cmd my-arg --boolflag --option my-option`

# Cause
Args reordering expects the next arg to be a value when no "`=`" is present. Providing a `BoolFlag`, the next args is not a value.