### PR TITLE
Ensure App provides Reader, Writer and ErrWriter fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,6 +1142,7 @@ demonstration purposes.  Use of one's imagination is encouraged.
 package main
 
 import (
+  "bytes"
   "errors"
   "flag"
   "fmt"
@@ -1385,10 +1386,17 @@ func main() {
 
     nc.Set("wat", "also-nope")
 
+    input, _ := ioutil.ReadAll(c.App.Reader)
+    c.App.Writer.Write(input)
+
     ec := cli.NewExitError("ohwell", 86)
     fmt.Fprintf(c.App.Writer, "%d", ec.ExitCode())
     fmt.Printf("made it!\n")
     return ec
+  }
+
+  if stuff := os.Getenv("STUFF"); stuff != "" {
+    app.Reader = bytes.NewReader([]byte(stuff))
   }
 
   if os.Getenv("HEXY") != "" {

--- a/app_test.go
+++ b/app_test.go
@@ -300,12 +300,6 @@ func TestApp_Command(t *testing.T) {
 	}
 }
 
-func TestApp_Setup_defaultsWriter(t *testing.T) {
-	app := &App{}
-	app.Setup()
-	expect(t, app.Writer, os.Stdout)
-}
-
 func TestApp_CommandWithArgBeforeFlags(t *testing.T) {
 	var parsedOption, firstArg string
 
@@ -618,11 +612,54 @@ func TestApp_ParseSliceFlagsWithMissingValue(t *testing.T) {
 	}
 }
 
-func TestApp_DefaultStdout(t *testing.T) {
+func TestApp_DefaultReader(t *testing.T) {
+	app := NewApp()
+
+	if app.Reader != os.Stdin {
+		t.Error("Default input reader not set.")
+	}
+}
+
+func TestApp_DefaultWriter(t *testing.T) {
 	app := NewApp()
 
 	if app.Writer != os.Stdout {
 		t.Error("Default output writer not set.")
+	}
+}
+
+func TestApp_DefaultErrWriter(t *testing.T) {
+	app := NewApp()
+
+	if app.ErrWriter != ErrWriter {
+		t.Error("Default output error writer not set.")
+	}
+}
+
+func TestApp_Setup_DefaultsReader(t *testing.T) {
+	app := &App{}
+	app.Setup()
+
+	if app.Reader != os.Stdin {
+		t.Error("Input reader not set after setup.")
+	}
+}
+
+func TestApp_Setup_DefaultsWriter(t *testing.T) {
+	app := &App{}
+	app.Setup()
+
+	if app.Writer != os.Stdout {
+		t.Error("Output writer not set after setup.")
+	}
+}
+
+func TestApp_Setup_DefaultsErrWriter(t *testing.T) {
+	app := &App{}
+	app.Setup()
+
+	if app.ErrWriter != ErrWriter {
+		t.Error("Output error writer not set after setup.")
 	}
 }
 


### PR DESCRIPTION
This allows users to easily use Reader/Writer/ErrWriter in preference to os.Stdin/os.Stdout/os.Stderr, and is helpful in testing applications which may read from stdin.