### PR TITLE
Expose a constructor for Map Input Source

### DIFF
--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -15,6 +15,12 @@ type MapInputSource struct {
 	valueMap map[interface{}]interface{}
 }
 
+// NewMapInputSource instantiates a MapInputSource from an arbitrary
+// string->value map
+func NewMapInputSource(valueMap map[interface{}]interface{}) MapInputSource {
+	return MapInputSource{valueMap: valueMap}
+}
+
 // nestedVal checks if the name has '.' delimiters.
 // If so, it tries to traverse the tree by the '.' delimited sections to find
 // a nested value for the key.


### PR DESCRIPTION
This makes it so people can more easily write their own sources
on top of altsrc. In addition, it changes the struct from map[interface{}]
to map[string] as all keys must be strings.