### PR TITLE
Allow zsh completion to be distributed like bash

### DIFF
--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,3 +1,5 @@
+: ${PROG:=$(basename ${(%):-%N})}
+
 _cli_zsh_autocomplete() {
 
   local -a opts
@@ -9,3 +11,5 @@ _cli_zsh_autocomplete() {
 }
 
 compdef _cli_zsh_autocomplete $PROG
+
+unset PROG


### PR DESCRIPTION
The readme describes a distribution pattern for bash_autocomplete. In
this pattern, the file is renamed to match the name of the program for
which the  autocompletion support is being added. When following this
pattern, it is not necessary to set the PROG environment variable.

Update zsh_autocomplete so that it can be distributed the same way.