### PR TITLE
Add flag error handling to App

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -94,6 +95,8 @@ type App struct {
 	// cli.go uses text/template to render templates. You can
 	// render custom help text by setting this variable.
 	CustomAppHelpTemplate string
+	// FlagErrorHandling sets the flag error handling type for flag parsing
+	FlagErrorHandling flag.ErrorHandling
 
 	didSetup bool
 }
@@ -112,15 +115,16 @@ func compileTime() time.Time {
 // Usage, Version and Action.
 func NewApp() *App {
 	return &App{
-		Name:         filepath.Base(os.Args[0]),
-		HelpName:     filepath.Base(os.Args[0]),
-		Usage:        "A new cli application",
-		UsageText:    "",
-		Version:      "0.0.0",
-		BashComplete: DefaultAppComplete,
-		Action:       helpCommand.Action,
-		Compiled:     compileTime(),
-		Writer:       os.Stdout,
+		Name:              filepath.Base(os.Args[0]),
+		HelpName:          filepath.Base(os.Args[0]),
+		Usage:             "A new cli application",
+		UsageText:         "",
+		Version:           "0.0.0",
+		BashComplete:      DefaultAppComplete,
+		Action:            helpCommand.Action,
+		Compiled:          compileTime(),
+		Writer:            os.Stdout,
+		FlagErrorHandling: flag.ContinueOnError,
 	}
 }
 
@@ -187,7 +191,7 @@ func (a *App) Run(arguments []string) (err error) {
 	shellComplete, arguments := checkShellCompleteFlag(a, arguments)
 
 	// parse flags
-	set, err := flagSet(a.Name, a.Flags)
+	set, err := flagSet(a.Name, a.Flags, a.FlagErrorHandling)
 	if err != nil {
 		return err
 	}
@@ -306,7 +310,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	a.Commands = newCmds
 
 	// parse flags
-	set, err := flagSet(a.Name, a.Flags)
+	set, err := flagSet(a.Name, a.Flags, a.FlagErrorHandling)
 	if err != nil {
 		return err
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -1648,7 +1648,7 @@ func TestCustomHelpVersionFlags(t *testing.T) {
 func TestHandleAction_WithNonFuncAction(t *testing.T) {
 	app := NewApp()
 	app.Action = 42
-	fs, err := flagSet(app.Name, app.Flags)
+	fs, err := flagSet(app.Name, app.Flags, app.FlagErrorHandling)
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
 	}
@@ -1676,7 +1676,7 @@ func TestHandleAction_WithNonFuncAction(t *testing.T) {
 func TestHandleAction_WithInvalidFuncSignature(t *testing.T) {
 	app := NewApp()
 	app.Action = func() string { return "" }
-	fs, err := flagSet(app.Name, app.Flags)
+	fs, err := flagSet(app.Name, app.Flags, app.FlagErrorHandling)
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
 	}
@@ -1704,7 +1704,7 @@ func TestHandleAction_WithInvalidFuncSignature(t *testing.T) {
 func TestHandleAction_WithInvalidFuncReturnSignature(t *testing.T) {
 	app := NewApp()
 	app.Action = func(_ *Context) (int, error) { return 0, nil }
-	fs, err := flagSet(app.Name, app.Flags)
+	fs, err := flagSet(app.Name, app.Flags, app.FlagErrorHandling)
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
 	}
@@ -1731,7 +1731,7 @@ func TestHandleAction_WithInvalidFuncReturnSignature(t *testing.T) {
 
 func TestHandleExitCoder_Default(t *testing.T) {
 	app := NewApp()
-	fs, err := flagSet(app.Name, app.Flags)
+	fs, err := flagSet(app.Name, app.Flags, app.FlagErrorHandling)
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
 	}
@@ -1747,7 +1747,7 @@ func TestHandleExitCoder_Default(t *testing.T) {
 
 func TestHandleExitCoder_Custom(t *testing.T) {
 	app := NewApp()
-	fs, err := flagSet(app.Name, app.Flags)
+	fs, err := flagSet(app.Name, app.Flags, app.FlagErrorHandling)
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
 	}
@@ -1775,7 +1775,7 @@ func TestHandleAction_WithUnknownPanic(t *testing.T) {
 		fn(ctx)
 		return nil
 	}
-	fs, err := flagSet(app.Name, app.Flags)
+	fs, err := flagSet(app.Name, app.Flags, app.FlagErrorHandling)
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
 	}

--- a/command.go
+++ b/command.go
@@ -111,7 +111,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		)
 	}
 
-	set, err := c.parseFlags(ctx.Args().Tail())
+	set, err := c.parseFlags(ctx.Args().Tail(), ctx.App.FlagErrorHandling)
 
 	context := NewContext(ctx.App, set, ctx)
 	context.Command = c
@@ -170,8 +170,8 @@ func (c Command) Run(ctx *Context) (err error) {
 	return err
 }
 
-func (c *Command) parseFlags(args Args) (*flag.FlagSet, error) {
-	set, err := flagSet(c.Name, c.Flags)
+func (c *Command) parseFlags(args Args, errorHandling flag.ErrorHandling) (*flag.FlagSet, error) {
+	set, err := flagSet(c.Name, c.Flags, errorHandling)
 	if err != nil {
 		return nil, err
 	}

--- a/flag.go
+++ b/flag.go
@@ -84,8 +84,8 @@ type errorableFlag interface {
 	ApplyWithError(*flag.FlagSet) error
 }
 
-func flagSet(name string, flags []Flag) (*flag.FlagSet, error) {
-	set := flag.NewFlagSet(name, flag.ContinueOnError)
+func flagSet(name string, flags []Flag, errorHandling flag.ErrorHandling) (*flag.FlagSet, error) {
+	set := flag.NewFlagSet(name, errorHandling)
 
 	for _, f := range flags {
 		//TODO remove in v2 when errorableFlag is removed


### PR DESCRIPTION
This allows the user to set how flag parsing should work.  By default,
the common flag const are not useful in the context of cli but if you
want to clear it by setting something like `flag.ContinueOnError -1`
then you don't get the invalid flag error.

This is useful for multiple projects implementing the same CLI interface
but do not define all the flags because they don't apply.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>