### PR TITLE
Exposed the `value` accessor in `Context`

### DIFF
--- a/context.go
+++ b/context.go
@@ -114,7 +114,7 @@ func (c *Context) Lineage() []*Context {
 	return lineage
 }
 
-// value returns the value of the flag corresponding to `name`
+// Value returns the value of the flag corresponding to `name`
 func (c *Context) Value(name string) interface{} {
 	return c.flagSet.Lookup(name).Value.(flag.Getter).Get()
 }

--- a/context.go
+++ b/context.go
@@ -115,7 +115,7 @@ func (c *Context) Lineage() []*Context {
 }
 
 // value returns the value of the flag corresponding to `name`
-func (c *Context) value(name string) interface{} {
+func (c *Context) Value(name string) interface{} {
 	return c.flagSet.Lookup(name).Value.(flag.Getter).Get()
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"context"
 	"flag"
-	"sort"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -328,7 +328,7 @@ func TestContextPropagation(t *testing.T) {
 	parent := NewContext(nil, nil, nil)
 	parent.Context = context.WithValue(context.Background(), "key", "val")
 	ctx := NewContext(nil, nil, parent)
-	val := ctx.Value("key")
+	val := ctx.Context.Value("key")
 	if val == nil {
 		t.Fatal("expected a parent context to be inherited but got nil")
 	}

--- a/flag_test.go
+++ b/flag_test.go
@@ -121,8 +121,8 @@ func TestFlagsFromEnv(t *testing.T) {
 		a := App{
 			Flags: []Flag{test.flag},
 			Action: func(ctx *Context) error {
-				if !reflect.DeepEqual(ctx.value(test.flag.Names()[0]), test.output) {
-					t.Errorf("ex:%01d expected %q to be parsed as %#v, instead was %#v", i, test.input, test.output, ctx.value(test.flag.Names()[0]))
+				if !reflect.DeepEqual(ctx.Value(test.flag.Names()[0]), test.output) {
+					t.Errorf("ex:%01d expected %q to be parsed as %#v, instead was %#v", i, test.input, test.output, ctx.Value(test.flag.Names()[0]))
 				}
 				return nil
 			},


### PR DESCRIPTION
I wrote a small utility to populate a `struct` reflectively from command-line-arguments, but to do this I needed to get at the values stored via `value`.  