### PR TITLE
Fix go vet error caused by unused value

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -293,7 +293,6 @@ func TestCommandSkipFlagParsing(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		value := ""
 		args := []string{}
 		app := &App{
 			Commands: []Command{
@@ -304,8 +303,6 @@ func TestCommandSkipFlagParsing(t *testing.T) {
 						StringFlag{Name: "flag"},
 					},
 					Action: func(c *Context) {
-						fmt.Printf("%+v\n", c.String("flag"))
-						value = c.String("flag")
 						args = c.Args()
 					},
 				},


### PR DESCRIPTION
Fix go vet error by removing the unused variable.
  ./command_test.go:296:3: value declared but not used
  vet: typecheck failures

`value` was originally added in `0671b166`, but usage was removed in
`e38e4ae2`.