### PR TITLE
Fix go vet failures in command_test.go

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -293,7 +293,6 @@ func TestCommandSkipFlagParsing(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		value := ""
 		args := []string{}
 		app := &App{
 			Commands: []Command{
@@ -304,8 +303,6 @@ func TestCommandSkipFlagParsing(t *testing.T) {
 						StringFlag{Name: "flag"},
 					},
 					Action: func(c *Context) {
-						fmt.Printf("%+v\n", c.String("flag"))
-						value = c.String("flag")
 						args = c.Args()
 					},
 				},


### PR DESCRIPTION
Noticed while looking at https://github.com/urfave/cli/pull/761