### PR TITLE
Fix sample of a command using YAML support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ import (
   "log"
   "os"
 
-  "github.com/urfave/cli"
+  "gopkg.in/urfave/cli.v1"
   "github.com/urfave/cli/altsrc"
 )
 


### PR DESCRIPTION
Fix sample of a command using YAML support.

A type errors occurred, if execute sample of a command using YAML support in README.

The reason is `altsrc.NewIntFlag` requires type "gopkg.in/urfave/cli.v1".IntFlag, but `cli.IntFlag` is type "github.com/urfave/cli".IntFlag in sample.

```go
altsrc.NewIntFlag(cli.IntFlag{Name: "test"})
// cannot use "github.com/urfave/cli".IntFlag literal (type "github.com/urfave/cli".IntFlag) as type "gopkg.in/urfave/cli.v1".IntFlag in argument to altsrc.NewIntFlag
```

This PR is solves this error.