### PR TITLE
Clarify that altsrc supports both TOML and JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ from other file input sources.
 
 Currently supported input source formats:
 * YAML
+* JSON
 * TOML
 
 In order to get values for a flag from an alternate input source the following
@@ -701,7 +702,7 @@ the yaml input source for any flags that are defined on that command.  As a note
 the "load" flag used would also have to be defined on the command flags in order
 for this code snipped to work.
 
-Currently only YAML and JSON files are supported but developers can add support
+Currently only YAML, JSON, and TOML files are supported but developers can add support
 for other input sources by implementing the altsrc.InputSourceContext for their
 given sources.
 


### PR DESCRIPTION
The documentation had two lists of supported input file formats for `altsrc`. One listed only YAML and TOML, the other listed only YAML and JSON.

Altsrc has methods for [JSON](https://godoc.org/github.com/urfave/cli/altsrc#NewJSONSourceFromFlagFunc), [YAML](https://godoc.org/github.com/urfave/cli/altsrc#NewYamlSourceFromFlagFunc), and [TOML](https://godoc.org/github.com/urfave/cli/altsrc#NewTomlSourceFromFlagFunc).

This is just a quick clarification. Thanks for a great package!