### PR TITLE
Add flag category support

### DIFF
--- a/app.go
+++ b/app.go
@@ -145,6 +145,14 @@ func (a *App) Setup() {
 		if c.HelpName == "" {
 			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
 		}
+
+		fc := FlagCategories{}
+		for _, flag := range c.Flags {
+			fc = fc.AddFlag(flag.GetCategory(), flag)
+		}
+
+		sort.Sort(fc)
+		c.FlagCategories = fc
 		newCmds = append(newCmds, c)
 	}
 	a.Commands = newCmds
@@ -166,7 +174,7 @@ func (a *App) Setup() {
 	}
 	sort.Sort(a.categories)
 
-if a.Metadata == nil {
+	if a.Metadata == nil {
 		a.Metadata = make(map[string]interface{})
 	}
 
@@ -192,11 +200,6 @@ func (a *App) Run(arguments []string) (err error) {
 	set, err := flagSet(a.Name, a.Flags)
 	if err != nil {
 		return err
-	}
-
-	a.flagCategories = FlagCategories{}
-	for _, flag := range a.Flags {
-		a.flagCategories = a.flagCategories.AddFlag(flag.GetCategory(), flag)
 	}
 
 	set.SetOutput(ioutil.Discard)
@@ -445,7 +448,7 @@ func (a *App) VisibleCommands() []Command {
 }
 
 // Categories returns a slice containing all the categories with the commands they contain
-func (a *App) FlagCategories() FlagCategories {
+func (a *App) VisibleFlagCategories() FlagCategories {
 	return a.flagCategories
 }
 

--- a/app.go
+++ b/app.go
@@ -51,6 +51,8 @@ type App struct {
 	HideVersion bool
 	// Populate on app startup, only gettable through method Categories()
 	categories CommandCategories
+	// Populate on app startup, only gettable through method Categories()
+	flagCategories FlagCategories
 	// An action to execute when the bash-completion flag is set
 	BashComplete BashCompleteFunc
 	// An action to execute before any subcommands are run, but after the context is ready
@@ -164,7 +166,7 @@ func (a *App) Setup() {
 	}
 	sort.Sort(a.categories)
 
-	if a.Metadata == nil {
+if a.Metadata == nil {
 		a.Metadata = make(map[string]interface{})
 	}
 
@@ -190,6 +192,11 @@ func (a *App) Run(arguments []string) (err error) {
 	set, err := flagSet(a.Name, a.Flags)
 	if err != nil {
 		return err
+	}
+
+	a.flagCategories = FlagCategories{}
+	for _, flag := range a.Flags {
+		a.flagCategories = a.flagCategories.AddFlag(flag.GetCategory(), flag)
 	}
 
 	set.SetOutput(ioutil.Discard)
@@ -435,6 +442,11 @@ func (a *App) VisibleCommands() []Command {
 		}
 	}
 	return ret
+}
+
+// Categories returns a slice containing all the categories with the commands they contain
+func (a *App) FlagCategories() FlagCategories {
+	return a.flagCategories
 }
 
 // VisibleFlags returns a slice of the Flags with Hidden=false

--- a/app_test.go
+++ b/app_test.go
@@ -1607,6 +1607,10 @@ func (c *customBoolFlag) GetHidden() bool {
 	return false
 }
 
+func (c *customBoolFlag) GetCategory() string {
+	return ""
+}
+
 func (c *customBoolFlag) Apply(set *flag.FlagSet) {
 	set.String(c.Nombre, c.Nombre, "")
 }

--- a/app_test.go
+++ b/app_test.go
@@ -1381,20 +1381,23 @@ func TestApp_VisibleCategories(t *testing.T) {
 	app.HideHelp = true
 	app.Commands = []Command{
 		{
-			Name:     "command1",
-			Category: "1",
-			HelpName: "foo command1",
-			Hidden:   true,
+			Name:           "command1",
+			Category:       "1",
+			HelpName:       "foo command1",
+			Hidden:         true,
+			FlagCategories: FlagCategories{},
 		},
 		{
-			Name:     "command2",
-			Category: "2",
-			HelpName: "foo command2",
+			Name:           "command2",
+			Category:       "2",
+			HelpName:       "foo command2",
+			FlagCategories: FlagCategories{},
 		},
 		{
-			Name:     "command3",
-			Category: "3",
-			HelpName: "foo command3",
+			Name:           "command3",
+			Category:       "3",
+			HelpName:       "foo command3",
+			FlagCategories: FlagCategories{},
 		},
 	}
 
@@ -1421,21 +1424,24 @@ func TestApp_VisibleCategories(t *testing.T) {
 	app.HideHelp = true
 	app.Commands = []Command{
 		{
-			Name:     "command1",
-			Category: "1",
-			HelpName: "foo command1",
-			Hidden:   true,
+			Name:           "command1",
+			Category:       "1",
+			HelpName:       "foo command1",
+			Hidden:         true,
+			FlagCategories: FlagCategories{},
 		},
 		{
-			Name:     "command2",
-			Category: "2",
-			HelpName: "foo command2",
-			Hidden:   true,
+			Name:           "command2",
+			Category:       "2",
+			HelpName:       "foo command2",
+			Hidden:         true,
+			FlagCategories: FlagCategories{},
 		},
 		{
-			Name:     "command3",
-			Category: "3",
-			HelpName: "foo command3",
+			Name:           "command3",
+			Category:       "3",
+			HelpName:       "foo command3",
+			FlagCategories: FlagCategories{},
 		},
 	}
 
@@ -1456,22 +1462,25 @@ func TestApp_VisibleCategories(t *testing.T) {
 	app.HideHelp = true
 	app.Commands = []Command{
 		{
-			Name:     "command1",
-			Category: "1",
-			HelpName: "foo command1",
-			Hidden:   true,
+			Name:           "command1",
+			Category:       "1",
+			HelpName:       "foo command1",
+			Hidden:         true,
+			FlagCategories: FlagCategories{},
 		},
 		{
-			Name:     "command2",
-			Category: "2",
-			HelpName: "foo command2",
-			Hidden:   true,
+			Name:           "command2",
+			Category:       "2",
+			HelpName:       "foo command2",
+			Hidden:         true,
+			FlagCategories: FlagCategories{},
 		},
 		{
-			Name:     "command3",
-			Category: "3",
-			HelpName: "foo command3",
-			Hidden:   true,
+			Name:           "command3",
+			Category:       "3",
+			HelpName:       "foo command3",
+			Hidden:         true,
+			FlagCategories: FlagCategories{},
 		},
 	}
 

--- a/app_test.go
+++ b/app_test.go
@@ -1603,6 +1603,10 @@ func (c *customBoolFlag) GetName() string {
 	return c.Nombre
 }
 
+func (c *customBoolFlag) GetHidden() bool {
+	return false
+}
+
 func (c *customBoolFlag) Apply(set *flag.FlagSet) {
 	set.String(c.Nombre, c.Nombre, "")
 }

--- a/category.go
+++ b/category.go
@@ -42,3 +42,46 @@ func (c *CommandCategory) VisibleCommands() []Command {
 	}
 	return ret
 }
+
+// FlagCategories is a slice of *FlagCategory.
+type FlagCategories []*FlagCategory
+
+// FlagCategory is a category containing commands.
+type FlagCategory struct {
+	Name  string
+	Flags Flags
+}
+
+func (f FlagCategories) Less(i, j int) bool {
+	return lexicographicLess(f[i].Name, f[j].Name)
+}
+
+func (f FlagCategories) Len() int {
+	return len(f)
+}
+
+func (f FlagCategories) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+// AddFlags adds a command to a category.
+func (f FlagCategories) AddFlag(category string, flag Flag) FlagCategories {
+	for _, flagCategory := range f {
+		if flagCategory.Name == category {
+			flagCategory.Flags = append(flagCategory.Flags, flag)
+			return f
+		}
+	}
+	return append(f, &FlagCategory{Name: category, Flags: []Flag{flag}})
+}
+
+// VisibleFlags returns a slice of the Flags with Hidden=false
+func (c *FlagCategory) VisibleFlags() []Flag {
+	ret := []Flag{}
+	for _, flag := range c.Flags {
+		if !flag.GetHidden() {
+			ret = append(ret, flag)
+		}
+	}
+	return ret
+}

--- a/command.go
+++ b/command.go
@@ -266,7 +266,7 @@ func reorderArgs(args []string) []string {
 }
 
 func translateShortOptions(set *flag.FlagSet, flagArgs Args) []string {
-	allCharsFlags := func (s string) bool {
+	allCharsFlags := func(s string) bool {
 		for i := range s {
 			f := set.Lookup(string(s[i]))
 			if f == nil {

--- a/command.go
+++ b/command.go
@@ -45,6 +45,8 @@ type Command struct {
 	Subcommands Commands
 	// List of flags to parse
 	Flags []Flag
+	// List of all flag categories
+	FlagCategories FlagCategories
 	// Treat all flags as normal arguments if true
 	SkipFlagParsing bool
 	// Skip argument reordering which attempts to move flags before arguments,
@@ -375,6 +377,11 @@ func (c Command) startApp(ctx *Context) error {
 	}
 
 	return app.RunAsSubcommand(ctx)
+}
+
+// Categories returns a slice containing all the categories with the commands they contain
+func (c Command) VisibleFlagCategories() FlagCategories {
+	return c.FlagCategories
 }
 
 // VisibleFlags returns a slice of the Flags with Hidden=false

--- a/command_test.go
+++ b/command_test.go
@@ -59,9 +59,9 @@ func TestCommandFlagParsing(t *testing.T) {
 
 func TestParseAndRunShortOpts(t *testing.T) {
 	cases := []struct {
-		testArgs               []string
-		expectedErr            error
-		expectedArgs           []string
+		testArgs     []string
+		expectedErr  error
+		expectedArgs []string
 	}{
 		{[]string{"foo", "test", "-a"}, nil, []string{}},
 		{[]string{"foo", "test", "-c", "arg1", "arg2"}, nil, []string{"arg1", "arg2"}},
@@ -71,18 +71,18 @@ func TestParseAndRunShortOpts(t *testing.T) {
 		{[]string{"foo", "test", "-cf"}, nil, []string{}},
 		{[]string{"foo", "test", "-acf"}, nil, []string{}},
 		{[]string{"foo", "test", "-invalid"}, errors.New("flag provided but not defined: -invalid"), []string{}},
-		{[]string{"foo", "test", "-acf", "arg1", "-invalid"}, nil, []string{"arg1" ,"-invalid"}},
+		{[]string{"foo", "test", "-acf", "arg1", "-invalid"}, nil, []string{"arg1", "-invalid"}},
 	}
 
 	var args []string
 	cmd := Command{
-		Name:                   "test",
-		Usage:                  "this is for testing",
-		Description:            "testing",
-		Action:                 func(c *Context) error {
-						args = c.Args()
-						return nil
-					},
+		Name:        "test",
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *Context) error {
+			args = c.Args()
+			return nil
+		},
 		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 		Flags: []Flag{

--- a/flag.go
+++ b/flag.go
@@ -73,7 +73,10 @@ type Flag interface {
 	// Apply Flag settings to the given flag set
 	Apply(*flag.FlagSet)
 	GetName() string
+	GetHidden() bool
 }
+
+type Flags []Flag
 
 // errorableFlag is an interface that allows us to return errors during apply
 // it allows flags defined in this library to return errors in a fashion backwards compatible

--- a/flag.go
+++ b/flag.go
@@ -73,6 +73,7 @@ type Flag interface {
 	// Apply Flag settings to the given flag set
 	Apply(*flag.FlagSet)
 	GetName() string
+	GetCategory() string
 	GetHidden() bool
 }
 

--- a/flag_generated.go
+++ b/flag_generated.go
@@ -15,6 +15,7 @@ type BoolFlag struct {
 	EnvVar      string
 	FilePath    string
 	Hidden      bool
+	Category    string
 	Destination *bool
 }
 
@@ -27,6 +28,11 @@ func (f BoolFlag) String() string {
 // GetName returns the name of the flag
 func (f BoolFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f BoolFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // Bool looks up the value of a local BoolFlag, returns
@@ -63,6 +69,7 @@ type BoolTFlag struct {
 	EnvVar      string
 	FilePath    string
 	Hidden      bool
+	Category    string
 	Destination *bool
 }
 
@@ -75,6 +82,11 @@ func (f BoolTFlag) String() string {
 // GetName returns the name of the flag
 func (f BoolTFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f BoolTFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // BoolT looks up the value of a local BoolTFlag, returns
@@ -111,6 +123,7 @@ type DurationFlag struct {
 	EnvVar      string
 	FilePath    string
 	Hidden      bool
+	Category    string
 	Value       time.Duration
 	Destination *time.Duration
 }
@@ -124,6 +137,11 @@ func (f DurationFlag) String() string {
 // GetName returns the name of the flag
 func (f DurationFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f DurationFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // Duration looks up the value of a local DurationFlag, returns
@@ -160,6 +178,7 @@ type Float64Flag struct {
 	EnvVar      string
 	FilePath    string
 	Hidden      bool
+	Category    string
 	Value       float64
 	Destination *float64
 }
@@ -173,6 +192,11 @@ func (f Float64Flag) String() string {
 // GetName returns the name of the flag
 func (f Float64Flag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f Float64Flag) GetHidden() bool {
+	return f.Hidden
 }
 
 // Float64 looks up the value of a local Float64Flag, returns
@@ -209,6 +233,7 @@ type GenericFlag struct {
 	EnvVar   string
 	FilePath string
 	Hidden   bool
+	Category string
 	Value    Generic
 }
 
@@ -221,6 +246,11 @@ func (f GenericFlag) String() string {
 // GetName returns the name of the flag
 func (f GenericFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f GenericFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // Generic looks up the value of a local GenericFlag, returns
@@ -257,6 +287,7 @@ type Int64Flag struct {
 	EnvVar      string
 	FilePath    string
 	Hidden      bool
+	Category    string
 	Value       int64
 	Destination *int64
 }
@@ -270,6 +301,11 @@ func (f Int64Flag) String() string {
 // GetName returns the name of the flag
 func (f Int64Flag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f Int64Flag) GetHidden() bool {
+	return f.Hidden
 }
 
 // Int64 looks up the value of a local Int64Flag, returns
@@ -306,6 +342,7 @@ type IntFlag struct {
 	EnvVar      string
 	FilePath    string
 	Hidden      bool
+	Category    string
 	Value       int
 	Destination *int
 }
@@ -319,6 +356,11 @@ func (f IntFlag) String() string {
 // GetName returns the name of the flag
 func (f IntFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f IntFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // Int looks up the value of a local IntFlag, returns
@@ -355,6 +397,7 @@ type IntSliceFlag struct {
 	EnvVar   string
 	FilePath string
 	Hidden   bool
+	Category string
 	Value    *IntSlice
 }
 
@@ -367,6 +410,11 @@ func (f IntSliceFlag) String() string {
 // GetName returns the name of the flag
 func (f IntSliceFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f IntSliceFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // IntSlice looks up the value of a local IntSliceFlag, returns
@@ -403,6 +451,7 @@ type Int64SliceFlag struct {
 	EnvVar   string
 	FilePath string
 	Hidden   bool
+	Category string
 	Value    *Int64Slice
 }
 
@@ -415,6 +464,11 @@ func (f Int64SliceFlag) String() string {
 // GetName returns the name of the flag
 func (f Int64SliceFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f Int64SliceFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // Int64Slice looks up the value of a local Int64SliceFlag, returns
@@ -451,6 +505,7 @@ type StringFlag struct {
 	EnvVar      string
 	FilePath    string
 	Hidden      bool
+	Category    string
 	Value       string
 	Destination *string
 }
@@ -464,6 +519,11 @@ func (f StringFlag) String() string {
 // GetName returns the name of the flag
 func (f StringFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f StringFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // String looks up the value of a local StringFlag, returns
@@ -500,6 +560,7 @@ type StringSliceFlag struct {
 	EnvVar   string
 	FilePath string
 	Hidden   bool
+	Category string
 	Value    *StringSlice
 }
 
@@ -512,6 +573,11 @@ func (f StringSliceFlag) String() string {
 // GetName returns the name of the flag
 func (f StringSliceFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f StringSliceFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // StringSlice looks up the value of a local StringSliceFlag, returns
@@ -548,6 +614,7 @@ type Uint64Flag struct {
 	EnvVar      string
 	FilePath    string
 	Hidden      bool
+	Category    string
 	Value       uint64
 	Destination *uint64
 }
@@ -561,6 +628,11 @@ func (f Uint64Flag) String() string {
 // GetName returns the name of the flag
 func (f Uint64Flag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f Uint64Flag) GetHidden() bool {
+	return f.Hidden
 }
 
 // Uint64 looks up the value of a local Uint64Flag, returns
@@ -597,6 +669,7 @@ type UintFlag struct {
 	EnvVar      string
 	FilePath    string
 	Hidden      bool
+	Category    string
 	Value       uint
 	Destination *uint
 }
@@ -610,6 +683,11 @@ func (f UintFlag) String() string {
 // GetName returns the name of the flag
 func (f UintFlag) GetName() string {
 	return f.Name
+}
+
+// GetHidden lets us know if the flag is hidden or not
+func (f UintFlag) GetHidden() bool {
+	return f.Hidden
 }
 
 // Uint looks up the value of a local UintFlag, returns

--- a/flag_generated.go
+++ b/flag_generated.go
@@ -35,6 +35,11 @@ func (f BoolFlag) GetHidden() bool {
 	return f.Hidden
 }
 
+// GetCategory lets us access the flag category
+func (f BoolFlag) GetCategory() string {
+	return f.Category
+}
+
 // Bool looks up the value of a local BoolFlag, returns
 // false if not found
 func (c *Context) Bool(name string) bool {
@@ -87,6 +92,11 @@ func (f BoolTFlag) GetName() string {
 // GetHidden lets us know if the flag is hidden or not
 func (f BoolTFlag) GetHidden() bool {
 	return f.Hidden
+}
+
+// GetCategory lets us access the flag category
+func (f BoolTFlag) GetCategory() string {
+	return f.Category
 }
 
 // BoolT looks up the value of a local BoolTFlag, returns
@@ -144,6 +154,11 @@ func (f DurationFlag) GetHidden() bool {
 	return f.Hidden
 }
 
+// GetCategory lets us access the flag category
+func (f DurationFlag) GetCategory() string {
+	return f.Category
+}
+
 // Duration looks up the value of a local DurationFlag, returns
 // 0 if not found
 func (c *Context) Duration(name string) time.Duration {
@@ -199,6 +214,11 @@ func (f Float64Flag) GetHidden() bool {
 	return f.Hidden
 }
 
+// GetCategory lets us access the flag category
+func (f Float64Flag) GetCategory() string {
+	return f.Category
+}
+
 // Float64 looks up the value of a local Float64Flag, returns
 // 0 if not found
 func (c *Context) Float64(name string) float64 {
@@ -251,6 +271,11 @@ func (f GenericFlag) GetName() string {
 // GetHidden lets us know if the flag is hidden or not
 func (f GenericFlag) GetHidden() bool {
 	return f.Hidden
+}
+
+// GetCategory lets us access the flag category
+func (f GenericFlag) GetCategory() string {
+	return f.Category
 }
 
 // Generic looks up the value of a local GenericFlag, returns
@@ -308,6 +333,11 @@ func (f Int64Flag) GetHidden() bool {
 	return f.Hidden
 }
 
+// GetCategory lets us access the flag category
+func (f Int64Flag) GetCategory() string {
+	return f.Category
+}
+
 // Int64 looks up the value of a local Int64Flag, returns
 // 0 if not found
 func (c *Context) Int64(name string) int64 {
@@ -361,6 +391,11 @@ func (f IntFlag) GetName() string {
 // GetHidden lets us know if the flag is hidden or not
 func (f IntFlag) GetHidden() bool {
 	return f.Hidden
+}
+
+// GetCategory lets us access the flag category
+func (f IntFlag) GetCategory() string {
+	return f.Category
 }
 
 // Int looks up the value of a local IntFlag, returns
@@ -417,6 +452,11 @@ func (f IntSliceFlag) GetHidden() bool {
 	return f.Hidden
 }
 
+// GetCategory lets us access the flag category
+func (f IntSliceFlag) GetCategory() string {
+	return f.Category
+}
+
 // IntSlice looks up the value of a local IntSliceFlag, returns
 // nil if not found
 func (c *Context) IntSlice(name string) []int {
@@ -469,6 +509,11 @@ func (f Int64SliceFlag) GetName() string {
 // GetHidden lets us know if the flag is hidden or not
 func (f Int64SliceFlag) GetHidden() bool {
 	return f.Hidden
+}
+
+// GetCategory lets us access the flag category
+func (f Int64SliceFlag) GetCategory() string {
+	return f.Category
 }
 
 // Int64Slice looks up the value of a local Int64SliceFlag, returns
@@ -526,6 +571,11 @@ func (f StringFlag) GetHidden() bool {
 	return f.Hidden
 }
 
+// GetCategory lets us access the flag category
+func (f StringFlag) GetCategory() string {
+	return f.Category
+}
+
 // String looks up the value of a local StringFlag, returns
 // "" if not found
 func (c *Context) String(name string) string {
@@ -578,6 +628,11 @@ func (f StringSliceFlag) GetName() string {
 // GetHidden lets us know if the flag is hidden or not
 func (f StringSliceFlag) GetHidden() bool {
 	return f.Hidden
+}
+
+// GetCategory lets us access the flag category
+func (f StringSliceFlag) GetCategory() string {
+	return f.Category
 }
 
 // StringSlice looks up the value of a local StringSliceFlag, returns
@@ -635,6 +690,11 @@ func (f Uint64Flag) GetHidden() bool {
 	return f.Hidden
 }
 
+// GetCategory lets us access the flag category
+func (f Uint64Flag) GetCategory() string {
+	return f.Category
+}
+
 // Uint64 looks up the value of a local Uint64Flag, returns
 // 0 if not found
 func (c *Context) Uint64(name string) uint64 {
@@ -688,6 +748,11 @@ func (f UintFlag) GetName() string {
 // GetHidden lets us know if the flag is hidden or not
 func (f UintFlag) GetHidden() bool {
 	return f.Hidden
+}
+
+// GetCategory lets us access the flag category
+func (f UintFlag) GetCategory() string {
+	return f.Category
 }
 
 // Uint looks up the value of a local UintFlag, returns

--- a/flag_test.go
+++ b/flag_test.go
@@ -1052,7 +1052,7 @@ func TestParseBoolShortOptionHandle(t *testing.T) {
 	a := App{
 		Commands: []Command{
 			{
-				Name: "foobar",
+				Name:                   "foobar",
 				UseShortOptionHandling: true,
 				Action: func(ctx *Context) error {
 					if ctx.Bool("serve") != true {

--- a/generate-flag-types
+++ b/generate-flag-types
@@ -176,6 +176,11 @@ def _write_cli_flag_types(outfile, types):
                 return f.Hidden
             }}
 
+            // GetCategory lets us access the flag category
+            func (f {name}Flag) GetCategory() string {{
+                return f.Category
+            }}
+
             // {name} looks up the value of a local {name}Flag, returns
             // {context_default} if not found
             func (c *Context) {name}(name string) {context_type} {{

--- a/generate-flag-types
+++ b/generate-flag-types
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 The flag types that ship with the cli library have many things in common, and
 so we can take advantage of the `go generate` command to create much of the
@@ -144,6 +144,7 @@ def _write_cli_flag_types(outfile, types):
             EnvVar string
             FilePath string
             Hidden bool
+            Category string
         """.format(**typedef))
 
         if typedef['value']:
@@ -168,6 +169,11 @@ def _write_cli_flag_types(outfile, types):
             // GetName returns the name of the flag
             func (f {name}Flag) GetName() string {{
                 return f.Name
+            }}
+
+            // GetHidden lets us know if the flag is hidden or not
+            func (f {name}Flag) GetHidden() bool {{
+                return f.Hidden
             }}
 
             // {name} looks up the value of a local {name}Flag, returns

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/urfave/cli
+
+require (
+	github.com/BurntSushi/toml v0.3.1
+	gopkg.in/urfave/cli.v1 v1.20.0
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
+gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/help.go
+++ b/help.go
@@ -54,9 +54,10 @@ CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}{{if .VisibleFlags}}
+   {{.Description}}{{end}}
 
-OPTIONS:
+OPTIONS:{{range .VisibleFlagCategories}}
+  {{.Name}}
    {{range .VisibleFlags}}{{.}}
    {{end}}{{end}}
 `
@@ -250,7 +251,10 @@ func printHelpCustom(out io.Writer, templ string, data interface{}, customFunc m
 		// If the writer is closed, t.Execute will fail, and there's nothing
 		// we can do to recover.
 		if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
-			fmt.Fprintf(ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
+      // Generic error message
+			fmt.Fprintf(ErrWriter, "CLI TEMPLATE ERROR DEBUG: %#v\n", err)
+      // Helpful error message
+			fmt.Fprintf(ErrWriter, "CLI TEMPLATE ERROR DEBUG: %#v\n", err.Error())
 		}
 		return
 	}

--- a/help.go
+++ b/help.go
@@ -54,12 +54,11 @@ CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}
-
+   {{.Description}}{{end}}{{if .VisibleFlagCategories}}
 OPTIONS:{{range .VisibleFlagCategories}}
   {{.Name}}
    {{range .VisibleFlags}}{{.}}
-   {{end}}{{end}}
+   {{end}}{{end}}{{end}}
 `
 
 // SubcommandHelpTemplate is the text template for the subcommand help topic.

--- a/runtests
+++ b/runtests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from __future__ import print_function
 
 import argparse


### PR DESCRIPTION
This could be better and needs some cleanup as well as tests. It gives you the basic ability that I wanted which lets you set a category on a flag and have it printed in the help to break up commands with super long help messages. Global options ignore this right now but could be made to use it if someone messed with the template.

Here is an example output with this patch applied.

```
NAME:
   collins-go-cli query - Search for assets in Collins

USAGE:
   collins-go-cli query [command options] [arguments...]

OPTIONS:
  
   -Z, --remote-lookup                Query remote datacenters for asset
   -T value, --type value             Only show asset with type value
   -n value, --nodeclass value        Assets in nodeclass value[,...]
   -p value, --pool value             Assets in pool value[,...]
   -s value, --size value             Number of assets to return per page (default: 100)
   --limit value                      Limit total results of assets (default: 0)
   -r value, --role value             Assets in primary role
   -R value, --secondary-role value   Assets in secondary role
   -i value, --ip-address value       Assets with IP address[es]
   -S value, --status value           Asset status (and optional state after :)
   -a value, --attribute value        Arbitrary attributes and values to match in query. : between key and value
   -H, --show-header                  Show header fields in output
   -c value, --columns value          Attributes to output as columns, comma separated (default: "tag,hostname,nodeclass,status,pool,primary_role,secondary_role")
   -x value, --extra-columns value    Show these columns in addition to the default columns, comma separated
   -f value, --field-separator value  Separator between columns in output
   -l, --link                         Output link to assets found in web UI
   -j, --json                         Output results in JSON
   -y, --yaml                         Output results in YAML
   
  Test
   -t value, --tag value  Assets with tag[s] value[,...]
   
```
It also adds go mod support so I can overwrite the package locally with the mod replace syntax.