### PR TITLE
use type switch instead of if/else

### DIFF
--- a/app.go
+++ b/app.go
@@ -495,11 +495,12 @@ func (a Author) String() string {
 // it's an ActionFunc or a func with the legacy signature for Action, the func
 // is run!
 func HandleAction(action interface{}, context *Context) (err error) {
-	if a, ok := action.(ActionFunc); ok {
+	switch a := action.(type) {
+	case ActionFunc:
 		return a(context)
-	} else if a, ok := action.(func(*Context) error); ok {
+	case func(*Context) error:
 		return a(context)
-	} else if a, ok := action.(func(*Context)); ok { // deprecated function signature
+	case func(*Context): // deprecated function signature
 		a(context)
 		return nil
 	}


### PR DESCRIPTION
This reduces the syntax noise of the code by
removing excessive type assertions.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>