### PR TITLE
V2: Issue #800: Adding Prepare directive which runs after Before but before Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,10 @@ func main() {
 }
 ```
 
+Consequently if you are using the `Before` as described above and you require further `Before`-like routines you can use
+`Prepare` and add your routines there. Additionally of note is that if any of the `Before` has errors the `Prepare`
+segment will not be called upon. Therefore execution flows such that `Before` is run before `Prepare`.
+
 #### Default Values for help output
 
 Sometimes it's useful to specify a flag's default help-text value within the flag declaration. This can be useful if the default value for a flag is a computed value. The default value can be set via the `DefaultText` struct field.
@@ -1261,6 +1265,10 @@ func main() {
           fmt.Fprintf(c.App.Writer, "brace for impact\n")
           return nil
         },
+        Prepare: func(c *cli.Context) error {
+          fmt.Fprintf(c.App.Writer, "we've almost made it!\n")
+          return nil
+        },
         After: func(c *cli.Context) error {
           fmt.Fprintf(c.App.Writer, "did we lose anyone?\n")
           return nil
@@ -1305,6 +1313,10 @@ func main() {
     },
     Before: func(c *cli.Context) error {
       fmt.Fprintf(c.App.Writer, "HEEEERE GOES\n")
+      return nil
+    },
+    Prepare: func(c *cli.Context) error {
+      fmt.Fprintf(c.App.Writer, "JUST ONE LAST BIT\n")
       return nil
     },
     After: func(c *cli.Context) error {

--- a/app.go
+++ b/app.go
@@ -44,6 +44,9 @@ type App struct {
 	// An action to execute before any subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no subcommands are run
 	Before BeforeFunc
+	// An action to execute after Before is run, any subcommands are run, and after the context is ready
+	// It is run even if Before() panics, and if a non-nil error is returned, no subcommands are run
+	Prepare PrepareFunc
 	// An action to execute after any subcommands are run, but after the subcommand has finished
 	// It is run even if Action() panics
 	After AfterFunc
@@ -253,6 +256,16 @@ func (a *App) Run(arguments []string) (err error) {
 		}
 	}
 
+	if a.Prepare != nil {
+		prepareErr := a.Prepare(context)
+		if prepareErr != nil {
+			ShowAppHelp(context)
+			HandleExitCoder(prepareErr)
+			err = prepareErr
+			return err
+		}
+	}
+
 	args := context.Args()
 	if args.Present() {
 		name := args.First()
@@ -369,6 +382,15 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 		if beforeErr != nil {
 			HandleExitCoder(beforeErr)
 			err = beforeErr
+			return err
+		}
+	}
+
+	if a.Prepare != nil {
+		prepareErr := a.Prepare(context)
+		if prepareErr != nil {
+			HandleExitCoder(prepareErr)
+			err = prepareErr
 			return err
 		}
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 type opCounts struct {
-	Total, ShellComplete, OnUsageError, Before, CommandNotFound, Action, After, SubCommand int
+	Total, ShellComplete, OnUsageError, Before, Prepare, CommandNotFound, Action, After, SubCommand int
 }
 
 func ExampleApp_Run() {
@@ -236,7 +236,7 @@ func ExampleApp_Run_shellComplete() {
 	os.Args = []string{"greet", fmt.Sprintf("--%s", genCompName())}
 
 	app := &App{
-		Name: "greet",
+		Name:                  "greet",
 		EnableShellCompletion: true,
 		Commands: []*Command{
 			{
@@ -335,7 +335,8 @@ func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
 						Usage: "language for the greeting",
 					},
 				},
-				Before: func(_ *Context) error { return nil },
+				Before:  func(_ *Context) error { return nil },
+				Prepare: func(_ *Context) error { return nil },
 			},
 		},
 	}
@@ -503,7 +504,6 @@ func TestApp_Float64Flag(t *testing.T) {
 }
 
 func TestApp_ParseSliceFlags(t *testing.T) {
-	var parsedOption, firstArg string
 	var parsedIntSlice []int
 	var parsedStringSlice []string
 
@@ -518,8 +518,6 @@ func TestApp_ParseSliceFlags(t *testing.T) {
 				Action: func(c *Context) error {
 					parsedIntSlice = c.IntSlice("p")
 					parsedStringSlice = c.StringSlice("ip")
-					parsedOption = c.String("option")
-					firstArg = c.Args().First()
 					return nil
 				},
 			},
@@ -734,6 +732,96 @@ func TestApp_BeforeFunc(t *testing.T) {
 	}
 }
 
+func TestApp_PrepareFunc(t *testing.T) {
+	counts := &opCounts{}
+	prepareError := fmt.Errorf("fail")
+	var err error
+
+	app := &App{
+		Prepare: func(c *Context) error {
+			counts.Total++
+			counts.Prepare = counts.Total
+			s := c.String("opt")
+			if s == "fail" {
+				return prepareError
+			}
+
+			return nil
+		},
+		Commands: []*Command{
+			{
+				Name: "sub",
+				Action: func(c *Context) error {
+					counts.Total++
+					counts.SubCommand = counts.Total
+					return nil
+				},
+			},
+		},
+		Flags: []Flag{
+			&StringFlag{Name: "opt"},
+		},
+	}
+
+	// run with the Prepare() func succeeding
+	err = app.Run([]string{"command", "--opt", "succeed", "sub"})
+
+	if err != nil {
+		t.Fatalf("Run error: %s", err)
+	}
+
+	if counts.Prepare != 1 {
+		t.Errorf("Prepare() not executed when expected")
+	}
+
+	if counts.SubCommand != 2 {
+		t.Errorf("Subcommand not executed when expected")
+	}
+
+	// reset
+	counts = &opCounts{}
+
+	// run with the Prepare() func failing
+	err = app.Run([]string{"command", "--opt", "fail", "sub"})
+
+	// should be the same error produced by the Prepare func
+	if err != prepareError {
+		t.Errorf("Run error expected, but not received")
+	}
+
+	if counts.Prepare != 1 {
+		t.Errorf("Prepare() not executed when expected")
+	}
+
+	if counts.SubCommand != 0 {
+		t.Errorf("Subcommand executed when NOT expected")
+	}
+
+	// reset
+	counts = &opCounts{}
+
+	afterError := errors.New("fail again")
+	app.After = func(_ *Context) error {
+		return afterError
+	}
+
+	// run with the Prepare() func failing, wrapped by After()
+	err = app.Run([]string{"command", "--opt", "fail", "sub"})
+
+	// should be the same error produced by the Prepare func
+	if _, ok := err.(MultiError); !ok {
+		t.Errorf("MultiError expected, but not received")
+	}
+
+	if counts.Prepare != 1 {
+		t.Errorf("Prepare() not executed when expected")
+	}
+
+	if counts.SubCommand != 0 {
+		t.Errorf("Subcommand executed when NOT expected")
+	}
+}
+
 func TestApp_AfterFunc(t *testing.T) {
 	counts := &opCounts{}
 	afterError := fmt.Errorf("fail")
@@ -783,10 +871,10 @@ func TestApp_AfterFunc(t *testing.T) {
 	// reset
 	counts = &opCounts{}
 
-	// run with the Before() func failing
+	// run with the After() func failing
 	err = app.Run([]string{"command", "--opt", "fail", "sub"})
 
-	// should be the same error produced by the Before func
+	// should be the same error produced by the After func
 	if err != afterError {
 		t.Errorf("Run error expected, but not received")
 	}
@@ -911,8 +999,21 @@ func TestApp_OrderOfOperations(t *testing.T) {
 		counts.Before = counts.Total
 		return errors.New("hay Before")
 	}
-
 	app.Before = beforeNoError
+
+	prepareNoError := func(c *Context) error {
+		counts.Total++
+		counts.Prepare = counts.Total
+		return nil
+	}
+
+	prepareError := func(c *Context) error {
+		counts.Total++
+		counts.Prepare = counts.Total
+		return errors.New("hay Prepare")
+	}
+	app.Prepare = prepareNoError
+
 	app.CommandNotFound = func(c *Context, command string) {
 		counts.Total++
 		counts.CommandNotFound = counts.Total
@@ -929,8 +1030,8 @@ func TestApp_OrderOfOperations(t *testing.T) {
 		counts.After = counts.Total
 		return errors.New("hay After")
 	}
-
 	app.After = afterNoError
+
 	app.Commands = []*Command{
 		{
 			Name: "bar",
@@ -971,10 +1072,11 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	_ = app.Run([]string{"command", "foo"})
 	expect(t, counts.OnUsageError, 0)
 	expect(t, counts.Before, 1)
+	expect(t, counts.Prepare, 2)
 	expect(t, counts.CommandNotFound, 0)
-	expect(t, counts.Action, 2)
-	expect(t, counts.After, 3)
-	expect(t, counts.Total, 3)
+	expect(t, counts.Action, 3)
+	expect(t, counts.After, 4)
+	expect(t, counts.Total, 4)
 
 	resetCounts()
 
@@ -982,9 +1084,21 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	_ = app.Run([]string{"command", "bar"})
 	expect(t, counts.OnUsageError, 0)
 	expect(t, counts.Before, 1)
+	expect(t, counts.Prepare, 0)
 	expect(t, counts.After, 2)
 	expect(t, counts.Total, 2)
 	app.Before = beforeNoError
+
+	resetCounts()
+
+	app.Prepare = prepareError
+	_ = app.Run([]string{"command", "bar"})
+	expect(t, counts.OnUsageError, 0)
+	expect(t, counts.Before, 1)
+	expect(t, counts.Prepare, 2)
+	expect(t, counts.After, 3)
+	expect(t, counts.Total, 3)
+	app.Prepare = prepareNoError
 
 	resetCounts()
 
@@ -992,8 +1106,9 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	_ = app.Run([]string{"command", "bar"})
 	expect(t, counts.OnUsageError, 0)
 	expect(t, counts.Before, 1)
-	expect(t, counts.SubCommand, 2)
-	expect(t, counts.Total, 2)
+	expect(t, counts.Prepare, 2)
+	expect(t, counts.SubCommand, 3)
+	expect(t, counts.Total, 3)
 	app.After = afterNoError
 
 	resetCounts()
@@ -1005,9 +1120,10 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	}
 	expect(t, counts.OnUsageError, 0)
 	expect(t, counts.Before, 1)
-	expect(t, counts.SubCommand, 2)
-	expect(t, counts.After, 3)
-	expect(t, counts.Total, 3)
+	expect(t, counts.Prepare, 2)
+	expect(t, counts.SubCommand, 3)
+	expect(t, counts.After, 4)
+	expect(t, counts.Total, 4)
 	app.After = afterNoError
 
 	resetCounts()
@@ -1017,9 +1133,10 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	_ = app.Run([]string{"command"})
 	expect(t, counts.OnUsageError, 0)
 	expect(t, counts.Before, 1)
-	expect(t, counts.Action, 2)
-	expect(t, counts.After, 3)
-	expect(t, counts.Total, 3)
+	expect(t, counts.Prepare, 2)
+	expect(t, counts.Action, 3)
+	expect(t, counts.After, 4)
+	expect(t, counts.Total, 4)
 	app.Commands = oldCommands
 }
 
@@ -1443,9 +1560,10 @@ func TestApp_VisibleCategories(t *testing.T) {
 
 func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 	app := &App{
-		Action: func(c *Context) error { return nil },
-		Before: func(c *Context) error { return fmt.Errorf("before error") },
-		After:  func(c *Context) error { return fmt.Errorf("after error") },
+		Action:  func(c *Context) error { return nil },
+		Before:  func(c *Context) error { return fmt.Errorf("before error") },
+		Prepare: func(c *Context) error { return fmt.Errorf("prepare error") },
+		After:   func(c *Context) error { return fmt.Errorf("after error") },
 	}
 
 	err := app.Run([]string{"foo"})
@@ -1455,6 +1573,9 @@ func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "before error") {
 		t.Errorf("expected text of error from Before method, but got none in \"%v\"", err)
+	}
+	if strings.Contains(err.Error(), "prepare error") {
+		t.Errorf("not expecting text of error from Prepare method, because Before errors before Prepare \"%v\"", err)
 	}
 	if !strings.Contains(err.Error(), "after error") {
 		t.Errorf("expected text of error from After method, but got none in \"%v\"", err)
@@ -1470,9 +1591,10 @@ func TestApp_Run_SubcommandDoesNotOverwriteErrorFromBefore(t *testing.T) {
 						Name: "sub",
 					},
 				},
-				Name:   "bar",
-				Before: func(c *Context) error { return fmt.Errorf("before error") },
-				After:  func(c *Context) error { return fmt.Errorf("after error") },
+				Name:    "bar",
+				Before:  func(c *Context) error { return fmt.Errorf("before error") },
+				Prepare: func(c *Context) error { return fmt.Errorf("prepare error") },
+				After:   func(c *Context) error { return fmt.Errorf("after error") },
 			},
 		},
 	}
@@ -1484,6 +1606,9 @@ func TestApp_Run_SubcommandDoesNotOverwriteErrorFromBefore(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "before error") {
 		t.Errorf("expected text of error from Before method, but got none in \"%v\"", err)
+	}
+	if strings.Contains(err.Error(), "prepare error") {
+		t.Errorf("not expecting text of error from Prepare method, because Before had an error prior, but got none in \"%v\"", err)
 	}
 	if !strings.Contains(err.Error(), "after error") {
 		t.Errorf("expected text of error from After method, but got none in \"%v\"", err)

--- a/funcs.go
+++ b/funcs.go
@@ -7,6 +7,11 @@ type ShellCompleteFunc func(*Context)
 // the context is ready if a non-nil error is returned, no subcommands are run
 type BeforeFunc func(*Context) error
 
+// PrepareFunc is an action to execute after the Before() routuines, before any
+// subcommands are run, but after the context is ready if a non-nil error is
+// returned, no subcommands are run
+type PrepareFunc func(*Context) error
+
 // AfterFunc is an action to execute after any subcommands are run, but after the
 // subcommand has finished it is run even if Action() panics
 type AfterFunc func(*Context) error


### PR DESCRIPTION
Adds the `Prepare` directive which runs after `Before` due to `Before` sometimes being held hostage if you are using the loading of configuration files a la `altsrc`.  This issue was reported here: https://github.com/urfave/cli/issues/800