### PR TITLE
Fix the unaligned indents for the command help messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,7 +874,7 @@ Will include:
 
 ```
 COMMANDS:
-    noop
+  noop
 
   Template actions:
     add

--- a/app_test.go
+++ b/app_test.go
@@ -136,8 +136,8 @@ func ExampleApp_Run_appHelp() {
 	//    Oliver Allen <oliver@toyshop.com>
 	//
 	// COMMANDS:
-	//      describeit, d  use it to see a description
-	//      help, h        Shows a list of commands or help for one command
+	//    describeit, d  use it to see a description
+	//    help, h        Shows a list of commands or help for one command
 	//
 	// GLOBAL OPTIONS:
 	//    --name value   a name to say (default: "bob")
@@ -190,7 +190,7 @@ func ExampleApp_Run_noAction() {
 	//     [global options] command [command options] [arguments...]
 	//
 	// COMMANDS:
-	//      help, h  Shows a list of commands or help for one command
+	//    help, h  Shows a list of commands or help for one command
 	//
 	// GLOBAL OPTIONS:
 	//    --help, -h     show help

--- a/help.go
+++ b/help.go
@@ -30,8 +30,9 @@ AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
 
-   {{.Name}}:{{end}}{{range .VisibleCommands}}
-     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
 
 GLOBAL OPTIONS:
    {{range $index, $option := .VisibleFlags}}{{if $index}}
@@ -71,9 +72,11 @@ USAGE:
    {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
-   {{.Name}}:{{end}}{{range .VisibleCommands}}
-     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}
-{{end}}{{if .VisibleFlags}}
+
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+
 OPTIONS:
    {{range .VisibleFlags}}{{.}}
    {{end}}{{end}}


### PR DESCRIPTION
All help messages have 3 spaces before their contents except `COMMANDS` section. If a command has a category, it will have 5 spaces before its description. It's ok. But even if there is no command category, it still occupies 5 spaces.

```
NAME:
   greet - A new cli application

USAGE:
   greet [global options] command [command options] [arguments...]

VERSION:
   0.1.0

COMMANDS:
     describeit, d  use it to see a description // why 5 spaces?
     help, h        Shows a list of commands or help for one command // why 5 spaces?

GLOBAL OPTIONS:
   --name value   a name to say (default: "bob")
   --help, -h     show help
   --version, -v  print the version
```

It seems like a bug. So I fixed these unaligned indentations for the commands that have no categories. In case of categories even exist, It works as intended.

```
NAME:
   greet - A new cli application

USAGE:
   greet [global options] command [command options] [arguments...]

VERSION:
   0.1.0

COMMANDS:
   describeit, d  use it to see a description
   help, h        Shows a list of commands or help for one command
   
   category1:
     sub1  sub1 command
     sub2  sub2 command
  
   category2:
     sub1  sub1 command

GLOBAL OPTIONS:
   --name value   a name to say (default: "bob")
   --help, -h     show help
   --version, -v  print the version
```