### PR TITLE
Add support for flags bash completion

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -221,6 +221,60 @@ func ExampleApp_Run_subcommandNoAction() {
 
 }
 
+func ExampleApp_Run_bashComplete_withShortFlag() {
+	os.Args = []string{"greet", "-", "--generate-bash-completion"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.EnableBashCompletion = true
+	app.Flags = []Flag{
+		IntFlag{
+			Name: "other,o",
+		},
+		StringFlag{
+			Name: "xyz,x",
+		},
+	}
+
+	app.Run(os.Args)
+	// Output:
+	// --other
+	// -o
+	// --xyz
+	// -x
+	// --help
+	// -h
+	// --version
+	// -v
+}
+
+func ExampleApp_Run_bashComplete_withLongFlag() {
+	os.Args = []string{"greet", "--s", "--generate-bash-completion"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.EnableBashCompletion = true
+	app.Flags = []Flag{
+		IntFlag{
+			Name: "other,o",
+		},
+		StringFlag{
+			Name: "xyz,x",
+		},
+		StringFlag{
+			Name: "some-flag,s",
+		},
+		StringFlag{
+			Name: "similar-flag",
+		},
+	}
+
+	app.Run(os.Args)
+	// Output:
+	// --some-flag
+	// --similar-flag
+}
+
 func ExampleApp_Run_bashComplete() {
 	// set args for examples sake
 	os.Args = []string{"greet", "--generate-bash-completion"}

--- a/app_test.go
+++ b/app_test.go
@@ -274,6 +274,35 @@ func ExampleApp_Run_bashComplete_withLongFlag() {
 	// --some-flag
 	// --similar-flag
 }
+func ExampleApp_Run_bashComplete_withMultipleLongFlag() {
+	os.Args = []string{"greet", "--st", "--generate-bash-completion"}
+
+	app := NewApp()
+	app.Name = "greet"
+	app.EnableBashCompletion = true
+	app.Flags = []Flag{
+		IntFlag{
+			Name: "int-flag,i",
+		},
+		StringFlag{
+			Name: "string,s",
+		},
+		StringFlag{
+			Name: "string-flag-2",
+		},
+		StringFlag{
+			Name: "similar-flag",
+		},
+		StringFlag{
+			Name: "some-flag",
+		},
+	}
+
+	app.Run(os.Args)
+	// Output:
+	// --string
+	// --string-flag-2
+}
 
 func ExampleApp_Run_bashComplete() {
 	// set args for examples sake

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -3,6 +3,7 @@
 : ${PROG:=$(basename ${BASH_SOURCE})}
 
 _cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[@]:0:$COMP_CWORD}" != "source" ]]; then
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
@@ -13,8 +14,8 @@ _cli_bash_autocomplete() {
     fi
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     return 0
+  fi
 }
 
-complete -F _cli_bash_autocomplete $PROG
-
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
 unset PROG

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -7,7 +7,7 @@ _cli_bash_autocomplete() {
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    if [[ $cur == -* ]]; then
+    if [[ "$cur" == "-"* ]]; then
       opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
     else
       opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -11,9 +11,6 @@ _cli_bash_autocomplete() {
     else
       opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
     fi
-    if [[ "$opts1" == "$cur1" ]]; then
-      return 0
-    fi
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     return 0
 }

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -3,7 +3,7 @@
 : ${PROG:=$(basename ${BASH_SOURCE})}
 
 _cli_bash_autocomplete() {
-  if [[ "${COMP_WORDS[@]:0:$COMP_CWORD}" != "source" ]]; then
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -6,7 +6,14 @@ _cli_bash_autocomplete() {
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    if [[ $cur == -* ]]; then
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+    else
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    fi
+    if [[ "$opts1" == "$cur1" ]]; then
+      return 0
+    fi
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     return 0
 }

--- a/help.go
+++ b/help.go
@@ -162,6 +162,22 @@ func DefaultAppComplete(c *Context) {
 }
 
 func DefaultAppCompleteWithFlags(cmd *Command) func(c *Context) {
+	cliArgContains := func(flagName string) bool {
+		for _, name := range strings.Split(flagName, ",") {
+			name = strings.Trim(name, " ")
+			count := utf8.RuneCountInString(name)
+			if count > 2 {
+				count = 2
+			}
+			flag := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
+			for _, a := range os.Args {
+				if a == flag {
+					return true
+				}
+			}
+		}
+		return false
+	}
 	return func(c *Context) {
 		if len(os.Args) > 2 {
 			lastArg := os.Args[len(os.Args)-2]
@@ -171,12 +187,13 @@ func DefaultAppCompleteWithFlags(cmd *Command) func(c *Context) {
 				for _, flag := range c.App.Flags {
 					for _, name := range strings.Split(flag.GetName(), ",") {
 						name = strings.Trim(name, " ")
-						if strings.HasPrefix(name, lastArg) && lastArg != name {
-							count := utf8.RuneCountInString(name)
-							if count > 2 {
-								count = 2
-							}
-							fmt.Fprintf(c.App.Writer, "%s%s\n", strings.Repeat("-", count), name)
+						count := utf8.RuneCountInString(name)
+						if count > 2 {
+							count = 2
+						}
+						flagCompletion := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
+						if strings.HasPrefix(name, lastArg) && lastArg != name && !cliArgContains(flag.GetName()) {
+							fmt.Fprintln(c.App.Writer, flagCompletion)
 						}
 					}
 				}
@@ -184,12 +201,13 @@ func DefaultAppCompleteWithFlags(cmd *Command) func(c *Context) {
 					for _, flag := range cmd.Flags {
 						for _, name := range strings.Split(flag.GetName(), ",") {
 							name = strings.Trim(name, " ")
-							if strings.HasPrefix(name, lastArg) && lastArg != name {
-								count := utf8.RuneCountInString(name)
-								if count > 2 {
-									count = 2
-								}
-								fmt.Fprintf(c.App.Writer, "%s%s\n", strings.Repeat("-", count), name)
+							count := utf8.RuneCountInString(name)
+							if count > 2 {
+								count = 2
+							}
+							flagCompletion := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
+							if strings.HasPrefix(name, lastArg) && lastArg != name && !cliArgContains(flag.GetName()) {
+								fmt.Fprintln(c.App.Writer, flagCompletion)
 							}
 						}
 					}

--- a/help.go
+++ b/help.go
@@ -199,6 +199,9 @@ func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
 	cur := shortFlagRegex.ReplaceAllString(lastArg, "")
 	cur = shortFlagRegex.ReplaceAllString(cur, "")
 	for _, flag := range flags {
+		if bflag, ok := flag.(BoolFlag); ok && bflag.Hidden {
+			continue
+		}
 		for _, name := range strings.Split(flag.GetName(), ",") {
 			name = strings.Trim(name, " ")
 			count := utf8.RuneCountInString(name)

--- a/help.go
+++ b/help.go
@@ -183,7 +183,7 @@ func printCommandSuggestions(commands []Command, writer io.Writer) {
 
 func cliArgContains(flagName string) bool {
 	for _, name := range strings.Split(flagName, ",") {
-		name = strings.Trim(name, " ")
+		name = strings.TrimSpace(name)
 		count := utf8.RuneCountInString(name)
 		if count > 2 {
 			count = 2

--- a/help.go
+++ b/help.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strings"
 	"text/tabwriter"
 	"text/template"
@@ -156,8 +155,6 @@ func ShowAppHelp(c *Context) (err error) {
 	HelpPrinterCustom(c.App.Writer, c.App.CustomAppHelpTemplate, c.App, customAppData())
 	return nil
 }
-
-var shortFlagRegex = regexp.MustCompile(`^-`)
 
 // DefaultAppComplete prints the list of subcommands as the default app completion method
 func DefaultAppComplete(c *Context) {


### PR DESCRIPTION
Fixed #188 

Short and long flags will be generated with `--generate-bash-completion` when last argument is hyphen (`-`) or double hyphen (`--`).

If flag is already provided in cli args it will not be generated. Also for double hyphens single character flags will not be generated.

Adds default BashCompletion for Commands and SubCommands.
