### PR TITLE
Make the exit code example more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,14 +901,14 @@ import (
 func main() {
   app := cli.NewApp()
   app.Flags = []cli.Flag{
-    cli.BoolTFlag{
+    cli.BoolFlag{
       Name:  "ginger-crouton",
-      Usage: "is it in the soup?",
+      Usage: "Add ginger croutons to the soup",
     },
   }
   app.Action = func(ctx *cli.Context) error {
     if !ctx.Bool("ginger-crouton") {
-      return cli.NewExitError("it is not in the soup", 86)
+      return cli.NewExitError("Ginger croutons are not in the soup", 86)
     }
     return nil
   }


### PR DESCRIPTION
The purpose of this example is to show that you can exit with an error
code if a flag is unspecified, but with the code as it is, the only way
to cause a non-zero exit is by adding the flag `--ginger-crouton=false`,
which is not explained in the example.

In this new version of the example, running the command with no flag
will exit with an error, and running it with the flag will exit
normally.

This resolves #820.