### PR TITLE
Use codeowners instead of maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+*       @urfave/cli

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,10 @@
 ## Contributing
 
-**NOTE**: the primary maintainer(s) may be found in
-[./MAINTAINERS.md](./MAINTAINERS.md).
+Use @urfave/cli to ping the maintainers.
 
-Feel free to put up a pull request to fix a bug or maybe add a feature. I will
+Feel free to put up a pull request to fix a bug or maybe add a feature. We will
 give it a code review and make sure that it does not break backwards
-compatibility. If I or any other collaborators agree that it is in line with
+compatibility. If collaborators agree that it is in line with
 the vision of the project, we will work with you to get the code into
 a mergeable state and merge it into the master branch.
 
@@ -15,5 +14,5 @@ to merge others pull requests. It is very important that new code does not
 break existing code, so be careful about what code you do choose to merge.
 
 If you feel like you have contributed to the project but have not yet been added
-as a collaborator, we probably forgot to add you :sweat_smile:.  Please open an
+as a collaborator, we probably forgot to add you :sweat_smile:. Please open an
 issue!

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,0 @@
-- @meatballhat
-- @lynncyrin
-- @AudriusButkevicius
-- @asahasrabuddhe


### PR DESCRIPTION
Inspired by cpython https://github.com/python/cpython/blob/master/.github/CODEOWNERS, I added github's codeowners file https://help.github.com/en/articles/about-code-owners. 

Using this file unlocks some nice automation (like automatic review pings) and removes the issue of "oh, we forgot to update the maintainers file"!