### PR TITLE
Support also GoLang 1.11 compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 dist: trusty
 osx_image: xcode8.3
 go:
+  - 1.10.x
   - 1.11.x
   - 1.12.x
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/urfave/cli
 
-go 1.11
+go 1.10
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/urfave/cli
 
-go 1.12
+go 1.11
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
Currently when using `github.com/urfave/cli` in project it requires GoLang compiler version 1.12

Error:
```
go build github.com/urfave/cli: module requires Go 1.12
```
