### PR TITLE
Add Subcommand fallback call to ExitErrHandler, fixing #816

### DIFF
--- a/command.go
+++ b/command.go
@@ -268,6 +268,7 @@ func (c Command) HasName(name string) bool {
 func (c Command) startApp(ctx *Context) error {
 	app := NewApp()
 	app.Metadata = ctx.App.Metadata
+	app.ExitErrHandler = ctx.App.ExitErrHandler
 	// set the name and usage
 	app.Name = fmt.Sprintf("%s %s", ctx.App.Name, c.Name)
 	if c.HelpName == "" {


### PR DESCRIPTION
Fixing issue #816 where the default HandleExitCoder was called (leading to a call to OsExiter) instead of the user input ExitErrHandler. 
This happens in the case of ExitError is returned from a subcommand.