### PR TITLE
build: show failures when running tests

### DIFF
--- a/build.go
+++ b/build.go
@@ -52,8 +52,8 @@ func main() {
 	}
 }
 
-func runCmd(args ...string) error {
-	cmd := exec.Command(args[0], args[1:]...)
+func runCmd(arg string, args ...string) error {
+	cmd := exec.Command(arg, args...)
 
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/build.go
+++ b/build.go
@@ -53,7 +53,12 @@ func main() {
 }
 
 func runCmd(args ...string) error {
-	cmd := exec.Command(args[0], args[1:]...)
+	var cmd *exec.Cmd
+	if len(args) > 1 {
+		cmd = exec.Command(args[0], args[1:]...)
+	} else {
+		cmd = exec.Command(args[0])
+	}
 
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/build.go
+++ b/build.go
@@ -53,12 +53,7 @@ func main() {
 }
 
 func runCmd(args ...string) error {
-	var cmd *exec.Cmd
-	if len(args) > 1 {
-		cmd = exec.Command(args[0], args[1:]...)
-	} else {
-		cmd = exec.Command(args[0])
-	}
+	cmd := exec.Command(args[0], args[1:]...)
 
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/build.go
+++ b/build.go
@@ -52,14 +52,18 @@ func main() {
 	}
 }
 
-func VetActionFunc(_ *cli.Context) error {
-	cmd := exec.Command("go", "vet")
+func runCmd(args ...string) error {
+	cmd := exec.Command(args[0], args[1:]...)
 
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
+}
+
+func VetActionFunc(_ *cli.Context) error {
+	return runCmd("go", "vet")
 }
 
 func TestActionFunc(c *cli.Context) error {
@@ -74,13 +78,7 @@ func TestActionFunc(c *cli.Context) error {
 
 		coverProfile := fmt.Sprintf("--coverprofile=%s.coverprofile", pkg)
 
-		cmd := exec.Command("go", "test", "-v", coverProfile, packageName)
-
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		err := cmd.Run()
+		err := runCmd("go", "test", "-v", coverProfile, packageName)
 		if err != nil {
 			return err
 		}
@@ -152,34 +150,16 @@ func GfmrunActionFunc(_ *cli.Context) error {
 		return err
 	}
 
-	cmd := exec.Command("gfmrun", "-c", fmt.Sprint(counter), "-s", "README.md")
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
+	return runCmd("gfmrun", "-c", fmt.Sprint(counter), "-s", "README.md")
 }
 
 func TocActionFunc(_ *cli.Context) error {
-	cmd := exec.Command("node_modules/.bin/markdown-toc", "-i", "README.md")
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Run()
+	err := runCmd("node_modules/.bin/markdown-toc", "-i", "README.md")
 	if err != nil {
 		return err
 	}
 
-	cmd = exec.Command("git", "diff", "--exit-code")
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err = cmd.Run()
+	err = runCmd("git", "diff", "--exit-code")
 	if err != nil {
 		return err
 	}
@@ -188,35 +168,17 @@ func TocActionFunc(_ *cli.Context) error {
 }
 
 func GenActionFunc(_ *cli.Context) error {
-	cmd := exec.Command("go", "generate", "flag-gen/main.go")
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Run()
+	err := runCmd("go", "generate", "flag-gen/main.go")
 	if err != nil {
 		return err
 	}
 
-	cmd = exec.Command("go", "generate", "cli.go")
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err = cmd.Run()
+	err = runCmd("go", "generate", "cli.go")
 	if err != nil {
 		return err
 	}
 
-	cmd = exec.Command("git", "diff", "--exit-code")
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err = cmd.Run()
+	err = runCmd("git", "diff", "--exit-code")
 	if err != nil {
 		return err
 	}

--- a/build.go
+++ b/build.go
@@ -6,12 +6,13 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/urfave/cli"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/urfave/cli"
 )
 
 var packages = []string{"cli", "altsrc"}
@@ -52,7 +53,13 @@ func main() {
 }
 
 func VetActionFunc(_ *cli.Context) error {
-	return exec.Command("go", "vet").Run()
+	cmd := exec.Command("go", "vet")
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
 }
 
 func TestActionFunc(c *cli.Context) error {
@@ -67,10 +74,13 @@ func TestActionFunc(c *cli.Context) error {
 
 		coverProfile := fmt.Sprintf("--coverprofile=%s.coverprofile", pkg)
 
-		err := exec.Command(
-			"go", "test", "-v", coverProfile, packageName,
-		).Run()
+		cmd := exec.Command("go", "test", "-v", coverProfile, packageName)
 
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		err := cmd.Run()
 		if err != nil {
 			return err
 		}
@@ -142,16 +152,34 @@ func GfmrunActionFunc(_ *cli.Context) error {
 		return err
 	}
 
-	return exec.Command("gfmrun", "-c", fmt.Sprint(counter), "-s", "README.md").Run()
+	cmd := exec.Command("gfmrun", "-c", fmt.Sprint(counter), "-s", "README.md")
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
 }
 
 func TocActionFunc(_ *cli.Context) error {
-	err := exec.Command("node_modules/.bin/markdown-toc", "-i", "README.md").Run()
+	cmd := exec.Command("node_modules/.bin/markdown-toc", "-i", "README.md")
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
 	if err != nil {
 		return err
 	}
 
-	err = exec.Command("git", "diff", "--exit-code").Run()
+	cmd = exec.Command("git", "diff", "--exit-code")
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
 	if err != nil {
 		return err
 	}
@@ -160,17 +188,35 @@ func TocActionFunc(_ *cli.Context) error {
 }
 
 func GenActionFunc(_ *cli.Context) error {
-	err := exec.Command("go", "generate", "flag-gen/main.go").Run()
+	cmd := exec.Command("go", "generate", "flag-gen/main.go")
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
 	if err != nil {
 		return err
 	}
 
-	err = exec.Command("go", "generate", "cli.go").Run()
+	cmd = exec.Command("go", "generate", "cli.go")
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
 	if err != nil {
 		return err
 	}
 
-	err = exec.Command("git", "diff", "--exit-code").Run()
+	cmd = exec.Command("git", "diff", "--exit-code")
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Before

When you have failing tests, you get output like this

```
go run build.go generate
go run build.go vet
go run build.go test
exit status 1
exit status 1
Command exited with code 1
```

The above output is the literal terminal output, it doesn't tell the user what the source of the test failure is.

Adding the verbose flag like so

```
go run -v build.go test
```

Does not fix the issue.

## After

When you have failing tests, you get output like this

```
go run -v build.go test
...
--- FAIL: TestToMan (0.00s)
...
FAIL
coverage: 84.0% of statements
FAIL	github.com/urfave/cli	0.089s
exit status 1
exit status 1
```

This gives the user enough information to resolve the issue.

## Changes

I hooked `Stdin`, `Stdout`, `Stderr` into the ox exec calls.

## Impact

This change effects the local build system, and does not relate to the functionality of the cli.

## Context

This change is followup from https://github.com/urfave/cli/pull/836