### PR TITLE
Escape single quotes in fish shell completion

### DIFF
--- a/docs_test.go
+++ b/docs_test.go
@@ -11,7 +11,7 @@ func testApp() *App {
 	app.Flags = []Flag{
 		StringFlag{
 			Name:      "socket, s",
-			Usage:     "some usage text",
+			Usage:     "some 'usage' text",
 			Value:     "value",
 			TakesFile: true,
 		},

--- a/fish.go
+++ b/fish.go
@@ -78,7 +78,8 @@ func (a *App) prepareFishCommands(commands []Command, allCommands *[]string, pre
 		))
 
 		if command.Usage != "" {
-			completion.WriteString(fmt.Sprintf(" -d '%s'", command.Usage))
+			completion.WriteString(fmt.Sprintf(" -d '%s'",
+				escapeSingleQuotes(command.Usage)))
 		}
 
 		if !command.HideHelp {
@@ -144,7 +145,8 @@ func (a *App) prepareFishFlags(flags []Flag, previousCommands []string) []string
 		}
 
 		if flag.GetUsage() != "" {
-			completion.WriteString(fmt.Sprintf(" -d '%s'", flag.GetUsage()))
+			completion.WriteString(fmt.Sprintf(" -d '%s'",
+				escapeSingleQuotes(flag.GetUsage())))
 		}
 
 		completions = append(completions, completion.String())
@@ -181,4 +183,8 @@ func (a *App) fishSubcommandHelper(allCommands []string) string {
 	}
 	return fishHelper
 
+}
+
+func escapeSingleQuotes(input string) string {
+	return strings.Replace(input, `'`, `\'`, -1)
 }

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -49,7 +49,7 @@ greet [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 \fB\-\-flag, \-\-fl, \-f\fP="":
 
 .PP
-\fB\-\-socket, \-s\fP="": some usage text (default: value)
+\fB\-\-socket, \-s\fP="": some 'usage' text (default: value)
 
 
 .SH COMMANDS

--- a/testdata/expected-doc-full.md
+++ b/testdata/expected-doc-full.md
@@ -32,7 +32,7 @@ greet [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--flag, --fl, -f**="": 
 
-**--socket, -s**="": some usage text (default: value)
+**--socket, -s**="": some 'usage' text (default: value)
 
 
 # COMMANDS

--- a/testdata/expected-doc-no-commands.md
+++ b/testdata/expected-doc-no-commands.md
@@ -32,5 +32,5 @@ greet [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--flag, --fl, -f**="": 
 
-**--socket, -s**="": some usage text (default: value)
+**--socket, -s**="": some 'usage' text (default: value)
 

--- a/testdata/expected-fish-full.fish
+++ b/testdata/expected-fish-full.fish
@@ -9,7 +9,7 @@ function __fish_greet_no_subcommand --description 'Test if there has been any su
     return 0
 end
 
-complete -c greet -n '__fish_greet_no_subcommand' -l socket -s s -r -d 'some usage text'
+complete -c greet -n '__fish_greet_no_subcommand' -l socket -s s -r -d 'some \'usage\' text'
 complete -c greet -n '__fish_greet_no_subcommand' -f -l flag -s fl -s f -r
 complete -c greet -n '__fish_greet_no_subcommand' -f -l another-flag -s b -d 'another usage text'
 complete -c greet -n '__fish_greet_no_subcommand' -f -l help -s h -d 'show help'


### PR DESCRIPTION
Single quotes can break the generated fish shell completion and should
be escaped correctly.