### PR TITLE
Go modules support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ go:
 os:
   - linux
   - osx
-  - windows
 
 env:
   GO111MODULE=on
@@ -23,6 +22,7 @@ before_script:
   - go get github.com/urfave/gfmrun/cmd/gfmrun
   - go get golang.org/x/tools/cmd/goimports
   - npm install markdown-toc
+  - go mod tidy
 
 script:
   - go run build.go generate

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ os:
 
 env:
   GO111MODULE=on
+  GOPROXY=https://proxy.golang.org
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,14 @@ cache:
     - node_modules
 
 before_script:
-  - go get github.com/shurcooL/vfsgen || true
-  - go get github.com/shurcooL/httpfs/union || true
-  - go get github.com/urfave/gfmrun/... || true
+  - go get github.com/urfave/gfmrun/cmd/gfmrun
   - go get golang.org/x/tools/cmd/goimports
   - npm install markdown-toc
 
 script:
   - go run build.go generate
   - go run build.go vet
-  - go run build.go testm
+  - go run build.go test
   - go run build.go gfmrun
   - go run build.go toc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: go
 sudo: false
-dist: trusty
-osx_image: xcode8.3
+dist: bionic
+osx_image: xcode10
 go:
-  - 1.10.x
   - 1.11.x
   - 1.12.x
+  - 1.13.x
 
 os:
   - linux
   - osx
+  - windows
+
+env:
+  GO111MODULE=on
 
 cache:
   directories:
@@ -20,14 +24,12 @@ before_script:
   - go get github.com/shurcooL/httpfs/union || true
   - go get github.com/urfave/gfmrun/... || true
   - go get golang.org/x/tools/cmd/goimports
-  - if [ ! -f node_modules/.bin/markdown-toc ] ; then
-      npm install markdown-toc ;
-    fi
+  - npm install markdown-toc
 
 script:
   - go run build.go generate
   - go run build.go vet
-  - go run build.go test
+  - go run build.go testm
   - go run build.go gfmrun
   - go run build.go toc
 

--- a/docs.go
+++ b/docs.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/cpuguy83/go-md2man/md2man"
+	"github.com/cpuguy83/go-md2man/v2/md2man"
 )
 
 // ToMarkdown creates a markdown string for the `*App`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/urfave/cli
 
-go 1.10
+go 1.11
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.10
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/cpuguy83/go-md2man v1.0.10
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
-github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
-github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
In line with Go's release policy, dropping support for Go 1.10 and adding support for Go 1.13