### PR TITLE
Avoid panic for missing flag value

### DIFF
--- a/app.go
+++ b/app.go
@@ -199,12 +199,12 @@ func (a *App) Run(arguments []string) (err error) {
 	// always appends the completion flag at the end of the command
 	shellComplete, arguments := checkShellCompleteFlag(a, arguments)
 
-	_, err = a.newFlagSet()
+	set, err := a.newFlagSet()
 	if err != nil {
 		return err
 	}
 
-	set, err := parseIter(a, arguments[1:])
+	err = parseIter(set, a, arguments[1:])
 	nerr := normalizeFlags(a.Flags, set)
 	context := NewContext(a, set, nil)
 	if nerr != nil {
@@ -322,12 +322,12 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	}
 	a.Commands = newCmds
 
-	_, err = a.newFlagSet()
+	set, err := a.newFlagSet()
 	if err != nil {
 		return err
 	}
 
-	set, err := parseIter(a, ctx.Args().Tail())
+	err = parseIter(set, a, ctx.Args().Tail())
 	nerr := normalizeFlags(a.Flags, set)
 	context := NewContext(a, set, ctx)
 

--- a/app_test.go
+++ b/app_test.go
@@ -659,6 +659,17 @@ func TestApp_UseShortOptionHandling(t *testing.T) {
 	expect(t, name, expected)
 }
 
+func TestApp_UseShortOptionHandling_missing_value(t *testing.T) {
+	app := NewApp()
+	app.UseShortOptionHandling = true
+	app.Flags = []Flag{
+		StringFlag{Name: "name, n"},
+	}
+
+	err := app.Run([]string{"", "-n"})
+	expect(t, err, errors.New("flag needs an argument: -n"))
+}
+
 func TestApp_UseShortOptionHandlingCommand(t *testing.T) {
 	var one, two bool
 	var name string
@@ -686,6 +697,21 @@ func TestApp_UseShortOptionHandlingCommand(t *testing.T) {
 	expect(t, one, true)
 	expect(t, two, false)
 	expect(t, name, expected)
+}
+
+func TestApp_UseShortOptionHandlingCommand_missing_value(t *testing.T) {
+	app := NewApp()
+	app.UseShortOptionHandling = true
+	command := Command{
+		Name: "cmd",
+		Flags: []Flag{
+			StringFlag{Name: "name, n"},
+		},
+	}
+	app.Commands = []Command{command}
+
+	err := app.Run([]string{"", "cmd", "-n"})
+	expect(t, err, errors.New("flag needs an argument: -n"))
 }
 
 func TestApp_UseShortOptionHandlingSubCommand(t *testing.T) {
@@ -720,6 +746,25 @@ func TestApp_UseShortOptionHandlingSubCommand(t *testing.T) {
 	expect(t, one, true)
 	expect(t, two, false)
 	expect(t, name, expected)
+}
+
+func TestApp_UseShortOptionHandlingSubCommand_missing_value(t *testing.T) {
+	app := NewApp()
+	app.UseShortOptionHandling = true
+	command := Command{
+		Name: "cmd",
+	}
+	subCommand := Command{
+		Name: "sub",
+		Flags: []Flag{
+			StringFlag{Name: "name, n"},
+		},
+	}
+	command.Subcommands = []Command{subCommand}
+	app.Commands = []Command{command}
+
+	err := app.Run([]string{"", "cmd", "sub", "-n"})
+	expect(t, err, errors.New("flag needs an argument: -n"))
 }
 
 func TestApp_Float64Flag(t *testing.T) {

--- a/command.go
+++ b/command.go
@@ -193,7 +193,12 @@ func (c *Command) parseFlags(args Args) (*flag.FlagSet, error) {
 		args = reorderArgs(args)
 	}
 
-	set, err := parseIter(c, args)
+	set, err := c.newFlagSet()
+	if err != nil {
+		return nil, err
+	}
+
+	err = parseIter(set, c, args)
 	if err != nil {
 		return nil, err
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -70,29 +70,34 @@ func TestParseAndRunShortOpts(t *testing.T) {
 		{[]string{"foo", "test", "-af"}, nil, []string{}},
 		{[]string{"foo", "test", "-cf"}, nil, []string{}},
 		{[]string{"foo", "test", "-acf"}, nil, []string{}},
-		{[]string{"foo", "test", "-invalid"}, errors.New("flag provided but not defined: -invalid"), []string{}},
+		{[]string{"foo", "test", "-invalid"}, errors.New("flag provided but not defined: -invalid"), nil},
 		{[]string{"foo", "test", "-acf", "arg1", "-invalid"}, nil, []string{"arg1", "-invalid"}},
-	}
-
-	var args []string
-	cmd := Command{
-		Name:        "test",
-		Usage:       "this is for testing",
-		Description: "testing",
-		Action: func(c *Context) error {
-			args = c.Args()
-			return nil
-		},
-		SkipArgReorder:         true,
-		UseShortOptionHandling: true,
-		Flags: []Flag{
-			BoolFlag{Name: "abc, a"},
-			BoolFlag{Name: "cde, c"},
-			BoolFlag{Name: "fgh, f"},
-		},
+		{[]string{"foo", "test", "-acfi", "not-arg", "arg1", "-invalid"}, nil, []string{"arg1", "-invalid"}},
+		{[]string{"foo", "test", "-i", "ivalue"}, nil, []string{}},
+		{[]string{"foo", "test", "-i", "ivalue", "arg1"}, nil, []string{"arg1"}},
+		{[]string{"foo", "test", "-i"}, errors.New("flag needs an argument: -i"), nil},
 	}
 
 	for _, c := range cases {
+		var args []string
+		cmd := Command{
+			Name:        "test",
+			Usage:       "this is for testing",
+			Description: "testing",
+			Action: func(c *Context) error {
+				args = c.Args()
+				return nil
+			},
+			SkipArgReorder:         true,
+			UseShortOptionHandling: true,
+			Flags: []Flag{
+				BoolFlag{Name: "abc, a"},
+				BoolFlag{Name: "cde, c"},
+				BoolFlag{Name: "fgh, f"},
+				StringFlag{Name: "ijk, i"},
+			},
+		}
+
 		app := NewApp()
 		app.Commands = []Command{cmd}
 


### PR DESCRIPTION
Currently, in cases where a flag value is required but not passed, and short option handling is enabled, a panic will occur due to a nil pointer dereference. This prevents that situation from occurring, instead propagating the appropriate flag-parsing error.

Small example to reproduce issue:
```go
package main

import (
	"os"

	"github.com/urfave/cli"
)

func main() {
	app := cli.NewApp()
	app.UseShortOptionHandling = true
	app.Flags = []cli.Flag{
		cli.StringFlag{Name: "flag"},
	}
	app.Run(os.Args)
}
```

Before:

```
$ ./simple-app --flag
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x10d5d42]
...
```

After:

```
$ ./simple-app --flag
Incorrect Usage. flag needs an argument: -flag

NAME:
   simple-app - A new cli application

USAGE:
   simple-app [global options] command [command options] [arguments...]

VERSION:
   0.0.0

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --flag value
   --help, -h     show help
   --version, -v  print the version
```