### PR TITLE
Improve docs generation for cli.Authors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.coverprofile
+*.orig
 node_modules/
 vendor

--- a/docs_test.go
+++ b/docs_test.go
@@ -64,7 +64,10 @@ func testApp() *App {
 	}}
 	app.UsageText = "app [first_arg] [second_arg]"
 	app.Usage = "Some app"
-	app.Authors = []*Author{{Name: "Harrison", Email: "harrison@lolwut.com"}}
+	app.Authors = []*Author{
+		{Name: "Harrison", Email: "harrison@lolwut.com"},
+		{Name: "Oliver Allen", Email: "oliver@toyshop.com"},
+	}
 	return app
 }
 
@@ -110,6 +113,19 @@ func TestToMarkdownNoCommands(t *testing.T) {
 	// Then
 	expect(t, err, nil)
 	expectFileContent(t, "testdata/expected-doc-no-commands.md", res)
+}
+
+func TestToMarkdownNoAuthors(t *testing.T) {
+	// Given
+	app := testApp()
+	app.Authors = []*Author{}
+
+	// When
+	res, err := app.ToMarkdown()
+
+	// Then
+	expect(t, err, nil)
+	expectFileContent(t, "testdata/expected-doc-no-authors.md", res)
 }
 
 func TestToMan(t *testing.T) {

--- a/template.go
+++ b/template.go
@@ -71,10 +71,9 @@ OPTIONS:
    {{end}}{{end}}
 `
 
-var MarkdownDocTemplate = `% {{ .App.Name }}(8) {{ .App.Description }}
-{{ range $Author := .App.Authors}}
-% {{ $Author.Name }}
-{{- end}}
+var MarkdownDocTemplate = `% {{ .App.Name }}(8){{ if .App.Description }} {{ .App.Description }}{{ end }}
+{{ range $a := .App.Authors }}
+% {{ $a }}{{ end }}
 
 # NAME
 

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -1,7 +1,10 @@
 .nh
-.TH greet(8) 
+.TH greet(8)
 
-.SH Harrison
+.SH Harrison harrison@lolwut.com
+\[la]mailto:harrison@lolwut.com\[ra]
+Oliver Allen oliver@toyshop.com
+\[la]mailto:oliver@toyshop.com\[ra]
 
 .SH NAME
 .PP

--- a/testdata/expected-doc-no-authors.md
+++ b/testdata/expected-doc-no-authors.md
@@ -1,7 +1,5 @@
 % greet(8)
 
-% Harrison <harrison@lolwut.com>
-% Oliver Allen <oliver@toyshop.com>
 
 # NAME
 

--- a/testdata/expected-doc-no-commands.md
+++ b/testdata/expected-doc-no-commands.md
@@ -1,6 +1,7 @@
-% greet(8) 
+% greet(8)
 
-% Harrison
+% Harrison <harrison@lolwut.com>
+% Oliver Allen <oliver@toyshop.com>
 
 # NAME
 

--- a/testdata/expected-doc-no-flags.md
+++ b/testdata/expected-doc-no-flags.md
@@ -1,6 +1,7 @@
-% greet(8) 
+% greet(8)
 
-% Harrison
+% Harrison <harrison@lolwut.com>
+% Oliver Allen <oliver@toyshop.com>
 
 # NAME
 


### PR DESCRIPTION
This allows specifying multiple authors, whereas no available authors
will be formatted correctly now.
