### PR TITLE
Simplify HelpPrinter and CustomHelpPrinter behaviors

### DIFF
--- a/help.go
+++ b/help.go
@@ -187,7 +187,7 @@ func ShowCommandHelp(ctx *Context, command string) error {
 	for _, c := range ctx.App.Commands {
 		if c.HasName(command) {
 			if c.CustomHelpTemplate != "" {
-				HelpPrinterCustom(ctx.App.Writer, c.CustomHelpTemplate, c, nil)
+				HelpPrinter(ctx.App.Writer, c.CustomHelpTemplate, c)
 			} else {
 				HelpPrinter(ctx.App.Writer, CommandHelpTemplate, c)
 			}
@@ -261,7 +261,7 @@ func printHelpCustom(out io.Writer, templ string, data interface{}, customFunc m
 }
 
 func printHelp(out io.Writer, templ string, data interface{}) {
-	printHelpCustom(out, templ, data, nil)
+	HelpPrinterCustom(out, templ, data, nil)
 }
 
 func checkVersion(c *Context) bool {

--- a/help.go
+++ b/help.go
@@ -47,13 +47,15 @@ type helpPrinter func(w io.Writer, templ string, data interface{})
 // Prints help for the App or Command with custom template function.
 type helpPrinterCustom func(w io.Writer, templ string, data interface{}, customFunc map[string]interface{})
 
-// HelpPrinter is a function that writes the help output. If not set a default
-// is used. The function signature is:
-// func(w io.Writer, templ string, data interface{})
+// HelpPrinter is a function that writes the help output. If not set explicitly,
+// this calls HelpPrinterCustom using only the default template functions.
 var HelpPrinter helpPrinter = printHelp
 
-// HelpPrinterCustom is same as HelpPrinter but
-// takes a custom function for template function map.
+// HelpPrinterCustom is a function that writes the help output. If not set
+// explicitly, a default is used.
+//
+// The customFuncs map will be combined with a default template.FuncMap to
+// allow using arbitrary functions in template rendering.
 var HelpPrinterCustom helpPrinterCustom = printHelpCustom
 
 // VersionPrinter prints the version for the App
@@ -240,11 +242,11 @@ func ShowCommandCompletions(ctx *Context, command string) {
 
 }
 
-func printHelpCustom(out io.Writer, templ string, data interface{}, customFunc map[string]interface{}) {
+func printHelpCustom(out io.Writer, templ string, data interface{}, customFuncs map[string]interface{}) {
 	funcMap := template.FuncMap{
 		"join": strings.Join,
 	}
-	for key, value := range customFunc {
+	for key, value := range customFuncs {
 		funcMap[key] = value
 	}
 

--- a/help.go
+++ b/help.go
@@ -186,11 +186,13 @@ func ShowCommandHelp(ctx *Context, command string) error {
 
 	for _, c := range ctx.App.Commands {
 		if c.HasName(command) {
-			if c.CustomHelpTemplate != "" {
-				HelpPrinter(ctx.App.Writer, c.CustomHelpTemplate, c)
-			} else {
-				HelpPrinter(ctx.App.Writer, CommandHelpTemplate, c)
+			templ := c.CustomHelpTemplate
+			if templ == "" {
+				templ = CommandHelpTemplate
 			}
+
+			HelpPrinter(ctx.App.Writer, templ, c)
+
 			return nil
 		}
 	}

--- a/help_test.go
+++ b/help_test.go
@@ -295,6 +295,7 @@ func TestShowCommandHelp_HelpPrinter(t *testing.T) {
 		})
 	}
 }
+
 func TestShowCommandHelp_HelpPrinterCustom(t *testing.T) {
 	doublecho := func(text string) string {
 		return text + " " + text
@@ -547,6 +548,144 @@ func TestShowAppHelp_HiddenCommand(t *testing.T) {
 
 	if !strings.Contains(output.String(), "frobbly") {
 		t.Errorf("expected output to include \"frobbly\"; got: %q", output.String())
+	}
+}
+
+func TestShowAppHelp_HelpPrinter(t *testing.T) {
+	doublecho := func(text string) string {
+		return text + " " + text
+	}
+
+	tests := []struct {
+		name         string
+		template     string
+		printer      helpPrinter
+		wantTemplate string
+		wantOutput   string
+	}{
+		{
+			name:     "standard-command",
+			template: "",
+			printer: func(w io.Writer, templ string, data interface{}) {
+				fmt.Fprint(w, "yo")
+			},
+			wantTemplate: AppHelpTemplate,
+			wantOutput:   "yo",
+		},
+		{
+			name:     "custom-template-command",
+			template: "{{doublecho .Name}}",
+			printer: func(w io.Writer, templ string, data interface{}) {
+				// Pass a custom function to ensure it gets used
+				fm := map[string]interface{}{"doublecho": doublecho}
+				printHelpCustom(w, templ, data, fm)
+			},
+			wantTemplate: "{{doublecho .Name}}",
+			wantOutput:   "my-app my-app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func(old helpPrinter) {
+				HelpPrinter = old
+			}(HelpPrinter)
+			HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+				if templ != tt.wantTemplate {
+					t.Errorf("want template:\n%s\ngot template:\n%s", tt.wantTemplate, templ)
+				}
+
+				tt.printer(w, templ, data)
+			}
+
+			var buf bytes.Buffer
+			app := &App{
+				Name:                  "my-app",
+				Writer:                &buf,
+				CustomAppHelpTemplate: tt.template,
+			}
+
+			err := app.Run([]string{"my-app", "help"})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := buf.String()
+			if got != tt.wantOutput {
+				t.Errorf("want output %q, got %q", tt.wantOutput, got)
+			}
+		})
+	}
+}
+
+func TestShowAppHelp_HelpPrinterCustom(t *testing.T) {
+	doublecho := func(text string) string {
+		return text + " " + text
+	}
+
+	tests := []struct {
+		name         string
+		template     string
+		printer      helpPrinterCustom
+		wantTemplate string
+		wantOutput   string
+	}{
+		{
+			name:     "standard-command",
+			template: "",
+			printer: func(w io.Writer, templ string, data interface{}, fm map[string]interface{}) {
+				fmt.Fprint(w, "yo")
+			},
+			wantTemplate: AppHelpTemplate,
+			wantOutput:   "yo",
+		},
+		{
+			name:     "custom-template-command",
+			template: "{{doublecho .Name}}",
+			printer: func(w io.Writer, templ string, data interface{}, _ map[string]interface{}) {
+				// Pass a custom function to ensure it gets used
+				fm := map[string]interface{}{"doublecho": doublecho}
+				printHelpCustom(w, templ, data, fm)
+			},
+			wantTemplate: "{{doublecho .Name}}",
+			wantOutput:   "my-app my-app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func(old helpPrinterCustom) {
+				HelpPrinterCustom = old
+			}(HelpPrinterCustom)
+			HelpPrinterCustom = func(w io.Writer, templ string, data interface{}, fm map[string]interface{}) {
+				if fm != nil {
+					t.Error("unexpected function map passed")
+				}
+
+				if templ != tt.wantTemplate {
+					t.Errorf("want template:\n%s\ngot template:\n%s", tt.wantTemplate, templ)
+				}
+
+				tt.printer(w, templ, data, fm)
+			}
+
+			var buf bytes.Buffer
+			app := &App{
+				Name:                  "my-app",
+				Writer:                &buf,
+				CustomAppHelpTemplate: tt.template,
+			}
+
+			err := app.Run([]string{"my-app", "help"})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := buf.String()
+			if got != tt.wantOutput {
+				t.Errorf("want output %q, got %q", tt.wantOutput, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Currently, the structure of`HelpPrinter` and `HelpPrinterCustom` make them extremely difficult to use correctly. 

As it stands:
- For any app configuration, `HelpPrinter` will be used most of the time. For most applications, it will be used 100% of the time.
- Specifically when printing app help or command help for an application when the command's `CustomHelpTemplate` is set, `HelpPrinterCustom` will be used. Any other time, `HelpPrinter` will continue to be used.
- While the default `HelpPrinter` simply makes a call to the default `HelpPrinterCustom`, it calls the private version of that function. This means if `HelpPrinterCustom` is overridden, `HelpPrinter` must _also_ be set in order to get consistent behavior across the application.

As an example, in an application that needs no custom behavior other than passing one additional custom template function, the easiest way I could find to get a consistent print behavior was to first wrap the original custom help printer, then assign to _both_ `HelpPrinter` and `HelpPrinterCustom`:
```go
func init() {
	// These are both sometimes used, so both must be overridden
	cli.HelpPrinterCustom = wrapPrinter(cli.HelpPrinterCustom)
	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
		cli.HelpPrinterCustom(w, templ, data, nil)
	}
}

// helpPrinter includes the custom indent template function.
func wrapPrinter(p helpPrinterCustom) helpPrinterCustom {
	return func(w io.Writer, tpl string, data interface{}, customFuncs map[string]interface{}) {
		// The exact function used here is just an example
		customFuncs["indent"] = func(spaces int, text string) string {
			padding := strings.Repeat(" ", spaces)
			return padding + strings.ReplaceAll(text, "\n", "\n"+padding)
		}

		// And now we defer back to the original function call
		p(w, tpl, data, customFuncs)
	}
}
```

The fix in this PR does a few things that should make things more consistent and harder to misuse. 

Since I don't think there's a good justification for the inconsistent calling of `HelpPrinterCustom` in one of the specific places where it happens to be used, I've replaced it with the higher-level `HelpPrinter` call, which by default will defer to `HelpPrinterCustom`. In the one place where it was actually required, the logic has been updated to prefer `HelpPrinter` except in the _exact_ case which `HelpPrinterCustom` was written to fulfill.

As well, the default `PrintHelp` function now calls the _public_ version of `PrintHelpCustom`, so if that is overridden, users don't also have to override `PrintHelp` for the change to propagate.

Combining these changes means that you can override either `HelpPrinter` or `HelpPrinterCustom` as necessary, and still get consistent behavior between printing app help, command help, and sub-command help, regardless of whether or not you're using a custom template. The default behavior is exactly the same as it was before.

I think this is the correct fix, but I figured it would be easier to get code out for discussion rather than opening an issue. Happy to make changes if need be.

---

**TL;DR**: `HelpPrinter` and `HelpPrinterCustom` were called interchangeably based on logic that didn't really make sense from a public interface perspective. Two changes:
- `HelpPrinter` now directly calls `HelpPrinterCustom` instead of just having the same implementation, so you don't have to override both if you override `HelpPrinterCustom`.
- Since `HelpPrinter` is just a wrapper around `HelpPrinterCustom`, only call `HelpPrinterCustom` directly in the one situation where we absolutely have to (see https://github.com/urfave/cli/pull/586 for context)