### PR TITLE
typo: fix wrong url in readme for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage documentation exists for each major version. Don't know what version you'r
 **Warning**: `v2` is in a beta state.
 
 ```
-$ go get github.com/urfave/cli.v2
+$ go get github.com/urfave/cli/v2
 ```
 
 ```go


### PR DESCRIPTION
Repo not found for `github.com/urfave/cli.v2`
```
→ go get github.com/urfave/cli.v2
go get github.com/urfave/cli.v2: git ls-remote -q origin in $GOPATH/pkg/mod/cache/vcs/f2d73ffea2d87a2720e81700b9dcf7285d8c2e5750a4b4c55dff989e537a7c8e: exit status 128:
        remote: Repository not found.
        fatal: repository 'https://github.com/urfave/cli.v2/' not found
```

Correct path `github.com/urfave/cli/v2`
```
→ go get github.com/urfave/cli/v2
go: finding github.com/urfave/cli/v2 v2.0.0-alpha.2
go: downloading github.com/urfave/cli/v2 v2.0.0-alpha.2
go: extracting github.com/urfave/cli/v2 v2.0.0-alpha.2
```

Was changed in this commit https://github.com/urfave/cli/commit/4545ff3aa17882cf7f3b682eb09086a88abbe60a#diff-04c6e90faac2675aa89e2176d2eec7d8R28

cc @lynncyrin