### PR TITLE
Ask for version when making bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/v1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/v1-bug-report.md
@@ -7,6 +7,10 @@ assignees: lynncyrin
 
 ---
 
+## my urfave/cli version is
+
+_**( Put the version of urfave/cli that you are using here )**_
+
 ## Checklist
 
 * [ ] Are you running the latest v1 release? The list of releases is [here](https://github.com/urfave/cli/releases).

--- a/.github/ISSUE_TEMPLATE/v2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/v2-bug-report.md
@@ -7,6 +7,10 @@ assignees: ''
 
 ---
 
+## my urfave/cli version is
+
+_**( Put the version of urfave/cli that you are using here )**_
+
 ## Checklist
 
 * [ ] Are you running the latest v2 release? The list of releases is [here](https://github.com/urfave/cli/releases).


### PR DESCRIPTION
I noticed that this issue https://github.com/urfave/cli/issues/949 would be dramatically easier for me to debug if the user had mentioned what version of the library they're using.