### PR TITLE
Recieve and handle ctrl + c and exit application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.orig
 node_modules/
 vendor
+.idea

--- a/app.go
+++ b/app.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -119,7 +118,7 @@ func NewApp() *App {
 		Action:           helpCommand.Action,
 		Compiled:         compileTime(),
 		Writer:           os.Stdout,
-		InterruptHandler: func(*Context, context.CancelFunc) {},
+		InterruptHandler: CancelContextOnInterrupt,
 	}
 }
 
@@ -158,7 +157,7 @@ func (a *App) Setup() {
 	}
 
 	if a.InterruptHandler == nil {
-		a.InterruptHandler = func(*Context, context.CancelFunc) {}
+		a.InterruptHandler = CancelContextOnInterrupt
 	}
 
 	if a.Compiled == (time.Time{}) {

--- a/app.go
+++ b/app.go
@@ -119,6 +119,7 @@ func NewApp() *App {
 		Action:       helpCommand.Action,
 		Compiled:     compileTime(),
 		Writer:       os.Stdout,
+		InterruptHandlerFunc: func(c *Context) {},
 	}
 }
 
@@ -154,6 +155,10 @@ func (a *App) Setup() {
 
 	if a.Action == nil {
 		a.Action = helpCommand.Action
+	}
+
+	if a.InterruptHandlerFunc == nil {
+		a.InterruptHandlerFunc = func(context *Context) {}
 	}
 
 	if a.Compiled == (time.Time{}) {

--- a/app.go
+++ b/app.go
@@ -88,6 +88,10 @@ type App struct {
 	// single-character bool arguments into one
 	// i.e. foobar -o -v -> foobar -ov
 	UseShortOptionHandling bool
+	// This function is automatically executed when the context is cancelled due to the program
+	// receiving an interrupt signal (Control+C). This function can be overridden to implement
+	// desired behaviour in such a scenario
+	InterruptHandlerFunc InterruptHandlerFunc
 
 	didSetup bool
 }

--- a/app.go
+++ b/app.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -91,7 +92,7 @@ type App struct {
 	// This function is automatically executed when the context is cancelled due to the program
 	// receiving an interrupt signal (Control+C). This function can be overridden to implement
 	// desired behaviour in such a scenario
-	InterruptHandlerFunc InterruptHandlerFunc
+	InterruptHandler InterruptHandlerFunc
 
 	didSetup bool
 }
@@ -110,15 +111,15 @@ func compileTime() time.Time {
 // Usage, Version and Action.
 func NewApp() *App {
 	return &App{
-		Name:         filepath.Base(os.Args[0]),
-		HelpName:     filepath.Base(os.Args[0]),
-		Usage:        "A new cli application",
-		UsageText:    "",
-		BashComplete: DefaultAppComplete,
-		Action:       helpCommand.Action,
-		Compiled:     compileTime(),
-		Writer:       os.Stdout,
-		InterruptHandlerFunc: func(c *Context) {},
+		Name:             filepath.Base(os.Args[0]),
+		HelpName:         filepath.Base(os.Args[0]),
+		Usage:            "A new cli application",
+		UsageText:        "",
+		BashComplete:     DefaultAppComplete,
+		Action:           helpCommand.Action,
+		Compiled:         compileTime(),
+		Writer:           os.Stdout,
+		InterruptHandler: func(*Context, context.CancelFunc) {},
 	}
 }
 
@@ -156,8 +157,8 @@ func (a *App) Setup() {
 		a.Action = helpCommand.Action
 	}
 
-	if a.InterruptHandlerFunc == nil {
-		a.InterruptHandlerFunc = func(context *Context) {}
+	if a.InterruptHandler == nil {
+		a.InterruptHandler = func(*Context, context.CancelFunc) {}
 	}
 
 	if a.Compiled == (time.Time{}) {

--- a/context.go
+++ b/context.go
@@ -40,7 +40,7 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
 		go func() {
 			// wait for context cancellation
 			<-ctx.Done()
-			os.Exit(1)
+			app.InterruptHandlerFunc(c)
 		}()
 		go func() {
 			defer cancel()

--- a/context.go
+++ b/context.go
@@ -38,10 +38,15 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
 	if c.Context == nil {
 		ctx, cancel := context.WithCancel(context.Background())
 		go func() {
+			// wait for context cancellation
+			<-ctx.Done()
+			os.Exit(1)
+		}()
+		go func() {
 			defer cancel()
-			sigs := make(chan os.Signal, 1)
-			signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-			<-sigs
+			signals := make(chan os.Signal, 1)
+			signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+			<-signals
 		}()
 		c.Context = ctx
 	}

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -18,7 +18,7 @@ cli v2 manual
   * [Subcommands](#subcommands)
   * [Subcommands categories](#subcommands-categories)
   * [Exit code](#exit-code)
-  * [Handling Interrupts](handling-interrupts)
+  * [Handling Interrupts](#handling-interrupts)
   * [Combining short options](#combining-short-options)
   * [Bash Completion](#bash-completion)
     + [Enabling](#enabling)

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -18,6 +18,7 @@ cli v2 manual
   * [Subcommands](#subcommands)
   * [Subcommands categories](#subcommands-categories)
   * [Exit code](#exit-code)
+  * [Handling Interrupts](handling-interrupts)
   * [Combining short options](#combining-short-options)
   * [Bash Completion](#bash-completion)
     + [Enabling](#enabling)
@@ -865,6 +866,46 @@ func main() {
   }
 }
 ```
+
+### Handling Interrupts
+
+This library supports customized handling of application behaviour when an interrupt signal (ctrl+c) is received. To control this behaviour, you can define the application's `InterruptHandler` function as shown below:
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	app := &cli.App{
+		Name:  "long",
+		Usage: "this takes a lot of time!",
+		Action: func(c *cli.Context) error {
+			fmt.Println("working...")
+			time.Sleep(10 * time.Second)
+			return nil
+		},
+	}
+
+	app.InterruptHandlerFunc = func(c *cli.Context) {
+		fmt.Println("received interrupt")
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+By default, this function does not do anything. It is the user's responsiblity to implement this function to define appropriate behaviour for their application.
 
 ### Combining short options
 

--- a/funcs.go
+++ b/funcs.go
@@ -43,6 +43,6 @@ type FlagEnvHintFunc func(envVars []string, str string) string
 // with the file path details.
 type FlagFileHintFunc func(filePath, str string) string
 
-// InterruptHandler is used to define the behaviour when a program is interrupted
+// InterruptHandlerFunc is used to define the behaviour when a program is interrupted
 // using Control+C
 type InterruptHandlerFunc func(*Context)

--- a/funcs.go
+++ b/funcs.go
@@ -1,5 +1,7 @@
 package cli
 
+import "context"
+
 // BashCompleteFunc is an action to execute when the shell completion flag is set
 type BashCompleteFunc func(*Context)
 
@@ -43,6 +45,6 @@ type FlagEnvHintFunc func(envVars []string, str string) string
 // with the file path details.
 type FlagFileHintFunc func(filePath, str string) string
 
-// InterruptHandlerFunc is used to define the behaviour when a program is interrupted
+// InterruptHandler is used to define the behaviour when a program is interrupted
 // using Control+C
-type InterruptHandlerFunc func(*Context)
+type InterruptHandlerFunc func(*Context, context.CancelFunc)

--- a/funcs.go
+++ b/funcs.go
@@ -42,3 +42,7 @@ type FlagEnvHintFunc func(envVars []string, str string) string
 // FlagFileHintFunc is used by the default FlagStringFunc to annotate flag help
 // with the file path details.
 type FlagFileHintFunc func(filePath, str string) string
+
+// InterruptHandlerFunc is used to define the behaviour when a program is interrupted
+// using Control+C
+type InterruptHandlerFunc func(*Context)

--- a/funcs.go
+++ b/funcs.go
@@ -1,7 +1,5 @@
 package cli
 
-import "context"
-
 // BashCompleteFunc is an action to execute when the shell completion flag is set
 type BashCompleteFunc func(*Context)
 
@@ -47,4 +45,4 @@ type FlagFileHintFunc func(filePath, str string) string
 
 // InterruptHandler is used to define the behaviour when a program is interrupted
 // using Control+C
-type InterruptHandlerFunc func(*Context, context.CancelFunc)
+type InterruptHandlerFunc func(*Context)

--- a/interrupt-handlers.go
+++ b/interrupt-handlers.go
@@ -1,0 +1,1 @@
+package cli

--- a/interrupt-handlers.go
+++ b/interrupt-handlers.go
@@ -1,1 +1,13 @@
 package cli
+
+import "os"
+
+var ExitOnInterrupt InterruptHandlerFunc = func(ctx *Context) {
+	CancelContextOnInterrupt(ctx)
+	<-ctx.Done()
+	os.Exit(1)
+}
+
+var CancelContextOnInterrupt InterruptHandlerFunc = func(ctx *Context) {
+	ctx.Cancel()
+}


### PR DESCRIPTION
Fixes #945 

We were correctly receiving `ctrl+c` signal and cancelling our application context. The missing piece of the puzzle was not listening for context cancellation and exiting the program.

Since `ctrl+c` is a non standard program termination, I have used a non zero exit code i.e. 1 for the moment. Please let me know if we want to give the user an option to set a exit code themselves in case of `ctrl+c` exit. We can then add an option in the `App` for that then.