### PR TITLE
Hide version info if user has not defined version [v2]

### DIFF
--- a/app.go
+++ b/app.go
@@ -110,7 +110,6 @@ func NewApp() *App {
 		HelpName:     filepath.Base(os.Args[0]),
 		Usage:        "A new cli application",
 		UsageText:    "",
-		Version:      "0.0.0",
 		BashComplete: DefaultAppComplete,
 		Action:       helpCommand.Action,
 		Compiled:     compileTime(),
@@ -141,7 +140,7 @@ func (a *App) Setup() {
 	}
 
 	if a.Version == "" {
-		a.Version = "0.0.0"
+		a.HideVersion = true
 	}
 
 	if a.BashComplete == nil {

--- a/app_test.go
+++ b/app_test.go
@@ -192,15 +192,11 @@ func ExampleApp_Run_noAction() {
 	// USAGE:
 	//    greet [global options] command [command options] [arguments...]
 	//
-	// VERSION:
-	//    0.0.0
-	//
 	// COMMANDS:
 	//    help, h  Shows a list of commands or help for one command
 	//
 	// GLOBAL OPTIONS:
-	//    --help, -h     show help (default: false)
-	//    --version, -v  print the version (default: false)
+	//    --help, -h  show help (default: false)
 }
 
 func ExampleApp_Run_subcommandNoAction() {
@@ -256,8 +252,6 @@ func ExampleApp_Run_bashComplete_withShortFlag() {
 	// -x
 	// --help
 	// -h
-	// --version
-	// -v
 }
 
 func ExampleApp_Run_bashComplete_withLongFlag() {

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -154,14 +154,11 @@ NAME:
 USAGE:
     greet [global options] command [command options] [arguments...]
 
-VERSION:
-    0.0.0
-
 COMMANDS:
     help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS
-    --version Shows version information
+    --help, -h  show help (default: false)
 ```
 
 ### Arguments


### PR DESCRIPTION
Fixes #248 and #524 

Changes
- Do not set default version
- `HideVersion` is now` true` if the user does not define flag