### PR TITLE
Remove v2 beta warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Usage documentation exists for each major version. Don't know what version you'r
 
 ### Using `v2` releases
 
-**Warning**: `v2` is in a beta state.
-
 ```
 $ go get github.com/urfave/cli/v2
 ```


### PR DESCRIPTION
created as an alternative to https://github.com/urfave/cli/pull/940