### PR TITLE
Add GO111MODULE=on to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage documentation exists for each major version. Don't know what version you'r
 **Warning**: `v2` is in a beta state.
 
 ```
-$ go get github.com/urfave/cli/v2
+$ GO111MODULE=on go get github.com/urfave/cli/v2
 ```
 
 ```go


### PR DESCRIPTION
Discovered via https://github.com/urfave/cli/issues/957 and the research I did for https://github.com/urfave/cli/issues/952, `GO111MODULE=on` is required for some users when downloading v2.