### PR TITLE
Ask users for `go list ...` output

### DIFF
--- a/.github/ISSUE_TEMPLATE/v1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/v1-bug-report.md
@@ -7,10 +7,6 @@ assignees: lynncyrin
 
 ---
 
-## my urfave/cli version is
-
-_**( Put the version of urfave/cli that you are using here )**_
-
 ## Checklist
 
 * [ ] Are you running the latest v1 release? The list of releases is [here](https://github.com/urfave/cli/releases).
@@ -58,4 +54,10 @@ We'd love to have more contributors on this project! If the fix for this bug is 
 
 ```
 # paste `go env` output in here
+```
+
+## Run `go list -u -m all` and paste its output here
+
+```
+# paste `go list -u -m all` output in here
 ```

--- a/.github/ISSUE_TEMPLATE/v2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/v2-bug-report.md
@@ -47,6 +47,7 @@ If you can reproduce this issue with a public CI system, please link a failing b
 ## Want to fix this yourself?
 
 We'd love to have more contributors on this project! If the fix for this bug is easily explained and very small, free free to create a pull request for it.
+
 ## Run `go version` and paste its output here
 
 ```
@@ -57,4 +58,10 @@ We'd love to have more contributors on this project! If the fix for this bug is 
 
 ```
 # paste `go env` output in here
+```
+
+## Run `go list -u -m all` and paste its output here
+
+```
+# paste `go list -u -m all` output in here
 ```

--- a/.github/ISSUE_TEMPLATE/v2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/v2-bug-report.md
@@ -7,10 +7,6 @@ assignees: ''
 
 ---
 
-## my urfave/cli version is
-
-_**( Put the version of urfave/cli that you are using here )**_
-
 ## Checklist
 
 * [ ] Are you running the latest v2 release? The list of releases is [here](https://github.com/urfave/cli/releases).


### PR DESCRIPTION
I noticed via these two issues https://github.com/urfave/cli/issues/964, https://github.com/urfave/cli/issues/957 that people are liking to just say "v1" or "v2" which sometimes won't be enough detail. Other times, it won't be correct!

So I've changed the issue template to instead prompt for `go list -u -m all`, which looks like this

```
❯ go list -u -m all
go: finding github.com/cpuguy83/go-md2man/v2 v2.0.0
go: finding gopkg.in/check.v1 latest
go: finding gopkg.in/yaml.v2 v2.2.7
github.com/urfave/cli/v2
github.com/BurntSushi/toml v0.3.1
github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d [v2.0.0]
github.com/pmezard/go-difflib v1.0.0
github.com/russross/blackfriday/v2 v2.0.1
github.com/shurcooL/sanitized_anchor_name v1.0.0
gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 [v1.0.0-20190902080502-41f04d3bba15]
gopkg.in/yaml.v2 v2.2.2 [v2.2.7]
```

😍  beautiful! so much information!