### PR TITLE
Context is set fix v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.coverprofile
 node_modules/
 vendor
+.idea

--- a/context.go
+++ b/context.go
@@ -87,7 +87,9 @@ func (c *Context) IsSet(name string) bool {
 		for _, f := range flags {
 			eachName(f.GetName(), func(name string) {
 				if isSet, ok := c.setFlags[name]; isSet || !ok {
+					// Check if a flag is set
 					if isSet {
+						// If the flag is set, also set its other aliases
 						eachName(f.GetName(), func(name string) {
 							c.setFlags[name] = true
 						})

--- a/context.go
+++ b/context.go
@@ -87,6 +87,12 @@ func (c *Context) IsSet(name string) bool {
 		for _, f := range flags {
 			eachName(f.GetName(), func(name string) {
 				if isSet, ok := c.setFlags[name]; isSet || !ok {
+					if isSet {
+						eachName(f.GetName(), func(name string) {
+							c.setFlags[name] = true
+						})
+					}
+
 					return
 				}
 

--- a/context_test.go
+++ b/context_test.go
@@ -182,6 +182,51 @@ func TestContext_IsSet(t *testing.T) {
 	expect(t, c.IsSet("myflagGlobal"), false)
 }
 
+func TestContext_IsSet_ShortAndFull_FlagNames(t *testing.T) {
+	var (
+		numberIsSet, nIsSet bool
+		tempIsSet, tIsSet bool
+		usernameIsSet, uIsSet bool
+		debugIsSet, dIsSet bool
+	)
+
+	a := App {
+		Flags: []Flag{
+			IntFlag{Name: "number, n"},
+			Float64Flag{Name: "temp, t"},
+			StringFlag{Name: "username, u"},
+			BoolFlag{Name: "debug, d"},
+		},
+		Action: func(ctx *Context) error {
+			numberIsSet = ctx.IsSet("number")
+			nIsSet = ctx.IsSet("n")
+			tempIsSet = ctx.IsSet("temp")
+			tIsSet = ctx.IsSet("t")
+			usernameIsSet = ctx.IsSet("username")
+			uIsSet = ctx.IsSet("u")
+			debugIsSet = ctx.IsSet("debug")
+			dIsSet = ctx.IsSet("d")
+			return nil
+		},
+	}
+
+	tests := []struct {
+		args[]string
+	}{
+		{args: []string{"", "--number", "5", "--temp", "5.2", "--username", "ajitem", "--debug"}},
+		{args: []string{"", "-n", "5", "-t", "5.2", "-u", "ajitem", "-d"}},
+	}
+
+	for _, tt := range tests {
+		_ = a.Run(tt.args)
+
+		expect(t, numberIsSet == nIsSet, true)
+		expect(t, tempIsSet == tIsSet, true)
+		expect(t, usernameIsSet == uIsSet, true)
+		expect(t, debugIsSet == dIsSet, true)
+	}
+}
+
 // XXX Corresponds to hack in context.IsSet for flags with EnvVar field
 // Should be moved to `flag_test` in v2
 func TestContext_IsSet_fromEnv(t *testing.T) {


### PR DESCRIPTION
## Motivation

Partly fixes #790 

While the issue primarily talks about the inconsistent behavior of the `StringSliceFlag`, there is another bug report hidden there. Consider the following code:

```go
package main

import (
	"fmt"
	"log"
	"os"

	"github.com/urfave/cli"
)

func main() {
	app := cli.NewApp()
	app.Flags = []cli.Flag{
		cli.StringSliceFlag{
			Name: "Hostnames, n",
			Usage: "`HOSTNAME`s to listen to.",
			Value: &cli.StringSlice{"localhost"},
		},
	}
	app.Action = func(c *cli.Context) error {
		if c.IsSet("Hostnames") {
			// do something
		}

		if c.IsSet("n") {
			// do something else
		}

		return nil
	}

	err := app.Run(os.Args)
	if err != nil {
		log.Fatal()
	}
}
```

Suppose we are to execute this code using either `--Hostnames` or `-n`, we would expect both the `c.IsSet("Hostnames")` and `c.IsSet("n")` to return `true`. However, this is not the case. If we use the full flag name to initialize the flag but, pass the short name to `c.IsSet`, we get false. 

This behavior is also inconsistent with the `c.StringSlice` or any `c.FlagName` function that returns the correct value regardless of whether we pass the full name or the short name to it. This PR aims to fix this inconsistency.

## Release Notes

**[BUG FIX]** `context.IsSet()` returns `true` or `false` correctly regardless of whether the short name or the full name of the flag is passed to it.

## Changes

- `.gitignore`: Add `.idea` folder to list of ignored files. JetBrains IDEs like GoLand create this folder.
- `context.go`: Add additional code that checks if a particular flag is set and, if set, marks all the other aliases of the flag in the context.
- `context_test.go`: Test Cases 

## Testing

Added a unit test that sets the flags using both full names and short names alternatively and verifies the consistency of the `context.IsSet` output.