### PR TITLE
String slice issue v1

### DIFF
--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -137,24 +137,28 @@ func (c *Context) GlobalInt64Slice(name string) []int64 {
 func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
 	f := set.Lookup(name)
 	if f != nil {
-		parsed, err := (f.Value.(*Int64Slice)).Value(), error(nil)
-		if err != nil {
-			return nil
-		}
-		// extract default value from the flag
-		var defaultVal []int64
-		for _, v := range strings.Split(f.DefValue, ",") {
-			iV, _ := strconv.ParseInt(v, 10, 64)
-			defaultVal = append(defaultVal, iV)
-		}
-		// if the current value is not equal to the default value
-		// remove the default values from the flag
-		if !isInt64SliceEqual(parsed, defaultVal) {
-			for _, v := range defaultVal {
-				parsed = removeFromInt64Slice(parsed, v)
+		if value, ok := f.Value.(*Int64Slice); ok {
+			// extract the slice from asserted value
+			parsed := value.Value()
+
+			// extract default value from the flag
+			var defaultVal []int64
+			for _, v := range strings.Split(f.DefValue, ",") {
+				int64Value, err := strconv.ParseInt(v, 10, 64)
+				if err != nil {
+					panic(err)
+				}
+				defaultVal = append(defaultVal, int64Value)
 			}
+			// if the current value is not equal to the default value
+			// remove the default values from the flag
+			if !isInt64SliceEqual(parsed, defaultVal) {
+				for _, v := range defaultVal {
+					parsed = removeFromInt64Slice(parsed, v)
+				}
+			}
+			return parsed
 		}
-		return parsed
 	}
 	return nil
 }

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -159,17 +159,13 @@ func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
 	return nil
 }
 
-func removeFromInt64Slice(slice []int64, val int64) (newVal []int64) {
-	var count int
-	for _, v := range slice {
+func removeFromInt64Slice(slice []int64, val int64) []int64 {
+	for i, v := range slice {
 		if v == val {
-			newVal = slice[count+1:]
-			return
+			return append(slice[:i], slice[i+1:]...)
 		}
-		newVal = append(newVal, v)
-		count++
 	}
-	return
+	return slice
 }
 
 func isInt64SliceEqual(newValue, defaultValue []int64) bool {

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -137,28 +137,33 @@ func (c *Context) GlobalInt64Slice(name string) []int64 {
 func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
 	f := set.Lookup(name)
 	if f != nil {
-		if value, ok := f.Value.(*Int64Slice); ok {
-			// extract the slice from asserted value
-			parsed := value.Value()
+		value, ok := f.Value.(*Int64Slice)
+		if !ok {
+			return nil
+		}
 
-			// extract default value from the flag
-			var defaultVal []int64
-			for _, v := range strings.Split(f.DefValue, ",") {
+		// extract the slice from asserted value
+		parsed := value.Value()
+
+		// extract default value from the flag
+		var defaultVal []int64
+		for _, v := range strings.Split(f.DefValue, ",") {
+			if v != "" {
 				int64Value, err := strconv.ParseInt(v, 10, 64)
 				if err != nil {
 					panic(err)
 				}
 				defaultVal = append(defaultVal, int64Value)
 			}
-			// if the current value is not equal to the default value
-			// remove the default values from the flag
-			if !isInt64SliceEqual(parsed, defaultVal) {
-				for _, v := range defaultVal {
-					parsed = removeFromInt64Slice(parsed, v)
-				}
-			}
-			return parsed
 		}
+		// if the current value is not equal to the default value
+		// remove the default values from the flag
+		if !isInt64SliceEqual(parsed, defaultVal) {
+			for _, v := range defaultVal {
+				parsed = removeFromInt64Slice(parsed, v)
+			}
+		}
+		return parsed
 	}
 	return nil
 }

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -89,19 +89,21 @@ func (f Int64SliceFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f Int64SliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	newVal := &Int64Slice{}
+
 	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
-		newVal := &Int64Slice{}
 		for _, s := range strings.Split(envVal, ",") {
 			s = strings.TrimSpace(s)
 			if err := newVal.Set(s); err != nil {
 				return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
 			}
 		}
-		if f.Value == nil {
-			f.Value = newVal
-		} else {
-			*f.Value = *newVal
-		}
+	}
+
+	if f.Value == nil {
+		f.Value = newVal
+	} else {
+		*f.Value = *newVal
 	}
 
 	eachName(f.Name, func(name string) {

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -137,28 +137,32 @@ func (c *Context) GlobalIntSlice(name string) []int {
 func lookupIntSlice(name string, set *flag.FlagSet) []int {
 	f := set.Lookup(name)
 	if f != nil {
-		if value, ok := f.Value.(*IntSlice); ok {
-			// extract the slice from asserted value
-			slice := value.Value()
+		value, ok := f.Value.(*IntSlice)
+		if !ok {
+			return nil
+		}
+		// extract the slice from asserted value
+		slice := value.Value()
 
-			// extract default value from the flag
-			var defaultVal []int
-			for _, v := range strings.Split(f.DefValue, ",") {
+		// extract default value from the flag
+		var defaultVal []int
+		for _, v := range strings.Split(f.DefValue, ",") {
+			if v != "" {
 				intValue, err := strconv.Atoi(v)
 				if err != nil {
 					panic(err)
 				}
 				defaultVal = append(defaultVal, intValue)
 			}
-			// if the current value is not equal to the default value
-			// remove the default values from the flag
-			if !isIntSliceEqual(slice, defaultVal) {
-				for _, v := range defaultVal {
-					slice = removeFromIntSlice(slice, v)
-				}
-			}
-			return slice
 		}
+		// if the current value is not equal to the default value
+		// remove the default values from the flag
+		if !isIntSliceEqual(slice, defaultVal) {
+			for _, v := range defaultVal {
+				slice = removeFromIntSlice(slice, v)
+			}
+		}
+		return slice
 	}
 	return nil
 }

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -137,24 +137,28 @@ func (c *Context) GlobalIntSlice(name string) []int {
 func lookupIntSlice(name string, set *flag.FlagSet) []int {
 	f := set.Lookup(name)
 	if f != nil {
-		parsed, err := (f.Value.(*IntSlice)).Value(), error(nil)
-		if err != nil {
-			return nil
-		}
-		// extract default value from the flag
-		var defaultVal []int
-		for _, v := range strings.Split(f.DefValue, ",") {
-			iV, _ := strconv.Atoi(v)
-			defaultVal = append(defaultVal, iV)
-		}
-		// if the current value is not equal to the default value
-		// remove the default values from the flag
-		if !isIntSliceEqual(parsed, defaultVal) {
-			for _, v := range defaultVal {
-				parsed = removeFromIntSlice(parsed, v)
+		if value, ok := f.Value.(*IntSlice); ok {
+			// extract the slice from asserted value
+			slice := value.Value()
+
+			// extract default value from the flag
+			var defaultVal []int
+			for _, v := range strings.Split(f.DefValue, ",") {
+				intValue, err := strconv.Atoi(v)
+				if err != nil {
+					panic(err)
+				}
+				defaultVal = append(defaultVal, intValue)
 			}
+			// if the current value is not equal to the default value
+			// remove the default values from the flag
+			if !isIntSliceEqual(slice, defaultVal) {
+				for _, v := range defaultVal {
+					slice = removeFromIntSlice(slice, v)
+				}
+			}
+			return slice
 		}
-		return parsed
 	}
 	return nil
 }

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -159,17 +159,13 @@ func lookupIntSlice(name string, set *flag.FlagSet) []int {
 	return nil
 }
 
-func removeFromIntSlice(slice []int, val int) (newVal []int) {
-	var count int
-	for _, v := range slice {
+func removeFromIntSlice(slice []int, val int) []int {
+	for i, v := range slice {
 		if v == val {
-			newVal = slice[count+1:]
-			return
+			return append(slice[:i], slice[i+1:]...)
 		}
-		newVal = append(newVal, v)
-		count++
 	}
-	return
+	return slice
 }
 
 func isIntSliceEqual(newValue, defaultValue []int) bool {

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -89,19 +89,21 @@ func (f IntSliceFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f IntSliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	newVal := &IntSlice{}
+
 	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
-		newVal := &IntSlice{}
 		for _, s := range strings.Split(envVal, ",") {
 			s = strings.TrimSpace(s)
 			if err := newVal.Set(s); err != nil {
 				return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
 			}
 		}
-		if f.Value == nil {
-			f.Value = newVal
-		} else {
-			*f.Value = *newVal
-		}
+	}
+
+	if f.Value == nil {
+		f.Value = newVal
+	} else {
+		*f.Value = *newVal
 	}
 
 	eachName(f.Name, func(name string) {

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -32,14 +32,14 @@ func (f *StringSlice) Get() interface{} {
 
 // StringSliceFlag is a flag with type *StringSlice
 type StringSliceFlag struct {
-	Name       string
-	Usage      string
-	EnvVar     string
-	FilePath   string
-	Required   bool
-	Hidden     bool
-	TakesFile  bool
-	Value      *StringSlice
+	Name      string
+	Usage     string
+	EnvVar    string
+	FilePath  string
+	Required  bool
+	Hidden    bool
+	TakesFile bool
+	Value     *StringSlice
 }
 
 // String returns a readable representation of this value
@@ -149,17 +149,13 @@ func lookupStringSlice(name string, set *flag.FlagSet) []string {
 	return nil
 }
 
-func removeFromStringSlice(slice []string, val string) (newVal []string) {
-	var count int
-	for _, v := range slice {
+func removeFromStringSlice(slice []string, val string) []string {
+	for i, v := range slice {
 		if v == val {
-			newVal = slice[count+1:]
-			return
+			return append(slice[:i], slice[i+1:]...)
 		}
-		newVal = append(newVal, v)
-		count++
 	}
-	return
+	return slice
 }
 
 func isStringSliceEqual(newValue, defaultValue []string) bool {

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -128,25 +128,27 @@ func (c *Context) GlobalStringSlice(name string) []string {
 func lookupStringSlice(name string, set *flag.FlagSet) []string {
 	f := set.Lookup(name)
 	if f != nil {
-		if value, ok := f.Value.(*StringSlice); ok {
-			// extract the slice from asserted value
-			slice := value.Value()
-
-			// extract default value from the flag
-			var defaultVal []string
-			for _, v := range strings.Split(f.DefValue, ",") {
-				defaultVal = append(defaultVal, v)
-			}
-
-			// if the current value is not equal to the default value
-			// remove the default values from the flag
-			if !isStringSliceEqual(slice, defaultVal) {
-				for _, v := range defaultVal {
-					slice = removeFromStringSlice(slice, v)
-				}
-			}
-			return slice
+		value, ok := f.Value.(*StringSlice)
+		if !ok {
+			return nil
 		}
+		// extract the slice from asserted value
+		slice := value.Value()
+
+		// extract default value from the flag
+		var defaultVal []string
+		for _, v := range strings.Split(f.DefValue, ",") {
+			defaultVal = append(defaultVal, v)
+		}
+
+		// if the current value is not equal to the default value
+		// remove the default values from the flag
+		if !isStringSliceEqual(slice, defaultVal) {
+			for _, v := range defaultVal {
+				slice = removeFromStringSlice(slice, v)
+			}
+		}
+		return slice
 	}
 	return nil
 }

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -32,14 +32,14 @@ func (f *StringSlice) Get() interface{} {
 
 // StringSliceFlag is a flag with type *StringSlice
 type StringSliceFlag struct {
-	Name      string
-	Usage     string
-	EnvVar    string
-	FilePath  string
-	Required  bool
-	Hidden    bool
-	TakesFile bool
-	Value     *StringSlice
+	Name       string
+	Usage      string
+	EnvVar     string
+	FilePath   string
+	Required   bool
+	Hidden     bool
+	TakesFile  bool
+	Value      *StringSlice
 }
 
 // String returns a readable representation of this value
@@ -85,19 +85,21 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f StringSliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	newVal := &StringSlice{}
+
 	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
-		newVal := &StringSlice{}
 		for _, s := range strings.Split(envVal, ",") {
 			s = strings.TrimSpace(s)
 			if err := newVal.Set(s); err != nil {
 				return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
 			}
 		}
-		if f.Value == nil {
-			f.Value = newVal
-		} else {
-			*f.Value = *newVal
-		}
+	}
+
+	if f.Value == nil {
+		f.Value = newVal
+	} else {
+		*f.Value = *newVal
 	}
 
 	eachName(f.Name, func(name string) {

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -128,23 +128,25 @@ func (c *Context) GlobalStringSlice(name string) []string {
 func lookupStringSlice(name string, set *flag.FlagSet) []string {
 	f := set.Lookup(name)
 	if f != nil {
-		parsed, err := (f.Value.(*StringSlice)).Value(), error(nil)
-		if err != nil {
-			return nil
-		}
-		// extract default value from the flag
-		var defaultVal []string
-		for _, v := range strings.Split(f.DefValue, ",") {
-			defaultVal = append(defaultVal, v)
-		}
-		// if the current value is not equal to the default value
-		// remove the default values from the flag
-		if !isStringSliceEqual(parsed, defaultVal) {
-			for _, v := range defaultVal {
-				parsed = removeFromStringSlice(parsed, v)
+		if value, ok := f.Value.(*StringSlice); ok {
+			// extract the slice from asserted value
+			slice := value.Value()
+
+			// extract default value from the flag
+			var defaultVal []string
+			for _, v := range strings.Split(f.DefValue, ",") {
+				defaultVal = append(defaultVal, v)
 			}
+
+			// if the current value is not equal to the default value
+			// remove the default values from the flag
+			if !isStringSliceEqual(slice, defaultVal) {
+				for _, v := range defaultVal {
+					slice = removeFromStringSlice(slice, v)
+				}
+			}
+			return slice
 		}
-		return parsed
 	}
 	return nil
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -1332,30 +1332,94 @@ func TestFlagFromFile(t *testing.T) {
 }
 
 func TestSliceFlag_WithDefaults(t *testing.T) {
-	a := &App{
-		Flags: []Flag{
-			StringSliceFlag{Name: "names, n", Value: &StringSlice{"john"}},
-			IntSliceFlag{Name: "userIds, u", Value: &IntSlice{3}},
-			Int64SliceFlag{Name: "phoneNumbers, p", Value: &Int64Slice{123456789}},
+	tests := []struct {
+		args   []string
+		app    *App
+	}{
+		{
+			args: []string{""},
+			app: &App{
+				Flags: []Flag{
+					StringSliceFlag{Name: "names, n", Value: &StringSlice{"john"}},
+					IntSliceFlag{Name: "userIds, u", Value: &IntSlice{3}},
+					Int64SliceFlag{Name: "phoneNumbers, p", Value: &Int64Slice{123456789}},
+				},
+				Action: func(ctx *Context) error {
+					expect(t, len(ctx.StringSlice("n")), 1)
+					for _, name := range ctx.StringSlice("names") {
+						expect(t, name == "john", true)
+					}
+
+					expect(t, len(ctx.IntSlice("u")), 1)
+					for _, userId := range ctx.IntSlice("userIds") {
+						expect(t, userId == 3, true)
+					}
+
+					expect(t, len(ctx.Int64Slice("p")), 1)
+					for _, phoneNumber := range ctx.Int64Slice("phoneNumbers") {
+						expect(t, phoneNumber == 123456789, true)
+					}
+					return nil
+				},
+			},
 		},
-		Action: func(ctx *Context) error {
-			expect(t, len(ctx.StringSlice("n")), 2)
-			for _, name := range ctx.StringSlice("names") {
-				expect(t, name != "john", true)
-			}
+		{
+			args: []string{"", "-n", "jane", "-n", "bob", "-u", "5", "-u", "10", "-p", "987654321"},
+			app: &App{
+				Flags: []Flag{
+					StringSliceFlag{Name: "names, n", Value: &StringSlice{"john"}},
+					IntSliceFlag{Name: "userIds, u", Value: &IntSlice{3}},
+					Int64SliceFlag{Name: "phoneNumbers, p", Value: &Int64Slice{123456789}},
+				},
+				Action: func(ctx *Context) error {
+					expect(t, len(ctx.StringSlice("n")), 2)
+					for _, name := range ctx.StringSlice("names") {
+						expect(t, name != "john", true)
+					}
 
-			expect(t, len(ctx.IntSlice("u")), 2)
-			for _, userId := range ctx.IntSlice("userIds") {
-				expect(t, userId != 3, true)
-			}
+					expect(t, len(ctx.IntSlice("u")), 2)
+					for _, userId := range ctx.IntSlice("userIds") {
+						expect(t, userId != 3, true)
+					}
 
-			expect(t, len(ctx.Int64Slice("p")), 1)
-			for _, phoneNumber := range ctx.Int64Slice("phoneNumbers") {
-				expect(t, phoneNumber != 123456789, true)
-			}
-			return nil
+					expect(t, len(ctx.Int64Slice("p")), 1)
+					for _, phoneNumber := range ctx.Int64Slice("phoneNumbers") {
+						expect(t, phoneNumber != 123456789, true)
+					}
+					return nil
+				},
+			},
+		},
+		{
+			args: []string{"", "--names", "john", "--userIds", "3", "--phoneNumbers", "123456789"},
+			app: &App{
+				Flags: []Flag{
+					StringSliceFlag{Name: "names, n", Value: &StringSlice{"john"}},
+					IntSliceFlag{Name: "userIds, u", Value: &IntSlice{3}},
+					Int64SliceFlag{Name: "phoneNumbers, p", Value: &Int64Slice{123456789}},
+				},
+				Action: func(ctx *Context) error {
+					expect(t, len(ctx.StringSlice("n")), 1)
+					for _, name := range ctx.StringSlice("names") {
+						expect(t, name == "john", true)
+					}
+
+					expect(t, len(ctx.IntSlice("u")), 1)
+					for _, userId := range ctx.IntSlice("userIds") {
+						expect(t, userId == 3, true)
+					}
+
+					expect(t, len(ctx.Int64Slice("p")), 1)
+					for _, phoneNumber := range ctx.Int64Slice("phoneNumbers") {
+						expect(t, phoneNumber == 123456789, true)
+					}
+					return nil
+				},
+			},
 		},
 	}
 
-	_ = a.Run([]string{"", "-n", "jane", "-n", "bob", "-u", "5", "-u", "10", "-p", "987654321"})
+	for _, tt := range tests {
+		_ = tt.app.Run(tt.args)
+	}
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -1330,3 +1330,32 @@ func TestFlagFromFile(t *testing.T) {
 		}
 	}
 }
+
+func TestSliceFlag_WithDefaults(t *testing.T) {
+	a := &App{
+		Flags: []Flag{
+			StringSliceFlag{Name: "names, n", Value: &StringSlice{"john"}},
+			IntSliceFlag{Name: "userIds, u", Value: &IntSlice{3}},
+			Int64SliceFlag{Name: "phoneNumbers, p", Value: &Int64Slice{123456789}},
+		},
+		Action: func(ctx *Context) error {
+			expect(t, len(ctx.StringSlice("n")), 2)
+			for _, name := range ctx.StringSlice("names") {
+				expect(t, name != "john", true)
+			}
+
+			expect(t, len(ctx.IntSlice("u")), 2)
+			for _, userId := range ctx.IntSlice("userIds") {
+				expect(t, userId != 3, true)
+			}
+
+			expect(t, len(ctx.Int64Slice("p")), 1)
+			for _, phoneNumber := range ctx.Int64Slice("phoneNumbers") {
+				expect(t, phoneNumber != 123456789, true)
+			}
+			return nil
+		},
+	}
+
+	_ = a.Run([]string{"", "-n", "jane", "-n", "bob", "-u", "5", "-u", "10", "-p", "987654321"})
+}


### PR DESCRIPTION
## Motivation

Fixes #790 

The issue describes a bug where the default values of a `Slice` type flag persist even after the user explicitly sets the flag. Consider the following code:

```go
package main

import (
	"fmt"
	"log"
	"os"

	"github.com/urfave/cli"
)

func main() {
	app := cli.NewApp()
	app.Flags = []cli.Flag{
		cli.StringSliceFlag{
			Name: "Hostnames, n",
			Usage: "`HOSTNAME`s to listen to.",
			Value: &cli.StringSlice{"localhost"},
		},
	}
	app.Action = func(c *cli.Context) error {
		if c.IsSet("Hostnames") {
			// do something
		}

		if c.IsSet("n") {
			// do something else
		}

		return nil
	}

	err := app.Run(os.Args)
	if err != nil {
		log.Fatal()
	}
}
```

Suppose, we execute this code using `--Hostnames a.b.c --Hostnames e.f.g`, we would expect the `c.StringSlice("Hostnames")` function to return a `StringSlice` with length equal to 2 and containing `a.b.c` and `e.f.g`. As of writing this PR, the call to `c.StringSlice("Hostnames")` returns a `StringSlice` with length equal to 3 and  containing `localhost`, `a.b.c` and `e.f.g`. This behavior is incorrect.

The same behavior can be replicated in the `IntSliceFlag` and `Int64SliceFlag` also. This PR aims to fix this inconsistency.

## Release Notes

**[BUG FIX]** String flag no longer persists the default value if the flag is explicitly initialized.

## Changes

- `flag_int64_slice.go`: Update `lookupInt64Slice` function to extract default values of the flag and then subsequently remove them.
- `flag_int_slice.go`: Update `lookupIntSlice` function to extract default values of the flag and then subsequently remove them.
- `flag_string_slice.go`: Update `lookupStringSlice` function to extract default values of the flag and then subsequently remove them.
- `flag_test.go`: Add unit tests.

## Testing

Unit tests are added to cover the following scenarios:

1. Flags are initialized with default values and are not explicitly initialized by the user.
2. Flags are initialized with default values and are explicitly initialized by the user.
3. Flags are initialized with default values and are explicitly initialized by the user with values the same as the default values.