### PR TITLE
Fix codecov reports in GitHub actions

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Send Coverage Report
         if: success()
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
## Motivation

Coverage reports seems broken with the switch to GitHub actions. This PR should address this issue.

## Changes

We now use the official codecov GitHub action to report the coverage.