### PR TITLE
Fix codecov reports in GitHub actions

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -61,5 +61,5 @@ jobs:
       - name: Send Coverage Report
         if: success() && matrix.go == 1.13 && matrix.os == 'ubuntu-latest'
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: fa7ff1caed3c43c68ae994495a6469d8
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -58,8 +58,9 @@ jobs:
           go run build.go gfmrun docs/v2/manual.md
           go run build.go toc docs/v2/manual.md
 
-      - name: Send Coverage Report
+      - name: Upload coverage to Codecov
         if: success() && matrix.go == 1.13 && matrix.os == 'ubuntu-latest'
-        env:
-          CODECOV_TOKEN: fa7ff1caed3c43c68ae994495a6469d8
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v1
+        with:
+          token: 0a8cc73b-bb7c-480b-8626-38a461643761
+          fail_ci_if_error: true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -59,7 +59,7 @@ jobs:
           go run build.go toc docs/v2/manual.md
 
       - name: Send Coverage Report
-        if: success()
+        if: success() && matrix.go == 1.13 && matrix.os == 'ubuntu-latest'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ install:
   - go version
   - go env
   - go get github.com/urfave/gfmrun/cmd/gfmrun
-  - go get golang.org/x/tools/cmd/goimports
   - go mod tidy
 
 build_script:


### PR DESCRIPTION
## Motivation

Coverage reports seems broken with the switch to GitHub actions. This PR should address this issue.

Follup-up of https://github.com/urfave/cli/pull/985
## Changes

We now use the official codecov GitHub action to report the coverage.