### PR TITLE
Run Github Actions on the master branch

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,6 +1,9 @@
 name: Run Tests
 
 on:
+  push:
+    branches:
+      - master  
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Motivation

Master merges are currently only running appveyor builds 
![image](https://user-images.githubusercontent.com/5768468/71070193-1ce26500-212f-11ea-9bee-a87db9af8675.png)

Whereas we would expect master merges to run build actions builds, like in this screnshot 
![image](https://user-images.githubusercontent.com/5768468/71070236-35eb1600-212f-11ea-9cc4-95853e4ea267.png)

This is likely to cause a variety of problems, but noticed it via this error message from codecov on this page https://codecov.io/gh/urfave/cli/compare/cae7b0c5e15e1e19e0f11ab37195be7655afa41c...2cb8524de32183d2eed9d355e3007417bd6708ae 
![image](https://user-images.githubusercontent.com/5768468/71070329-68950e80-212f-11ea-802b-2da3597e49e1.png)

So this PR changed the Github Actions config to run tests on master

## Documentation

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#filtering-for-specific-branches-tags-and-paths