### PR TITLE
Use VisibleFlags during doc generation

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -48,8 +48,8 @@ func (a *App) writeDocTemplate(w io.Writer) error {
 	return t.ExecuteTemplate(w, name, &cliTemplate{
 		App:          a,
 		Commands:     prepareCommands(a.Commands, 0),
-		GlobalArgs:   prepareArgsWithValues(a.Flags),
-		SynopsisArgs: prepareArgsSynopsis(a.Flags),
+		GlobalArgs:   prepareArgsWithValues(a.VisibleFlags()),
+		SynopsisArgs: prepareArgsSynopsis(a.VisibleFlags()),
 	})
 }
 

--- a/docs_test.go
+++ b/docs_test.go
@@ -22,6 +22,10 @@ func testApp() *App {
 			Aliases: []string{"b"},
 			Usage:   "another usage text",
 		},
+		&BoolFlag{
+			Name:   "hidden-flag",
+			Hidden: true,
+		},
 	}
 	app.Commands = []*Command{{
 		Aliases: []string{"c"},


### PR DESCRIPTION
## Motivation

Hidden commands are excluded during doc generation but hidden flags are not. This results in generated documentation (man pages and markdown) including hidden flags in the output. Using `VisibleFlags()` instead of the `Flags` slice filters out hidden flags before preparing them for document output.

## Testing

I added a hidden flag to the testApp. Test output should remain unchanged, since hidden flags should not be included in documentation output.