### PR TITLE
Recommend Go Modules in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Usage documentation exists for each major version. Don't know what version you'r
 - `v2` - [./docs/v2/manual.md](./docs/v2/manual.md)
 - `v1` - [./docs/v1/manual.md](./docs/v1/manual.md)
 
+## Installation
+
+Make sure you have a working Go environment.  Go version 1.11+ is supported. [See the install instructions for Go](http://golang.org/doc/install.html).
+
+Go Modules are strongly recommended when using this package. [See the go blog guide on using Go Modules](https://blog.golang.org/using-go-modules).
+
 ### Using `v2` releases
 
 ```
@@ -37,7 +43,7 @@ import (
 ### Using `v1` releases
 
 ```
-$ go get github.com/urfave/cli
+$ GO111MODULE=on go get github.com/urfave/cli
 ```
 
 ```go
@@ -47,11 +53,6 @@ import (
 )
 ...
 ```
-
-## Installation
-
-Make sure you have a working Go environment.  Go version 1.10+ is supported.  [See
-the install instructions for Go](http://golang.org/doc/install.html).
 
 ### GOPATH
 


### PR DESCRIPTION
## Motivation

We get a steady flow of issues that are sourced in people not using Go Modules, and the recommendation has included "use Go Modules" in all of those cases. For example:

- https://github.com/urfave/cli/issues/925#issuecomment-559330456
- https://github.com/urfave/cli/issues/926#issuecomment-552679445
- https://github.com/urfave/cli/issues/964#issuecomment-559694642
- https://github.com/urfave/cli/issues/972#issuecomment-561635022
- https://github.com/urfave/cli/issues/1010#issuecomment-568701956
- https://github.com/amacneil/dbmate/issues/106#issuecomment-561911504
- https://github.com/technosophos/dashing/issues/51#issuecomment-561842973
- https://github.com/ethereum/go-ethereum/issues/20164
- https://github.com/anubhavmishra/envoy-consul-sds/pull/4

Further, we recently decided via https://github.com/urfave/cli/issues/952#issuecomment-561456146 that we are not interested in supporting `GOPATH` mode. To the best of my knowledge, this leaves _"Go Modules"_ and _"Vendoring"_ as the two remaining packaging methods that we support. Given that our clear preference here is Go Modules, I think we should update the readme to explicitly and strongly recommend Go Modules.