### PR TITLE
Fix 2.1.0 regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 vendor
 .idea
+coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 node_modules/
 vendor
 .idea
-coverage.txt

--- a/context.go
+++ b/context.go
@@ -25,11 +25,9 @@ type Context struct {
 // NewContext creates a new context. For use in when invoking an App or Command action.
 func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
 	c := &Context{App: app, flagSet: set, parentContext: parentCtx}
-
 	if parentCtx != nil {
 		c.Context = parentCtx.Context
 		c.shellComplete = parentCtx.shellComplete
-
 		if parentCtx.flagSet == nil {
 			parentCtx.flagSet = &flag.FlagSet{}
 		}

--- a/context.go
+++ b/context.go
@@ -33,6 +33,10 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
 	if parentCtx != nil {
 		c.Context = parentCtx.Context
 		c.shellComplete = parentCtx.shellComplete
+
+		if parentCtx.flagSet == nil {
+			parentCtx.flagSet = &flag.FlagSet{}
+		}
 	}
 
 	c.Command = &Command{}

--- a/context.go
+++ b/context.go
@@ -24,7 +24,12 @@ type Context struct {
 
 // NewContext creates a new context. For use in when invoking an App or Command action.
 func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
-	c := &Context{App: app, flagSet: set, parentContext: parentCtx}
+	c := &Context{
+		App:           app,
+		flagSet:       set,
+		parentContext: parentCtx,
+	}
+
 	if parentCtx != nil {
 		c.Context = parentCtx.Context
 		c.shellComplete = parentCtx.shellComplete

--- a/context.go
+++ b/context.go
@@ -24,11 +24,7 @@ type Context struct {
 
 // NewContext creates a new context. For use in when invoking an App or Command action.
 func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
-	c := &Context{
-		App:           app,
-		flagSet:       set,
-		parentContext: parentCtx,
-	}
+	c := &Context{App: app, flagSet: set, parentContext: parentCtx}
 
 	if parentCtx != nil {
 		c.Context = parentCtx.Context

--- a/context_test.go
+++ b/context_test.go
@@ -370,9 +370,33 @@ func TestContextAttributeAccessing(t *testing.T) {
 			newContextInput: nil,
 		},
 		{
-			testCase:        "empty_set_bool_and_present_ctx_bool_with_background_context",
+			testCase:        "present_set_bool_and_present_ctx_bool_with_background_context",
 			setBoolInput:    "",
 			ctxBoolInput:    "ctx-bool",
+			newContextInput: &Context{Context: context.Background()},
+		},
+		{
+			testCase:        "present_set_bool_and_present_ctx_bool",
+			setBoolInput:    "ctx-bool",
+			ctxBoolInput:    "ctx-bool",
+			newContextInput: nil,
+		},
+		{
+			testCase:        "present_set_bool_and_present_ctx_bool_with_background_context",
+			setBoolInput:    "ctx-bool",
+			ctxBoolInput:    "ctx-bool",
+			newContextInput: &Context{Context: context.Background()},
+		},
+		{
+			testCase:        "present_set_bool_and_different_ctx_bool",
+			setBoolInput:    "ctx-bool",
+			ctxBoolInput:    "not-ctx-bool",
+			newContextInput: nil,
+		},
+		{
+			testCase:        "present_set_bool_and_different_ctx_bool_with_background_context",
+			setBoolInput:    "ctx-bool",
+			ctxBoolInput:    "not-ctx-bool",
 			newContextInput: &Context{Context: context.Background()},
 		},
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -293,13 +293,6 @@ func TestContext_Lineage(t *testing.T) {
 	expect(t, lineage[1], parentCtx)
 }
 
-func TestContext_BackgroundContextAttributeAccessing(t *testing.T) {
-	parentContext := context.Background()
-	ctx := NewContext(nil, nil, &Context{Context: parentContext})
-	value := ctx.Bool("some-bool")
-	expect(t, value, false)
-}
-
 func TestContext_lookupFlagSet(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("local-flag", false, "doc")
@@ -348,6 +341,57 @@ func TestContextPropagation(t *testing.T) {
 	ctx = NewContext(nil, nil, parent)
 	if ctx.Context == nil {
 		t.Fatal("expected context to not be nil even if the parent's context is nil")
+	}
+}
+
+func TestContextAttributeAccessing(t *testing.T) {
+	tdata := []struct {
+		testCase        string
+		setBoolInput    string
+		ctxBoolInput    string
+		newContextInput *Context
+	}{
+		{
+			testCase:        "empty",
+			setBoolInput:    "",
+			ctxBoolInput:    "",
+			newContextInput: nil,
+		},
+		{
+			testCase:        "empty_with_background_context",
+			setBoolInput:    "",
+			ctxBoolInput:    "",
+			newContextInput: &Context{Context: context.Background()},
+		},
+		{
+			testCase:        "empty_set_bool_and_present_ctx_bool",
+			setBoolInput:    "",
+			ctxBoolInput:    "ctx-bool",
+			newContextInput: nil,
+		},
+		{
+			testCase:        "empty_set_bool_and_present_ctx_bool_with_background_context",
+			setBoolInput:    "",
+			ctxBoolInput:    "ctx-bool",
+			newContextInput: &Context{Context: context.Background()},
+		},
+	}
+
+	for _, test := range tdata {
+		t.Run(test.testCase, func(t *testing.T) {
+			// setup
+			set := flag.NewFlagSet("test", 0)
+			set.Bool(test.setBoolInput, false, "doc")
+			ctx := NewContext(nil, set, test.newContextInput)
+
+			// logic under test
+			value := ctx.Bool(test.ctxBoolInput)
+
+			// assertions
+			if value != false {
+				t.Errorf("expected test.value to be false, but it was not")
+			}
+		})
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -380,8 +380,8 @@ func TestContextAttributeAccessing(t *testing.T) {
 	for _, test := range tdata {
 		t.Run(test.testCase, func(t *testing.T) {
 			// setup
-			set := flag.NewFlagSet("test", 0)
-			set.Bool(test.setBoolInput, false, "doc")
+			set := flag.NewFlagSet("some-flag-set-name", 0)
+			set.Bool(test.setBoolInput, false, "usage documentation")
 			ctx := NewContext(nil, set, test.newContextInput)
 
 			// logic under test
@@ -389,7 +389,7 @@ func TestContextAttributeAccessing(t *testing.T) {
 
 			// assertions
 			if value != false {
-				t.Errorf("expected test.value to be false, but it was not")
+				t.Errorf("expected \"value\" to be false, but it was not")
 			}
 		})
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -293,6 +293,13 @@ func TestContext_Lineage(t *testing.T) {
 	expect(t, lineage[1], parentCtx)
 }
 
+func TestContext_BackgroundContextAttributeAccessing(t *testing.T) {
+	parentContext := context.Background()
+	ctx := NewContext(nil, nil, &Context{Context: parentContext})
+	value := ctx.Bool("some-bool")
+	expect(t, value, false)
+}
+
 func TestContext_lookupFlagSet(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("local-flag", false, "doc")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 View [unreleased 2.X] series changes.
 
+## [2.1.1] - 2019-12-24
+
+### Fixed
+
+* Fixed a `Context` regression introduced in `v2.1.0` in [urfave/cli/pull/1014](https://github.com/urfave/cli/pull/1014) via [@lynncyrin](https://github.com/lynncyrin)
+
 ## [2.1.0] - 2019-12-24
 
 These release notes were written for the git hash [ae84df4cef4a2a6f1a0cb1d41ea0f3af8755e5a8](https://github.com/urfave/cli/tree/ae84df4cef4a2a6f1a0cb1d41ea0f3af8755e5a8)
@@ -541,7 +547,8 @@ signature of `func(*cli.Context) error`, as defined by `cli.ActionFunc`.
 ### Added
 - Initial implementation.
 
-[unreleased 2.X]: https://github.com/urfave/cli/compare/v2.1.0...HEAD
+[unreleased 2.X]: https://github.com/urfave/cli/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/urfave/cli/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/urfave/cli/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/urfave/cli/compare/v1.22.2...v2.0.0
 

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -1,8 +1,6 @@
 cli v2 manual
 ===
 
-todo
-
 <!-- toc -->
 
 - [Getting Started](#getting-started)

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -1401,54 +1401,54 @@ func main() {
       cli.ShowSubcommandHelp(c)
       cli.ShowVersion(c)
 
-			fmt.Printf("%#v\n", c.App.Command("doo"))
-			// // uncomment when https://github.com/urfave/cli/pull/1014 is released
-			// if c.Bool("infinite") {
-			// 	c.App.Run([]string{"app", "doo", "wop"})
-			// }
+      fmt.Printf("%#v\n", c.App.Command("doo"))
+      // // uncomment when https://github.com/urfave/cli/pull/1014 is released
+      // if c.Bool("infinite") {
+      // 	c.App.Run([]string{"app", "doo", "wop"})
+      // }
 
-			// // uncomment when https://github.com/urfave/cli/pull/1014 is released
-			// if c.Bool("forevar") {
-			// 	c.App.RunAsSubcommand(c)
-			// }
-			c.App.Setup()
-			fmt.Printf("%#v\n", c.App.VisibleCategories())
-			fmt.Printf("%#v\n", c.App.VisibleCommands())
-			fmt.Printf("%#v\n", c.App.VisibleFlags())
+      // // uncomment when https://github.com/urfave/cli/pull/1014 is released
+      // if c.Bool("forevar") {
+      // 	c.App.RunAsSubcommand(c)
+      // }
+      c.App.Setup()
+      fmt.Printf("%#v\n", c.App.VisibleCategories())
+      fmt.Printf("%#v\n", c.App.VisibleCommands())
+      fmt.Printf("%#v\n", c.App.VisibleFlags())
 
-			fmt.Printf("%#v\n", c.Args().First())
-			if c.Args().Len() > 0 {
-				fmt.Printf("%#v\n", c.Args().Get(1))
-			}
-			fmt.Printf("%#v\n", c.Args().Present())
-			fmt.Printf("%#v\n", c.Args().Tail())
+      fmt.Printf("%#v\n", c.Args().First())
+      if c.Args().Len() > 0 {
+        fmt.Printf("%#v\n", c.Args().Get(1))
+      }
+      fmt.Printf("%#v\n", c.Args().Present())
+      fmt.Printf("%#v\n", c.Args().Tail())
 
-			set := flag.NewFlagSet("contrive", 0)
-			nc := cli.NewContext(c.App, set, c)
+      set := flag.NewFlagSet("contrive", 0)
+      nc := cli.NewContext(c.App, set, c)
 
-			// // uncomment when https://github.com/urfave/cli/pull/1014 is released
-			// fmt.Printf("%#v\n", nc.Args())
-			// fmt.Printf("%#v\n", nc.Bool("nope"))
-			// fmt.Printf("%#v\n", !nc.Bool("nerp"))
-			// fmt.Printf("%#v\n", nc.Duration("howlong"))
-			// fmt.Printf("%#v\n", nc.Float64("hay"))
-			// fmt.Printf("%#v\n", nc.Generic("bloop"))
-			// fmt.Printf("%#v\n", nc.Int64("bonk"))
-			// fmt.Printf("%#v\n", nc.Int64Slice("burnks"))
-			// fmt.Printf("%#v\n", nc.Int("bips"))
-			// fmt.Printf("%#v\n", nc.IntSlice("blups"))
-			// fmt.Printf("%#v\n", nc.String("snurt"))
-			// fmt.Printf("%#v\n", nc.StringSlice("snurkles"))
-			// fmt.Printf("%#v\n", nc.Uint("flub"))
-			// fmt.Printf("%#v\n", nc.Uint64("florb"))
+      // // uncomment when https://github.com/urfave/cli/pull/1014 is released
+      // fmt.Printf("%#v\n", nc.Args())
+      // fmt.Printf("%#v\n", nc.Bool("nope"))
+      // fmt.Printf("%#v\n", !nc.Bool("nerp"))
+      // fmt.Printf("%#v\n", nc.Duration("howlong"))
+      // fmt.Printf("%#v\n", nc.Float64("hay"))
+      // fmt.Printf("%#v\n", nc.Generic("bloop"))
+      // fmt.Printf("%#v\n", nc.Int64("bonk"))
+      // fmt.Printf("%#v\n", nc.Int64Slice("burnks"))
+      // fmt.Printf("%#v\n", nc.Int("bips"))
+      // fmt.Printf("%#v\n", nc.IntSlice("blups"))
+      // fmt.Printf("%#v\n", nc.String("snurt"))
+      // fmt.Printf("%#v\n", nc.StringSlice("snurkles"))
+      // fmt.Printf("%#v\n", nc.Uint("flub"))
+      // fmt.Printf("%#v\n", nc.Uint64("florb"))
 
-			// // uncomment when https://github.com/urfave/cli/pull/1014 is released
-			// fmt.Printf("%#v\n", nc.FlagNames())
-			// fmt.Printf("%#v\n", nc.IsSet("wat"))
-			// fmt.Printf("%#v\n", nc.Set("wat", "nope"))
-			// fmt.Printf("%#v\n", nc.NArg())
-			// fmt.Printf("%#v\n", nc.NumFlags())
-			// fmt.Printf("%#v\n", nc.Lineage()[1])
+      // // uncomment when https://github.com/urfave/cli/pull/1014 is released
+      // fmt.Printf("%#v\n", nc.FlagNames())
+      // fmt.Printf("%#v\n", nc.IsSet("wat"))
+      // fmt.Printf("%#v\n", nc.Set("wat", "nope"))
+      // fmt.Printf("%#v\n", nc.NArg())
+      // fmt.Printf("%#v\n", nc.NumFlags())
+      // fmt.Printf("%#v\n", nc.Lineage()[1])
       nc.Set("wat", "also-nope")
 
       ec := cli.Exit("ohwell", 86)

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -1,6 +1,8 @@
 cli v2 manual
 ===
 
+todo
+
 <!-- toc -->
 
 - [Getting Started](#getting-started)

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -1401,51 +1401,54 @@ func main() {
       cli.ShowSubcommandHelp(c)
       cli.ShowVersion(c)
 
-      fmt.Printf("%#v\n", c.App.Command("doo"))
-      if c.Bool("infinite") {
-        c.App.Run([]string{"app", "doo", "wop"})
-      }
+			fmt.Printf("%#v\n", c.App.Command("doo"))
+			// // uncomment when https://github.com/urfave/cli/pull/1014 is released
+			// if c.Bool("infinite") {
+			// 	c.App.Run([]string{"app", "doo", "wop"})
+			// }
 
-      if c.Bool("forevar") {
-        c.App.RunAsSubcommand(c)
-      }
-      c.App.Setup()
-      fmt.Printf("%#v\n", c.App.VisibleCategories())
-      fmt.Printf("%#v\n", c.App.VisibleCommands())
-      fmt.Printf("%#v\n", c.App.VisibleFlags())
+			// // uncomment when https://github.com/urfave/cli/pull/1014 is released
+			// if c.Bool("forevar") {
+			// 	c.App.RunAsSubcommand(c)
+			// }
+			c.App.Setup()
+			fmt.Printf("%#v\n", c.App.VisibleCategories())
+			fmt.Printf("%#v\n", c.App.VisibleCommands())
+			fmt.Printf("%#v\n", c.App.VisibleFlags())
 
-      fmt.Printf("%#v\n", c.Args().First())
-      if c.Args().Len() > 0 {
-        fmt.Printf("%#v\n", c.Args().Get(1))
-      }
-      fmt.Printf("%#v\n", c.Args().Present())
-      fmt.Printf("%#v\n", c.Args().Tail())
+			fmt.Printf("%#v\n", c.Args().First())
+			if c.Args().Len() > 0 {
+				fmt.Printf("%#v\n", c.Args().Get(1))
+			}
+			fmt.Printf("%#v\n", c.Args().Present())
+			fmt.Printf("%#v\n", c.Args().Tail())
 
-      set := flag.NewFlagSet("contrive", 0)
-      nc := cli.NewContext(c.App, set, c)
+			set := flag.NewFlagSet("contrive", 0)
+			nc := cli.NewContext(c.App, set, c)
 
-      fmt.Printf("%#v\n", nc.Args())
-      fmt.Printf("%#v\n", nc.Bool("nope"))
-      fmt.Printf("%#v\n", !nc.Bool("nerp"))
-      fmt.Printf("%#v\n", nc.Duration("howlong"))
-      fmt.Printf("%#v\n", nc.Float64("hay"))
-      fmt.Printf("%#v\n", nc.Generic("bloop"))
-      fmt.Printf("%#v\n", nc.Int64("bonk"))
-      fmt.Printf("%#v\n", nc.Int64Slice("burnks"))
-      fmt.Printf("%#v\n", nc.Int("bips"))
-      fmt.Printf("%#v\n", nc.IntSlice("blups"))
-      fmt.Printf("%#v\n", nc.String("snurt"))
-      fmt.Printf("%#v\n", nc.StringSlice("snurkles"))
-      fmt.Printf("%#v\n", nc.Uint("flub"))
-      fmt.Printf("%#v\n", nc.Uint64("florb"))
+			// // uncomment when https://github.com/urfave/cli/pull/1014 is released
+			// fmt.Printf("%#v\n", nc.Args())
+			// fmt.Printf("%#v\n", nc.Bool("nope"))
+			// fmt.Printf("%#v\n", !nc.Bool("nerp"))
+			// fmt.Printf("%#v\n", nc.Duration("howlong"))
+			// fmt.Printf("%#v\n", nc.Float64("hay"))
+			// fmt.Printf("%#v\n", nc.Generic("bloop"))
+			// fmt.Printf("%#v\n", nc.Int64("bonk"))
+			// fmt.Printf("%#v\n", nc.Int64Slice("burnks"))
+			// fmt.Printf("%#v\n", nc.Int("bips"))
+			// fmt.Printf("%#v\n", nc.IntSlice("blups"))
+			// fmt.Printf("%#v\n", nc.String("snurt"))
+			// fmt.Printf("%#v\n", nc.StringSlice("snurkles"))
+			// fmt.Printf("%#v\n", nc.Uint("flub"))
+			// fmt.Printf("%#v\n", nc.Uint64("florb"))
 
-      fmt.Printf("%#v\n", nc.FlagNames())
-      fmt.Printf("%#v\n", nc.IsSet("wat"))
-      fmt.Printf("%#v\n", nc.Set("wat", "nope"))
-      fmt.Printf("%#v\n", nc.NArg())
-      fmt.Printf("%#v\n", nc.NumFlags())
-      fmt.Printf("%#v\n", nc.Lineage()[1])
-
+			// // uncomment when https://github.com/urfave/cli/pull/1014 is released
+			// fmt.Printf("%#v\n", nc.FlagNames())
+			// fmt.Printf("%#v\n", nc.IsSet("wat"))
+			// fmt.Printf("%#v\n", nc.Set("wat", "nope"))
+			// fmt.Printf("%#v\n", nc.NArg())
+			// fmt.Printf("%#v\n", nc.NumFlags())
+			// fmt.Printf("%#v\n", nc.Lineage()[1])
       nc.Set("wat", "also-nope")
 
       ec := cli.Exit("ohwell", 86)


### PR DESCRIPTION
## Motivation

Fixes https://github.com/urfave/cli/issues/1015

## Release Notes

Fixed a `Context` regression introduced in https://github.com/urfave/cli/pull/1013

## Changes

When passing in `context.Background()`, initialize a `*flagSet` value. This prevents the code from panicking when `flagSet` is accessed later.

## Testing

In addition to the automated tests, I stood up a testing package (here => https://github.com/lynncyrin/testing-cli/pull/1) with this new code. The testing package ran successfully with this new cli code.

## Followup

After `v2.1.1` is released, I'll remove the commented out documentation lines. Also, this issue creates more justification for investigating https://github.com/urfave/cli/issues/1006.

## Reviewer Guidelines

All our builds are broken until this is resolved 😅 