### PR TITLE
simplify code - eliminate type assertions

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -261,19 +261,19 @@ func flagValue(f Flag) reflect.Value {
 func stringifyFlag(f Flag) string {
 	fv := flagValue(f)
 
-	switch f.(type) {
+	switch f := f.(type) {
 	case *IntSliceFlag:
 		return withEnvHint(flagStringSliceField(f, "EnvVars"),
-			stringifyIntSliceFlag(f.(*IntSliceFlag)))
+			stringifyIntSliceFlag(f))
 	case *Int64SliceFlag:
 		return withEnvHint(flagStringSliceField(f, "EnvVars"),
-			stringifyInt64SliceFlag(f.(*Int64SliceFlag)))
+			stringifyInt64SliceFlag(f))
 	case *Float64SliceFlag:
 		return withEnvHint(flagStringSliceField(f, "EnvVars"),
-			stringifyFloat64SliceFlag(f.(*Float64SliceFlag)))
+			stringifyFloat64SliceFlag(f))
 	case *StringSliceFlag:
 		return withEnvHint(flagStringSliceField(f, "EnvVars"),
-			stringifyStringSliceFlag(f.(*StringSliceFlag)))
+			stringifyStringSliceFlag(f))
 	}
 
 	placeholder, usage := unquoteUsage(fv.FieldByName("Usage").String())


### PR DESCRIPTION
"gosimple" linter says:
```
S1034: assigning the result of this type assertion to a variable (switch f := f.(type)) could eliminate the following type assertions:
	flag.go:267:26
	flag.go:270:28
	flag.go:273:30
	flag.go:276:29
```
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## Motivation

To simplify the code base.

<!--
  What goal is this change working towards?
  If this PR fixes one of more issues, list them here.
  One line each, like so:
    Fixes #123
    Fixes #39
-->

