### PR TITLE
Refactor the getting flag names - make it more explicit

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -203,11 +203,8 @@ func withEnvHint(envVars []string, str string) string {
 	return str + envText
 }
 
-func flagNames(f Flag) []string {
+func flagNames(name string, aliases []string) []string {
 	var ret []string
-
-	name := flagStringField(f, "Name")
-	aliases := flagStringSliceField(f, "Aliases")
 
 	for _, part := range append([]string{name}, aliases...) {
 		// v1 -> v2 migration warning zone:
@@ -229,17 +226,6 @@ func flagStringSliceField(f Flag, name string) []string {
 	}
 
 	return []string{}
-}
-
-func flagStringField(f Flag, name string) string {
-	fv := flagValue(f)
-	field := fv.FieldByName(name)
-
-	if field.IsValid() {
-		return field.String()
-	}
-
-	return ""
 }
 
 func withFileHint(filePath, str string) string {

--- a/flag_bool.go
+++ b/flag_bool.go
@@ -34,7 +34,7 @@ func (f *BoolFlag) String() string {
 
 // Names returns the names of the flag
 func (f *BoolFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_duration.go
+++ b/flag_duration.go
@@ -34,7 +34,7 @@ func (f *DurationFlag) String() string {
 
 // Names returns the names of the flag
 func (f *DurationFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_float64.go
+++ b/flag_float64.go
@@ -34,7 +34,7 @@ func (f *Float64Flag) String() string {
 
 // Names returns the names of the flag
 func (f *Float64Flag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -90,7 +90,7 @@ func (f *Float64SliceFlag) String() string {
 
 // Names returns the names of the flag
 func (f *Float64SliceFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_generic.go
+++ b/flag_generic.go
@@ -39,7 +39,7 @@ func (f *GenericFlag) String() string {
 
 // Names returns the names of the flag
 func (f *GenericFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_int.go
+++ b/flag_int.go
@@ -34,7 +34,7 @@ func (f *IntFlag) String() string {
 
 // Names returns the names of the flag
 func (f *IntFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_int64.go
+++ b/flag_int64.go
@@ -34,7 +34,7 @@ func (f *Int64Flag) String() string {
 
 // Names returns the names of the flag
 func (f *Int64Flag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -91,7 +91,7 @@ func (f *Int64SliceFlag) String() string {
 
 // Names returns the names of the flag
 func (f *Int64SliceFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -102,7 +102,7 @@ func (f *IntSliceFlag) String() string {
 
 // Names returns the names of the flag
 func (f *IntSliceFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_path.go
+++ b/flag_path.go
@@ -30,7 +30,7 @@ func (f *PathFlag) String() string {
 
 // Names returns the names of the flag
 func (f *PathFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_string.go
+++ b/flag_string.go
@@ -31,7 +31,7 @@ func (f *StringFlag) String() string {
 
 // Names returns the names of the flag
 func (f *StringFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -86,7 +86,7 @@ func (f *StringSliceFlag) String() string {
 
 // Names returns the names of the flag
 func (f *StringSliceFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -86,7 +86,7 @@ func (f *TimestampFlag) String() string {
 
 // Names returns the names of the flag
 func (f *TimestampFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_uint.go
+++ b/flag_uint.go
@@ -34,7 +34,7 @@ func (f *UintFlag) String() string {
 
 // Names returns the names of the flag
 func (f *UintFlag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required

--- a/flag_uint64.go
+++ b/flag_uint64.go
@@ -34,7 +34,7 @@ func (f *Uint64Flag) String() string {
 
 // Names returns the names of the flag
 func (f *Uint64Flag) Names() []string {
-	return flagNames(f)
+	return flagNames(f.Name, f.Aliases)
 }
 
 // IsRequired returns whether or not the flag is required


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## Motivation

Simplify the code base - avoid the using 'reflect' package while getting flag names.

<!--
  What goal is this change working towards?
  If this PR fixes one of more issues, list them here.
  One line each, like so:
    Fixes #123
    Fixes #39
-->

## Changes

Instead of searching special fields in a struct by `reflect` package we can pass it explicitly. This changes reduce the complexity of the code.

<!--
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Reviewer Guidelines

I have removed the `flagStringField` function, because now it is not used anywhere.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->
