### PR TITLE
Reduce the stdout logs in tests

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -612,7 +612,7 @@ func TestApp_UseShortOptionHandling(t *testing.T) {
 	var name string
 	expected := "expectedName"
 
-	app := NewApp()
+	app := newTestApp()
 	app.UseShortOptionHandling = true
 	app.Flags = []Flag{
 		&BoolFlag{Name: "one", Aliases: []string{"o"}},
@@ -633,7 +633,7 @@ func TestApp_UseShortOptionHandling(t *testing.T) {
 }
 
 func TestApp_UseShortOptionHandling_missing_value(t *testing.T) {
-	app := NewApp()
+	app := newTestApp()
 	app.UseShortOptionHandling = true
 	app.Flags = []Flag{
 		&StringFlag{Name: "name", Aliases: []string{"n"}},
@@ -648,7 +648,7 @@ func TestApp_UseShortOptionHandlingCommand(t *testing.T) {
 	var name string
 	expected := "expectedName"
 
-	app := NewApp()
+	app := newTestApp()
 	app.UseShortOptionHandling = true
 	command := &Command{
 		Name: "cmd",
@@ -673,7 +673,7 @@ func TestApp_UseShortOptionHandlingCommand(t *testing.T) {
 }
 
 func TestApp_UseShortOptionHandlingCommand_missing_value(t *testing.T) {
-	app := NewApp()
+	app := newTestApp()
 	app.UseShortOptionHandling = true
 	command := &Command{
 		Name: "cmd",
@@ -692,7 +692,7 @@ func TestApp_UseShortOptionHandlingSubCommand(t *testing.T) {
 	var name string
 	expected := "expectedName"
 
-	app := NewApp()
+	app := newTestApp()
 	app.UseShortOptionHandling = true
 	command := &Command{
 		Name: "cmd",
@@ -722,7 +722,7 @@ func TestApp_UseShortOptionHandlingSubCommand(t *testing.T) {
 }
 
 func TestApp_UseShortOptionHandlingSubCommand_missing_value(t *testing.T) {
-	app := NewApp()
+	app := newTestApp()
 	app.UseShortOptionHandling = true
 	command := &Command{
 		Name: "cmd",
@@ -925,6 +925,7 @@ func TestApp_BeforeFunc(t *testing.T) {
 		Flags: []Flag{
 			&StringFlag{Name: "opt"},
 		},
+		Writer: ioutil.Discard,
 	}
 
 	// run with the Before() func succeeding
@@ -1186,7 +1187,7 @@ func TestRequiredFlagAppRunBehavior(t *testing.T) {
 	for _, test := range tdata {
 		t.Run(test.testCase, func(t *testing.T) {
 			// setup
-			app := NewApp()
+			app := newTestApp()
 			app.Flags = test.appFlags
 			app.Commands = test.appCommands
 
@@ -1280,7 +1281,6 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	app := &App{
 		EnableBashCompletion: true,
 		BashComplete: func(c *Context) {
-			_, _ = fmt.Fprintf(os.Stderr, "---> BashComplete(%#v)\n", c)
 			counts.Total++
 			counts.ShellComplete = counts.Total
 		},
@@ -1289,6 +1289,7 @@ func TestApp_OrderOfOperations(t *testing.T) {
 			counts.OnUsageError = counts.Total
 			return errors.New("hay OnUsageError")
 		},
+		Writer: ioutil.Discard,
 	}
 
 	beforeNoError := func(c *Context) error {
@@ -1422,49 +1423,50 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 	}
 
 	for _, flagSet := range subcommandHelpTopics {
-		t.Logf("==> checking with flags %v", flagSet)
+		t.Run(fmt.Sprintf("checking with flags %v", flagSet), func(t *testing.T) {
 
-		app := &App{}
-		buf := new(bytes.Buffer)
-		app.Writer = buf
+			app := &App{}
+			buf := new(bytes.Buffer)
+			app.Writer = buf
 
-		subCmdBar := &Command{
-			Name:  "bar",
-			Usage: "does bar things",
-		}
-		subCmdBaz := &Command{
-			Name:  "baz",
-			Usage: "does baz things",
-		}
-		cmd := &Command{
-			Name:        "foo",
-			Description: "descriptive wall of text about how it does foo things",
-			Subcommands: []*Command{subCmdBar, subCmdBaz},
-			Action:      func(c *Context) error { return nil },
-		}
-
-		app.Commands = []*Command{cmd}
-		err := app.Run(flagSet)
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		output := buf.String()
-
-		if strings.Contains(output, "No help topic for") {
-			t.Errorf("expect a help topic, got none: \n%q", output)
-		}
-
-		for _, shouldContain := range []string{
-			cmd.Name, cmd.Description,
-			subCmdBar.Name, subCmdBar.Usage,
-			subCmdBaz.Name, subCmdBaz.Usage,
-		} {
-			if !strings.Contains(output, shouldContain) {
-				t.Errorf("want help to contain %q, did not: \n%q", shouldContain, output)
+			subCmdBar := &Command{
+				Name:  "bar",
+				Usage: "does bar things",
 			}
-		}
+			subCmdBaz := &Command{
+				Name:  "baz",
+				Usage: "does baz things",
+			}
+			cmd := &Command{
+				Name:        "foo",
+				Description: "descriptive wall of text about how it does foo things",
+				Subcommands: []*Command{subCmdBar, subCmdBaz},
+				Action:      func(c *Context) error { return nil },
+			}
+
+			app.Commands = []*Command{cmd}
+			err := app.Run(flagSet)
+
+			if err != nil {
+				t.Error(err)
+			}
+
+			output := buf.String()
+
+			if strings.Contains(output, "No help topic for") {
+				t.Errorf("expect a help topic, got none: \n%q", output)
+			}
+
+			for _, shouldContain := range []string{
+				cmd.Name, cmd.Description,
+				subCmdBar.Name, subCmdBar.Usage,
+				subCmdBaz.Name, subCmdBaz.Usage,
+			} {
+				if !strings.Contains(output, shouldContain) {
+					t.Errorf("want help to contain %q, did not: \n%q", shouldContain, output)
+				}
+			}
+		})
 	}
 }
 
@@ -1610,31 +1612,31 @@ func TestApp_Run_Help(t *testing.T) {
 	var helpArguments = [][]string{{"boom", "--help"}, {"boom", "-h"}, {"boom", "help"}}
 
 	for _, args := range helpArguments {
-		buf := new(bytes.Buffer)
+		t.Run(fmt.Sprintf("checking with arguments %v", args), func(t *testing.T) {
 
-		t.Logf("==> checking with arguments %v", args)
+			buf := new(bytes.Buffer)
 
-		app := &App{
-			Name:   "boom",
-			Usage:  "make an explosive entrance",
-			Writer: buf,
-			Action: func(c *Context) error {
-				buf.WriteString("boom I say!")
-				return nil
-			},
-		}
+			app := &App{
+				Name:   "boom",
+				Usage:  "make an explosive entrance",
+				Writer: buf,
+				Action: func(c *Context) error {
+					buf.WriteString("boom I say!")
+					return nil
+				},
+			}
 
-		err := app.Run(args)
-		if err != nil {
-			t.Error(err)
-		}
+			err := app.Run(args)
+			if err != nil {
+				t.Error(err)
+			}
 
-		output := buf.String()
-		t.Logf("output: %q\n", buf.Bytes())
+			output := buf.String()
 
-		if !strings.Contains(output, "boom - make an explosive entrance") {
-			t.Errorf("want help to contain %q, did not: \n%q", "boom - make an explosive entrance", output)
-		}
+			if !strings.Contains(output, "boom - make an explosive entrance") {
+				t.Errorf("want help to contain %q, did not: \n%q", "boom - make an explosive entrance", output)
+			}
+		})
 	}
 }
 
@@ -1642,32 +1644,32 @@ func TestApp_Run_Version(t *testing.T) {
 	var versionArguments = [][]string{{"boom", "--version"}, {"boom", "-v"}}
 
 	for _, args := range versionArguments {
-		buf := new(bytes.Buffer)
+		t.Run(fmt.Sprintf("checking with arguments %v", args), func(t *testing.T) {
 
-		t.Logf("==> checking with arguments %v", args)
+			buf := new(bytes.Buffer)
 
-		app := &App{
-			Name:    "boom",
-			Usage:   "make an explosive entrance",
-			Version: "0.1.0",
-			Writer:  buf,
-			Action: func(c *Context) error {
-				buf.WriteString("boom I say!")
-				return nil
-			},
-		}
+			app := &App{
+				Name:    "boom",
+				Usage:   "make an explosive entrance",
+				Version: "0.1.0",
+				Writer:  buf,
+				Action: func(c *Context) error {
+					buf.WriteString("boom I say!")
+					return nil
+				},
+			}
 
-		err := app.Run(args)
-		if err != nil {
-			t.Error(err)
-		}
+			err := app.Run(args)
+			if err != nil {
+				t.Error(err)
+			}
 
-		output := buf.String()
-		t.Logf("output: %q\n", buf.Bytes())
+			output := buf.String()
 
-		if !strings.Contains(output, "0.1.0") {
-			t.Errorf("want version to contain %q, did not: \n%q", "0.1.0", output)
-		}
+			if !strings.Contains(output, "0.1.0") {
+				t.Errorf("want version to contain %q, did not: \n%q", "0.1.0", output)
+			}
+		})
 	}
 }
 
@@ -1835,6 +1837,7 @@ func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 		Action: func(c *Context) error { return nil },
 		Before: func(c *Context) error { return fmt.Errorf("before error") },
 		After:  func(c *Context) error { return fmt.Errorf("after error") },
+		Writer: ioutil.Discard,
 	}
 
 	err := app.Run([]string{"foo"})
@@ -1979,7 +1982,8 @@ func (c *customBoolFlag) IsSet() bool {
 
 func TestCustomFlagsUnused(t *testing.T) {
 	app := &App{
-		Flags: []Flag{&customBoolFlag{"custom"}},
+		Flags:  []Flag{&customBoolFlag{"custom"}},
+		Writer: ioutil.Discard,
 	}
 
 	err := app.Run([]string{"foo"})
@@ -1990,7 +1994,8 @@ func TestCustomFlagsUnused(t *testing.T) {
 
 func TestCustomFlagsUsed(t *testing.T) {
 	app := &App{
-		Flags: []Flag{&customBoolFlag{"custom"}},
+		Flags:  []Flag{&customBoolFlag{"custom"}},
+		Writer: ioutil.Discard,
 	}
 
 	err := app.Run([]string{"foo", "--custom=bar"})
@@ -2000,7 +2005,9 @@ func TestCustomFlagsUsed(t *testing.T) {
 }
 
 func TestCustomHelpVersionFlags(t *testing.T) {
-	app := &App{}
+	app := &App{
+		Writer: ioutil.Discard,
+	}
 
 	// Be sure to reset the global flags
 	defer func(helpFlag Flag, versionFlag Flag) {
@@ -2018,7 +2025,7 @@ func TestCustomHelpVersionFlags(t *testing.T) {
 }
 
 func TestHandleExitCoder_Default(t *testing.T) {
-	app := NewApp()
+	app := newTestApp()
 	fs, err := flagSet(app.Name, app.Flags)
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
@@ -2034,7 +2041,7 @@ func TestHandleExitCoder_Default(t *testing.T) {
 }
 
 func TestHandleExitCoder_Custom(t *testing.T) {
-	app := NewApp()
+	app := newTestApp()
 	fs, err := flagSet(app.Name, app.Flags)
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
@@ -2091,6 +2098,7 @@ func TestShellCompletionForIncompleteFlags(t *testing.T) {
 		Action: func(ctx *Context) error {
 			return fmt.Errorf("should not get here")
 		},
+		Writer: ioutil.Discard,
 	}
 	err := app.Run([]string{"", "--test-completion", "--" + "generate-bash-completion"})
 	if err != nil {
@@ -2101,7 +2109,7 @@ func TestShellCompletionForIncompleteFlags(t *testing.T) {
 func TestWhenExitSubCommandWithCodeThenAppQuitUnexpectedly(t *testing.T) {
 	testCode := 104
 
-	app := NewApp()
+	app := newTestApp()
 	app.Commands = []*Command{
 		{
 			Name: "cmd",
@@ -2120,7 +2128,6 @@ func TestWhenExitSubCommandWithCodeThenAppQuitUnexpectedly(t *testing.T) {
 	var exitCodeFromExitErrHandler int
 	app.ExitErrHandler = func(c *Context, err error) {
 		if exitErr, ok := err.(ExitCoder); ok {
-			t.Log(exitErr)
 			exitCodeFromExitErrHandler = exitErr.ExitCode()
 		}
 	}
@@ -2150,4 +2157,10 @@ func TestWhenExitSubCommandWithCodeThenAppQuitUnexpectedly(t *testing.T) {
 	if exitCodeFromExitErrHandler != testCode {
 		t.Errorf("exitCodeFromOsExiter valeu should be %v, but its value is %v", testCode, exitCodeFromExitErrHandler)
 	}
+}
+
+func newTestApp() *App {
+	a := NewApp()
+	a.Writer = ioutil.Discard
+	return a
 }

--- a/command_test.go
+++ b/command_test.go
@@ -93,7 +93,7 @@ func TestParseAndRunShortOpts(t *testing.T) {
 			},
 		}
 
-		app := NewApp()
+		app := newTestApp()
 		app.Commands = []*Command{cmd}
 
 		err := app.Run(c.testArgs)
@@ -116,6 +116,7 @@ func TestCommand_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 				},
 			},
 		},
+		Writer: ioutil.Discard,
 	}
 
 	err := app.Run([]string{"foo", "bar"})
@@ -317,12 +318,12 @@ func TestCommandSkipFlagParsing(t *testing.T) {
 						&StringFlag{Name: "flag"},
 					},
 					Action: func(c *Context) error {
-						fmt.Printf("%+v\n", c.String("flag"))
 						args = c.Args()
 						return nil
 					},
 				},
 			},
+			Writer: ioutil.Discard,
 		}
 
 		err := app.Run(c.testArgs)

--- a/docs_test.go
+++ b/docs_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func testApp() *App {
-	app := NewApp()
+	app := newTestApp()
 	app.Name = "greet"
 	app.Flags = []Flag{
 		&StringFlag{

--- a/flag_test.go
+++ b/flag_test.go
@@ -1719,6 +1719,7 @@ func TestTimestampFlagApply(t *testing.T) {
 func TestTimestampFlagApply_Fail_Parse_Wrong_Layout(t *testing.T) {
 	fl := TimestampFlag{Name: "time", Aliases: []string{"t"}, Layout: "randomlayout"}
 	set := flag.NewFlagSet("test", 0)
+	set.SetOutput(ioutil.Discard)
 	_ = fl.Apply(set)
 
 	err := set.Parse([]string{"--time", "2006-01-02T15:04:05Z"})
@@ -1728,6 +1729,7 @@ func TestTimestampFlagApply_Fail_Parse_Wrong_Layout(t *testing.T) {
 func TestTimestampFlagApply_Fail_Parse_Wrong_Time(t *testing.T) {
 	fl := TimestampFlag{Name: "time", Aliases: []string{"t"}, Layout: "Jan 2, 2006 at 3:04pm (MST)"}
 	set := flag.NewFlagSet("test", 0)
+	set.SetOutput(ioutil.Discard)
 	_ = fl.Apply(set)
 
 	err := set.Parse([]string{"--time", "2006-01-02T15:04:05Z"})


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## Motivation

Keep the stdout clean if all tests are passed. It helps to debug a broken test, because only a failed test prints to the output.

<!--
  What goal is this change working towards?
  If this PR fixes one of more issues, list them here.
  One line each, like so:
    Fixes #123
    Fixes #39
-->

## Changes

Most of the time we should use a silent `Writer` in the tests.

<!--
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Reviewer Guidelines

I have replaced almost all `NewApp()` calls to `newTestApp()`.
In case when new application initialised like `_ := App{...}` I've just added only new field `Writer: ioutil.Discard`.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->
