### PR TITLE
Use a more k8s/release friendly PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,12 +8,10 @@
 
 _(REQUIRED)_
 
-<!--
-  /kind bug
-  /kind cleanup  
-  /kind documentation
-  /kind feature
- -->
+- [ ] bug
+- [ ] cleanup  
+- [ ] documentation
+- [ ] feature
 
 ## What this PR does / why we need it:
 
@@ -46,17 +44,6 @@ _(fill-in or delete this section)_
    Which parts of the code should reviewers focus on?
 -->
 
-## Release Notes
-
-_(REQUIRED)_
-
-<!--
-  If this PR makes user facing changes, please describe them here. This
-  description will be copied into the release notes/changelog, whenever the
-  next version is released. Keep this section short, and focus on high level
-  changes.
--->
-
 ## Testing
 
 _(fill-in or delete this section)_
@@ -64,3 +51,19 @@ _(fill-in or delete this section)_
 <!--
   Describe how you tested this change.
 -->
+
+## Release Notes
+
+_(REQUIRED)_
+<!--
+  If this PR makes user facing changes, please describe them here. This
+  description will be copied into the release notes/changelog, whenever the
+  next version is released. Keep this section short, and focus on high level
+  changes.
+
+  Put your text between the block. To omit notes, use NONE within the block.
+-->
+
+```release-note
+
+```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,38 +4,57 @@
   If a section of the PR template does not apply to this PR, then delete that section.
  -->
 
-## Motivation
+## What type of PR is this?
 
-_(fill-in or delete this section)_
+_(REQUIRED)_
+
+<!--
+  /kind bug
+  /kind cleanup  
+  /kind documentation
+  /kind feature
+ -->
+
+## What this PR does / why we need it:
+
+_(REQUIRED)_
 
 <!--
   What goal is this change working towards?
+  Provide a bullet pointed summary of how each file was changed.
+  Briefly explain any decisions you made with respect to the changes.
+  Include anything here that you didn't include in *Release Notes*
+  above, such as changes to CI or changes to internal methods.
+-->
+
+## Which issue(s) this PR fixes:
+
+_(REQUIRED)_
+<!--
   If this PR fixes one of more issues, list them here.
   One line each, like so:
     Fixes #123
     Fixes #39
 -->
 
-## Release Notes
+## Special notes for your reviewer:
 
 _(fill-in or delete this section)_
 
 <!--
-  If this PR makes user facing changes, please describe them here.
-  This description will be copied into the release notes, whenever
-  the next version is released. Keep this section short, and
-  focus on high level changes.
+   Is there any particular feedback you would / wouldn't like?
+   Which parts of the code should reviewers focus on?
 -->
 
-## Changes
+## Release Notes
 
-_(fill-in or delete this section)_
+_(REQUIRED)_
 
 <!--
-  Provide a bullet pointed summary of how each file was changed.
-  Briefly explain any decisions you made with respect to the changes.
-  Include anything here that you didn't include in *Release Notes*
-  above, such as changes to CI or changes to internal methods.
+  If this PR makes user facing changes, please describe them here. This
+  description will be copied into the release notes/changelog, whenever the
+  next version is released. Keep this section short, and focus on high level
+  changes.
 -->
 
 ## Testing
@@ -44,13 +63,4 @@ _(fill-in or delete this section)_
 
 <!--
   Describe how you tested this change.
--->
-
-## Reviewer Guidelines
-
-_(fill-in or delete this section)_
-
-<!--
-   Is there any particular feedback you would / wouldn't like?
-   Which parts of the code should reviewers focus on?
 -->


### PR DESCRIPTION
## What type of PR is this?  
  /kind documentation
  
## What this PR does / why we need it:

Modifying the PR template will will enable easier parsing kubernetes release-notes tool (tracked in #965). The tool makes some assumptions about PR bodies so limiting drift between those assumptions and the PR template should make release note generation more reliable.

## Which issue(s) this PR fixes:

Partially addresses #965 

## Special notes for your reviewer:

Tried to keep the spirit of the original template but I've made some sections "Required" if they are important to release notes generation. Also I assume the list of "allowed" labels has been updated (or will be) based on the labels in this template.