### PR TITLE
Revert "Merge pull request #741 from corruptmemory/expose-value"

### DIFF
--- a/context.go
+++ b/context.go
@@ -106,8 +106,8 @@ func (c *Context) Lineage() []*Context {
 	return lineage
 }
 
-// Value returns the value of the flag corresponding to `name`
-func (c *Context) Value(name string) interface{} {
+// value returns the value of the flag corresponding to `name`
+func (c *Context) value(name string) interface{} {
 	return c.flagSet.Lookup(name).Value.(flag.Getter).Get()
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"context"
 	"flag"
-	"os"
 	"sort"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -328,7 +328,7 @@ func TestContextPropagation(t *testing.T) {
 	parent := NewContext(nil, nil, nil)
 	parent.Context = context.WithValue(context.Background(), "key", "val")
 	ctx := NewContext(nil, nil, parent)
-	val := ctx.Context.Value("key")
+	val := ctx.Value("key")
 	if val == nil {
 		t.Fatal("expected a parent context to be inherited but got nil")
 	}

--- a/flag_test.go
+++ b/flag_test.go
@@ -121,8 +121,8 @@ func TestFlagsFromEnv(t *testing.T) {
 		a := App{
 			Flags: []Flag{test.flag},
 			Action: func(ctx *Context) error {
-				if !reflect.DeepEqual(ctx.Value(test.flag.Names()[0]), test.output) {
-					t.Errorf("ex:%01d expected %q to be parsed as %#v, instead was %#v", i, test.input, test.output, ctx.Value(test.flag.Names()[0]))
+				if !reflect.DeepEqual(ctx.value(test.flag.Names()[0]), test.output) {
+					t.Errorf("ex:%01d expected %q to be parsed as %#v, instead was %#v", i, test.input, test.output, ctx.value(test.flag.Names()[0]))
 				}
 				return nil
 			},


### PR DESCRIPTION
## Changes

This reverts commit 108d39a38e17130fe4de61b94ec443bbb265fec4, reversing
changes made to 754ed1bf85da93060d928f9eca0bce83eb5f19be.

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- [x] bug

## What this PR does / why we need it:

https://github.com/urfave/cli/pull/741#issuecomment-573635202

## Testing

I haven't seen a reproduction for this issue, so @Napas if you're investing in seeing this merged you need to provide me with a test case.

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
- Removed changing context to expose a Value accessor from [#741](https://github.com/urfave/cli/pull/741)
```