### PR TITLE
Fix possible panics in slice type assertion

### DIFF
--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -155,11 +155,9 @@ func (c *Context) Float64Slice(name string) []float64 {
 func lookupFloat64Slice(name string, set *flag.FlagSet) []float64 {
 	f := set.Lookup(name)
 	if f != nil {
-		parsed, err := (f.Value.(*Float64Slice)).Value(), error(nil)
-		if err != nil {
-			return nil
+		if slice, ok := f.Value.(*Float64Slice); ok {
+			return slice.Value()
 		}
-		return parsed
 	}
 	return nil
 }

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -151,11 +151,9 @@ func (c *Context) Int64Slice(name string) []int64 {
 func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
 	f := set.Lookup(name)
 	if f != nil {
-		parsed, err := (f.Value.(*Int64Slice)).Value(), error(nil)
-		if err != nil {
-			return nil
+		if slice, ok := f.Value.(*Int64Slice); ok {
+			return slice.Value()
 		}
-		return parsed
 	}
 	return nil
 }

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -165,11 +165,9 @@ func (c *Context) IntSlice(name string) []int {
 func lookupIntSlice(name string, set *flag.FlagSet) []int {
 	f := set.Lookup(name)
 	if f != nil {
-		parsed, err := (f.Value.(*IntSlice)).Value(), error(nil)
-		if err != nil {
-			return nil
+		if slice, ok := f.Value.(*IntSlice); ok {
+			return slice.Value()
 		}
-		return parsed
 	}
 	return nil
 }

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -149,11 +149,9 @@ func (c *Context) StringSlice(name string) []string {
 func lookupStringSlice(name string, set *flag.FlagSet) []string {
 	f := set.Lookup(name)
 	if f != nil {
-		parsed, err := (f.Value.(*StringSlice)).Value(), error(nil)
-		if err != nil {
-			return nil
+		if slice, ok := f.Value.(*StringSlice); ok {
+			return slice.Value()
 		}
-		return parsed
 	}
 	return nil
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Before accessing the slices `.Value()` we should type check that it is
that actual type, otherwise we will end-up in a panic.


## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

None

## Testing

Reproducer:
```go
package main

import (
	"os"

	"github.com/urfave/cli/v2"
)

func main() {
	app := cli.NewApp()
	app.Flags = []cli.Flag{&cli.StringFlag{Name: "test"}}
	app.Action = func(ctx *cli.Context) error {
		ctx.StringSlice("test")
		return nil
	}
	if err := app.Run(os.Args); err != nil {
		os.Exit(1)
	}
}
```

## Release Notes

```release-note
- Fixed possible runtime panic in slice parsing
```