### PR TITLE
Extract cli.Context into an interface

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - v1
+      - v3-development-master
   pull_request:
     branches:
       - master
       - v1
+      - v3-development-master
 
 jobs:
 

--- a/altsrc/flag.go
+++ b/altsrc/flag.go
@@ -13,14 +13,14 @@ import (
 // allows a value to be set on the existing parsed flags.
 type FlagInputSourceExtension interface {
 	cli.Flag
-	ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error
+	ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error
 }
 
 // ApplyInputSourceValues iterates over all provided flags and
 // executes ApplyInputSourceValue on flags implementing the
 // FlagInputSourceExtension interface to initialize these flags
 // to an alternate input source.
-func ApplyInputSourceValues(context *cli.Context, inputSourceContext InputSourceContext, flags []cli.Flag) error {
+func ApplyInputSourceValues(context cli.Context, inputSourceContext InputSourceContext, flags []cli.Flag) error {
 	for _, f := range flags {
 		inputSourceExtendedFlag, isType := f.(FlagInputSourceExtension)
 		if isType {
@@ -38,7 +38,7 @@ func ApplyInputSourceValues(context *cli.Context, inputSourceContext InputSource
 // input source based on the func provided. If there is no error it will then apply the new input source to any flags
 // that are supported by the input source
 func InitInputSource(flags []cli.Flag, createInputSource func() (InputSourceContext, error)) cli.BeforeFunc {
-	return func(context *cli.Context) error {
+	return func(context cli.Context) error {
 		inputSource, err := createInputSource()
 		if err != nil {
 			return fmt.Errorf("Unable to create input source: inner error: \n'%v'", err.Error())
@@ -49,10 +49,10 @@ func InitInputSource(flags []cli.Flag, createInputSource func() (InputSourceCont
 }
 
 // InitInputSourceWithContext is used to to setup an InputSourceContext on a cli.Command Before method. It will create a new
-// input source based on the func provided with potentially using existing cli.Context values to initialize itself. If there is
+// input source based on the func provided with potentially using existing cli.defaultContext values to initialize itself. If there is
 // no error it will then apply the new input source to any flags that are supported by the input source
-func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(context *cli.Context) (InputSourceContext, error)) cli.BeforeFunc {
-	return func(context *cli.Context) error {
+func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(context cli.Context) (InputSourceContext, error)) cli.BeforeFunc {
+	return func(context cli.Context) error {
 		inputSource, err := createInputSource(context)
 		if err != nil {
 			return fmt.Errorf("Unable to create input source with context: inner error: \n'%v'", err.Error())
@@ -63,7 +63,7 @@ func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(context
 }
 
 // ApplyInputSourceValue applies a generic value to the flagSet if required
-func (f *GenericFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *GenericFlag) ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
 		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
 			value, err := isc.Generic(f.GenericFlag.Name)
@@ -82,7 +82,7 @@ func (f *GenericFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourc
 }
 
 // ApplyInputSourceValue applies a StringSlice value to the flagSet if required
-func (f *StringSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *StringSliceFlag) ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
 		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
 			value, err := isc.StringSlice(f.StringSliceFlag.Name)
@@ -104,7 +104,7 @@ func (f *StringSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputS
 }
 
 // ApplyInputSourceValue applies a IntSlice value if required
-func (f *IntSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *IntSliceFlag) ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
 		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
 			value, err := isc.IntSlice(f.IntSliceFlag.Name)
@@ -126,7 +126,7 @@ func (f *IntSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputSour
 }
 
 // ApplyInputSourceValue applies a Bool value to the flagSet if required
-func (f *BoolFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *BoolFlag) ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
 		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
 			value, err := isc.Bool(f.BoolFlag.Name)
@@ -144,7 +144,7 @@ func (f *BoolFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceCo
 }
 
 // ApplyInputSourceValue applies a String value to the flagSet if required
-func (f *StringFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *StringFlag) ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
 		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.String(f.StringFlag.Name)
@@ -162,7 +162,7 @@ func (f *StringFlag) ApplyInputSourceValue(context *cli.Context, isc InputSource
 }
 
 // ApplyInputSourceValue applies a Path value to the flagSet if required
-func (f *PathFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *PathFlag) ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
 		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.String(f.PathFlag.Name)
@@ -190,7 +190,7 @@ func (f *PathFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceCo
 }
 
 // ApplyInputSourceValue applies a int value to the flagSet if required
-func (f *IntFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *IntFlag) ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
 		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.Int(f.IntFlag.Name)
@@ -208,7 +208,7 @@ func (f *IntFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceCon
 }
 
 // ApplyInputSourceValue applies a Duration value to the flagSet if required
-func (f *DurationFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *DurationFlag) ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
 		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.Duration(f.DurationFlag.Name)
@@ -226,7 +226,7 @@ func (f *DurationFlag) ApplyInputSourceValue(context *cli.Context, isc InputSour
 }
 
 // ApplyInputSourceValue applies a Float64 value to the flagSet if required
-func (f *Float64Flag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *Float64Flag) ApplyInputSourceValue(context cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
 		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.Float64(f.Float64Flag.Name)

--- a/altsrc/flag.go
+++ b/altsrc/flag.go
@@ -49,7 +49,7 @@ func InitInputSource(flags []cli.Flag, createInputSource func() (InputSourceCont
 }
 
 // InitInputSourceWithContext is used to to setup an InputSourceContext on a cli.Command Before method. It will create a new
-// input source based on the func provided with potentially using existing cli.defaultContext values to initialize itself. If there is
+// input source based on the func provided with potentially using existing cli.Context values to initialize itself. If there is
 // no error it will then apply the new input source to any flags that are supported by the input source
 func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(context cli.Context) (InputSourceContext, error)) cli.BeforeFunc {
 	return func(context cli.Context) error {

--- a/altsrc/flag_test.go
+++ b/altsrc/flag_test.go
@@ -314,7 +314,7 @@ func runTest(t *testing.T, test testApplyInputSource) cli.Context {
 		valueMap: map[interface{}]interface{}{test.FlagName: test.MapValue},
 	}
 	set := flag.NewFlagSet(test.FlagSetName, flag.ContinueOnError)
-	c := cli.NewContext(nil, set, nil)
+	c := cli.NewContext().WithFlagset(set)
 	if test.EnvVarName != "" && test.EnvVarValue != "" {
 		_ = os.Setenv(test.EnvVarName, test.EnvVarValue)
 		defer os.Setenv(test.EnvVarName, "")

--- a/altsrc/flag_test.go
+++ b/altsrc/flag_test.go
@@ -308,7 +308,7 @@ func TestFloat64ApplyInputSourceMethodEnvVarSet(t *testing.T) {
 	expect(t, 1.4, c.Float64("test"))
 }
 
-func runTest(t *testing.T, test testApplyInputSource) *cli.Context {
+func runTest(t *testing.T, test testApplyInputSource) cli.Context {
 	inputSource := &MapInputSource{
 		file:     test.SourcePath,
 		valueMap: map[interface{}]interface{}{test.FlagName: test.MapValue},

--- a/altsrc/flag_test.go
+++ b/altsrc/flag_test.go
@@ -314,7 +314,7 @@ func runTest(t *testing.T, test testApplyInputSource) cli.Context {
 		valueMap: map[interface{}]interface{}{test.FlagName: test.MapValue},
 	}
 	set := flag.NewFlagSet(test.FlagSetName, flag.ContinueOnError)
-	c := cli.NewContext().WithFlagset(set)
+	c := cli.NewContext().WithFlagSet(set)
 	if test.EnvVarName != "" && test.EnvVarValue != "" {
 		_ = os.Setenv(test.EnvVarName, test.EnvVarValue)
 		defer os.Setenv(test.EnvVarName, "")

--- a/altsrc/json_command_test.go
+++ b/altsrc/json_command_test.go
@@ -24,7 +24,7 @@ func TestCommandJSONFileTest(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -58,7 +58,7 @@ func TestCommandJSONFileTestGlobalEnvVarWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -93,7 +93,7 @@ func TestCommandJSONFileTestGlobalEnvVarWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -125,7 +125,7 @@ func TestCommandJSONFileTestSpecifiedFlagWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName, "--test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -157,7 +157,7 @@ func TestCommandJSONFileTestSpecifiedFlagWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName, "--top.test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -189,7 +189,7 @@ func TestCommandJSONFileTestDefaultValueFileWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -221,7 +221,7 @@ func TestCommandJSONFileTestDefaultValueFileWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -256,7 +256,7 @@ func TestCommandJSONFileFlagHasDefaultGlobalEnvJSONSetGlobalEnvWins(t *testing.T
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -290,7 +290,7 @@ func TestCommandJSONFileFlagHasDefaultGlobalEnvJSONSetGlobalEnvWinsNested(t *tes
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",

--- a/altsrc/json_command_test.go
+++ b/altsrc/json_command_test.go
@@ -31,7 +31,7 @@ func TestCommandJSONFileTest(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 15)
 			return nil
@@ -65,7 +65,7 @@ func TestCommandJSONFileTestGlobalEnvVarWins(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 10)
 			return nil
@@ -100,7 +100,7 @@ func TestCommandJSONFileTestGlobalEnvVarWinsNested(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 10)
 			return nil
@@ -132,7 +132,7 @@ func TestCommandJSONFileTestSpecifiedFlagWins(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 7)
 			return nil
@@ -164,7 +164,7 @@ func TestCommandJSONFileTestSpecifiedFlagWinsNested(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 7)
 			return nil
@@ -196,7 +196,7 @@ func TestCommandJSONFileTestDefaultValueFileWins(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 15)
 			return nil
@@ -228,7 +228,7 @@ func TestCommandJSONFileTestDefaultValueFileWinsNested(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 15)
 			return nil
@@ -263,7 +263,7 @@ func TestCommandJSONFileFlagHasDefaultGlobalEnvJSONSetGlobalEnvWins(t *testing.T
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 11)
 			return nil
@@ -297,7 +297,7 @@ func TestCommandJSONFileFlagHasDefaultGlobalEnvJSONSetGlobalEnvWinsNested(t *tes
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 11)
 			return nil

--- a/altsrc/json_command_test.go
+++ b/altsrc/json_command_test.go
@@ -24,7 +24,7 @@ func TestCommandJSONFileTest(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -58,7 +58,7 @@ func TestCommandJSONFileTestGlobalEnvVarWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -93,7 +93,7 @@ func TestCommandJSONFileTestGlobalEnvVarWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -125,7 +125,7 @@ func TestCommandJSONFileTestSpecifiedFlagWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName, "--test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -157,7 +157,7 @@ func TestCommandJSONFileTestSpecifiedFlagWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName, "--top.test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -189,7 +189,7 @@ func TestCommandJSONFileTestDefaultValueFileWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -221,7 +221,7 @@ func TestCommandJSONFileTestDefaultValueFileWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -256,7 +256,7 @@ func TestCommandJSONFileFlagHasDefaultGlobalEnvJSONSetGlobalEnvWins(t *testing.T
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -290,7 +290,7 @@ func TestCommandJSONFileFlagHasDefaultGlobalEnvJSONSetGlobalEnvWinsNested(t *tes
 	test := []string{"test-cmd", "--load", fileName}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",

--- a/altsrc/json_source_context.go
+++ b/altsrc/json_source_context.go
@@ -11,7 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// NewJSONSourceFromFlagFunc returns a func that takes a cli.defaultContext
+// NewJSONSourceFromFlagFunc returns a func that takes a cli.Context
 // and returns an InputSourceContext suitable for retrieving config
 // variables from a file containing JSON data with the file name defined
 // by the given flag.

--- a/altsrc/json_source_context.go
+++ b/altsrc/json_source_context.go
@@ -11,12 +11,12 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// NewJSONSourceFromFlagFunc returns a func that takes a cli.Context
+// NewJSONSourceFromFlagFunc returns a func that takes a cli.defaultContext
 // and returns an InputSourceContext suitable for retrieving config
 // variables from a file containing JSON data with the file name defined
 // by the given flag.
-func NewJSONSourceFromFlagFunc(flag string) func(c *cli.Context) (InputSourceContext, error) {
-	return func(context *cli.Context) (InputSourceContext, error) {
+func NewJSONSourceFromFlagFunc(flag string) func(c cli.Context) (InputSourceContext, error) {
+	return func(context cli.Context) (InputSourceContext, error) {
 		return NewJSONSourceFromFile(context.String(flag))
 	}
 }

--- a/altsrc/toml_command_test.go
+++ b/altsrc/toml_command_test.go
@@ -24,7 +24,7 @@ func TestCommandTomFileTest(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 15)
 			return nil
@@ -57,7 +57,7 @@ func TestCommandTomlFileTestGlobalEnvVarWins(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 10)
 			return nil
@@ -91,7 +91,7 @@ func TestCommandTomlFileTestGlobalEnvVarWinsNested(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 10)
 			return nil
@@ -123,7 +123,7 @@ func TestCommandTomlFileTestSpecifiedFlagWins(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 7)
 			return nil
@@ -156,7 +156,7 @@ func TestCommandTomlFileTestSpecifiedFlagWinsNested(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 7)
 			return nil
@@ -188,7 +188,7 @@ func TestCommandTomlFileTestDefaultValueFileWins(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 15)
 			return nil
@@ -220,7 +220,7 @@ func TestCommandTomlFileTestDefaultValueFileWinsNested(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 15)
 			return nil
@@ -255,7 +255,7 @@ func TestCommandTomlFileFlagHasDefaultGlobalEnvTomlSetGlobalEnvWins(t *testing.T
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 11)
 			return nil
@@ -289,7 +289,7 @@ func TestCommandTomlFileFlagHasDefaultGlobalEnvTomlSetGlobalEnvWinsNested(t *tes
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 11)
 			return nil

--- a/altsrc/toml_command_test.go
+++ b/altsrc/toml_command_test.go
@@ -17,7 +17,7 @@ func TestCommandTomFileTest(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -50,7 +50,7 @@ func TestCommandTomlFileTestGlobalEnvVarWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -84,7 +84,7 @@ func TestCommandTomlFileTestGlobalEnvVarWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -116,7 +116,7 @@ func TestCommandTomlFileTestSpecifiedFlagWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml", "--test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -149,7 +149,7 @@ func TestCommandTomlFileTestSpecifiedFlagWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml", "--top.test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -181,7 +181,7 @@ func TestCommandTomlFileTestDefaultValueFileWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -213,7 +213,7 @@ func TestCommandTomlFileTestDefaultValueFileWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -248,7 +248,7 @@ func TestCommandTomlFileFlagHasDefaultGlobalEnvTomlSetGlobalEnvWins(t *testing.T
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -282,7 +282,7 @@ func TestCommandTomlFileFlagHasDefaultGlobalEnvTomlSetGlobalEnvWinsNested(t *tes
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",

--- a/altsrc/toml_command_test.go
+++ b/altsrc/toml_command_test.go
@@ -17,7 +17,7 @@ func TestCommandTomFileTest(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -50,7 +50,7 @@ func TestCommandTomlFileTestGlobalEnvVarWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -84,7 +84,7 @@ func TestCommandTomlFileTestGlobalEnvVarWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -116,7 +116,7 @@ func TestCommandTomlFileTestSpecifiedFlagWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml", "--test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -149,7 +149,7 @@ func TestCommandTomlFileTestSpecifiedFlagWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml", "--top.test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -181,7 +181,7 @@ func TestCommandTomlFileTestDefaultValueFileWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -213,7 +213,7 @@ func TestCommandTomlFileTestDefaultValueFileWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -248,7 +248,7 @@ func TestCommandTomlFileFlagHasDefaultGlobalEnvTomlSetGlobalEnvWins(t *testing.T
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -282,7 +282,7 @@ func TestCommandTomlFileFlagHasDefaultGlobalEnvTomlSetGlobalEnvWinsNested(t *tes
 	test := []string{"test-cmd", "--load", "current.toml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",

--- a/altsrc/toml_file_loader.go
+++ b/altsrc/toml_file_loader.go
@@ -85,8 +85,8 @@ func NewTomlSourceFromFile(file string) (InputSourceContext, error) {
 }
 
 // NewTomlSourceFromFlagFunc creates a new TOML InputSourceContext from a provided flag name and source context.
-func NewTomlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (InputSourceContext, error) {
-	return func(context *cli.Context) (InputSourceContext, error) {
+func NewTomlSourceFromFlagFunc(flagFileName string) func(context cli.Context) (InputSourceContext, error) {
+	return func(context cli.Context) (InputSourceContext, error) {
 		filePath := context.String(flagFileName)
 		return NewTomlSourceFromFile(filePath)
 	}

--- a/altsrc/yaml_command_test.go
+++ b/altsrc/yaml_command_test.go
@@ -24,7 +24,7 @@ func TestCommandYamlFileTest(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 15)
 			return nil
@@ -57,7 +57,7 @@ func TestCommandYamlFileTestGlobalEnvVarWins(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 10)
 			return nil
@@ -92,7 +92,7 @@ func TestCommandYamlFileTestGlobalEnvVarWinsNested(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 10)
 			return nil
@@ -124,7 +124,7 @@ func TestCommandYamlFileTestSpecifiedFlagWins(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 7)
 			return nil
@@ -157,7 +157,7 @@ func TestCommandYamlFileTestSpecifiedFlagWinsNested(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 7)
 			return nil
@@ -189,7 +189,7 @@ func TestCommandYamlFileTestDefaultValueFileWins(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 15)
 			return nil
@@ -222,7 +222,7 @@ func TestCommandYamlFileTestDefaultValueFileWinsNested(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 15)
 			return nil
@@ -257,7 +257,7 @@ func TestCommandYamlFileFlagHasDefaultGlobalEnvYamlSetGlobalEnvWins(t *testing.T
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("test")
 			expect(t, val, 11)
 			return nil
@@ -292,7 +292,7 @@ func TestCommandYamlFileFlagHasDefaultGlobalEnvYamlSetGlobalEnvWinsNested(t *tes
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action: func(c *cli.Context) error {
+		Action: func(c cli.Context) error {
 			val := c.Int("top.test")
 			expect(t, val, 11)
 			return nil

--- a/altsrc/yaml_command_test.go
+++ b/altsrc/yaml_command_test.go
@@ -17,7 +17,7 @@ func TestCommandYamlFileTest(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -50,7 +50,7 @@ func TestCommandYamlFileTestGlobalEnvVarWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -85,7 +85,7 @@ func TestCommandYamlFileTestGlobalEnvVarWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -117,7 +117,7 @@ func TestCommandYamlFileTestSpecifiedFlagWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml", "--test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -150,7 +150,7 @@ func TestCommandYamlFileTestSpecifiedFlagWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml", "--top.test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -182,7 +182,7 @@ func TestCommandYamlFileTestDefaultValueFileWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -215,7 +215,7 @@ func TestCommandYamlFileTestDefaultValueFileWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -250,7 +250,7 @@ func TestCommandYamlFileFlagHasDefaultGlobalEnvYamlSetGlobalEnvWins(t *testing.T
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -285,7 +285,7 @@ func TestCommandYamlFileFlagHasDefaultGlobalEnvYamlSetGlobalEnvWinsNested(t *tes
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext().WithApp(app).WithFlagset(set)
+	c := cli.NewContext().WithApp(app).WithFlagSet(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",

--- a/altsrc/yaml_command_test.go
+++ b/altsrc/yaml_command_test.go
@@ -17,7 +17,7 @@ func TestCommandYamlFileTest(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -50,7 +50,7 @@ func TestCommandYamlFileTestGlobalEnvVarWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -85,7 +85,7 @@ func TestCommandYamlFileTestGlobalEnvVarWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -117,7 +117,7 @@ func TestCommandYamlFileTestSpecifiedFlagWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml", "--test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -150,7 +150,7 @@ func TestCommandYamlFileTestSpecifiedFlagWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml", "--top.test", "7"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -182,7 +182,7 @@ func TestCommandYamlFileTestDefaultValueFileWins(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -215,7 +215,7 @@ func TestCommandYamlFileTestDefaultValueFileWinsNested(t *testing.T) {
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -250,7 +250,7 @@ func TestCommandYamlFileFlagHasDefaultGlobalEnvYamlSetGlobalEnvWins(t *testing.T
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",
@@ -285,7 +285,7 @@ func TestCommandYamlFileFlagHasDefaultGlobalEnvYamlSetGlobalEnvWinsNested(t *tes
 	test := []string{"test-cmd", "--load", "current.yaml"}
 	_ = set.Parse(test)
 
-	c := cli.NewContext(app, set, nil)
+	c := cli.NewContext().WithApp(app).WithFlagset(set)
 
 	command := &cli.Command{
 		Name:        "test-cmd",

--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -31,8 +31,8 @@ func NewYamlSourceFromFile(file string) (InputSourceContext, error) {
 }
 
 // NewYamlSourceFromFlagFunc creates a new Yaml InputSourceContext from a provided flag name and source context.
-func NewYamlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (InputSourceContext, error) {
-	return func(context *cli.Context) (InputSourceContext, error) {
+func NewYamlSourceFromFlagFunc(flagFileName string) func(context cli.Context) (InputSourceContext, error) {
+	return func(context cli.Context) (InputSourceContext, error) {
 		filePath := context.String(flagFileName)
 		return NewYamlSourceFromFile(filePath)
 	}

--- a/app.go
+++ b/app.go
@@ -528,4 +528,3 @@ func (a *Author) String() string {
 
 	return fmt.Sprintf("%v%v", a.Name, e)
 }
-

--- a/app.go
+++ b/app.go
@@ -231,7 +231,8 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 
 	err = parseIter(set, a, arguments[1:], shellComplete)
 	nerr := normalizeFlags(a.Flags, set)
-	cntxt := NewContext(a, set, NewWrappedContext(ctx))
+	//cntxt := NewContext(a, set, NewWrappedContext(ctx))
+	cntxt := NewContext().WithApp(a).WithFlagset(set).WithContext(ctx)
 	if nerr != nil {
 		_, _ = fmt.Fprintln(a.Writer, nerr)
 		_ = ShowAppHelp(cntxt)
@@ -357,7 +358,8 @@ func (a *App) RunAsSubcommand(ctx Context) (err error) {
 
 	err = parseIter(set, a, ctx.Args().Tail(), ctx.ShellComplete())
 	nerr := normalizeFlags(a.Flags, set)
-	cntxt := NewContext(a, set, ctx)
+	//cntxt := NewContext(a, set, ctx)
+	cntxt := NewContext().WithApp(a).WithFlagset(set).WithParent(ctx)
 
 	if nerr != nil {
 		_, _ = fmt.Fprintln(a.Writer, nerr)

--- a/app.go
+++ b/app.go
@@ -210,7 +210,7 @@ func (a *App) Run(arguments []string) (err error) {
 	return a.RunContext(context.Background(), arguments)
 }
 
-// RunContext is like Run except it takes aContext that will be
+// RunContext is like Run except it takes a Context that will be
 // passed to its commands and sub-commands. Through this, you can
 // propagate timeouts and cancellation requests
 func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
@@ -231,7 +231,7 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 
 	err = parseIter(set, a, arguments[1:], shellComplete)
 	nerr := normalizeFlags(a.Flags, set)
-	cntxt := NewContext(a, set, NewParentContext(ctx))
+	cntxt := NewContext(a, set, NewWrappedContext(ctx))
 	if nerr != nil {
 		_, _ = fmt.Fprintln(a.Writer, nerr)
 		_ = ShowAppHelp(cntxt)

--- a/app.go
+++ b/app.go
@@ -232,7 +232,7 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 	err = parseIter(set, a, arguments[1:], shellComplete)
 	nerr := normalizeFlags(a.Flags, set)
 	//cntxt := NewContext(a, set, NewWrappedContext(ctx))
-	cntxt := NewContext().WithApp(a).WithFlagset(set).WithContext(ctx)
+	cntxt := NewContext().WithApp(a).WithFlagSet(set).WithContext(ctx)
 	if nerr != nil {
 		_, _ = fmt.Fprintln(a.Writer, nerr)
 		_ = ShowAppHelp(cntxt)
@@ -359,7 +359,7 @@ func (a *App) RunAsSubcommand(ctx Context) (err error) {
 	err = parseIter(set, a, ctx.Args().Tail(), ctx.ShellComplete())
 	nerr := normalizeFlags(a.Flags, set)
 	//cntxt := NewContext(a, set, ctx)
-	cntxt := NewContext().WithApp(a).WithFlagset(set).WithParent(ctx)
+	cntxt := NewContext().WithApp(a).WithFlagSet(set).WithParent(ctx)
 
 	if nerr != nil {
 		_, _ = fmt.Fprintln(a.Writer, nerr)

--- a/app_test.go
+++ b/app_test.go
@@ -2013,7 +2013,7 @@ func TestHandleExitCoder_Default(t *testing.T) {
 		t.Errorf("error creating FlagSet: %s", err)
 	}
 
-	ctx := NewContext().WithApp(app).WithFlagset(fs)
+	ctx := NewContext().WithApp(app).WithFlagSet(fs)
 	app.handleExitCoder(ctx, NewExitError("Default Behavior Error", 42))
 
 	output := fakeErrWriter.String()
@@ -2033,7 +2033,7 @@ func TestHandleExitCoder_Custom(t *testing.T) {
 		_, _ = fmt.Fprintln(ErrWriter, "I'm a Custom error handler, I print what I want!")
 	}
 
-	ctx := NewContext().WithApp(app).WithFlagset(fs)
+	ctx := NewContext().WithApp(app).WithFlagSet(fs)
 	app.handleExitCoder(ctx, NewExitError("Default Behavior Error", 42))
 
 	output := fakeErrWriter.String()

--- a/app_test.go
+++ b/app_test.go
@@ -1221,7 +1221,7 @@ func TestApp_VersionPrinter(t *testing.T) {
 	}
 
 	app := &App{}
-	ctx := NewContext(app, nil, nil)
+	ctx := NewContext().WithApp(app)
 	ShowVersion(ctx)
 
 	if wasCalled == false {
@@ -2013,7 +2013,7 @@ func TestHandleExitCoder_Default(t *testing.T) {
 		t.Errorf("error creating FlagSet: %s", err)
 	}
 
-	ctx := NewContext(app, fs, nil)
+	ctx := NewContext().WithApp(app).WithFlagset(fs)
 	app.handleExitCoder(ctx, NewExitError("Default Behavior Error", 42))
 
 	output := fakeErrWriter.String()
@@ -2033,7 +2033,7 @@ func TestHandleExitCoder_Custom(t *testing.T) {
 		_, _ = fmt.Fprintln(ErrWriter, "I'm a Custom error handler, I print what I want!")
 	}
 
-	ctx := NewContext(app, fs, nil)
+	ctx := NewContext().WithApp(app).WithFlagset(fs)
 	app.handleExitCoder(ctx, NewExitError("Default Behavior Error", 42))
 
 	output := fakeErrWriter.String()

--- a/app_test.go
+++ b/app_test.go
@@ -478,7 +478,7 @@ func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {
 
 	set := flag.NewFlagSet("", flag.ContinueOnError)
 	_ = set.Parse([]string{"", "---foo"})
-	c := &defaultContext{flagSet: set}
+	c := &cliContext{flagSet: set}
 
 	err := a.RunAsSubcommand(c)
 

--- a/app_test.go
+++ b/app_test.go
@@ -39,7 +39,7 @@ func ExampleApp_Run() {
 		Flags: []Flag{
 			&StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},
 		},
-		Action: func(c *Context) error {
+		Action: func(c Context) error {
 			fmt.Printf("Hello %v\n", c.String("name"))
 			return nil
 		},
@@ -47,7 +47,7 @@ func ExampleApp_Run() {
 		Authors:   []*Author{{Name: "Oliver Allen", Email: "oliver@toyshop.example.com"}},
 	}
 
-	app.Run(os.Args)
+	_ = app.Run(os.Args)
 	// Output:
 	// Hello Jeremy
 }
@@ -76,7 +76,7 @@ func ExampleApp_Run_subcommand() {
 								Usage: "Name of the person to greet",
 							},
 						},
-						Action: func(c *Context) error {
+						Action: func(c Context) error {
 							fmt.Println("Hello,", c.String("name"))
 							return nil
 						},
@@ -112,7 +112,7 @@ func ExampleApp_Run_appHelp() {
 				Aliases:     []string{"d"},
 				Usage:       "use it to see a description",
 				Description: "This is how we describe describeit the function",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					fmt.Printf("i like to describe things")
 					return nil
 				},
@@ -162,7 +162,7 @@ func ExampleApp_Run_commandHelp() {
 				Aliases:     []string{"d"},
 				Usage:       "use it to see a description",
 				Description: "This is how we describe describeit the function",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					fmt.Printf("i like to describe things")
 					return nil
 				},
@@ -328,7 +328,7 @@ func ExampleApp_Run_bashComplete() {
 				Aliases:     []string{"d"},
 				Usage:       "use it to see a description",
 				Description: "This is how we describe describeit the function",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					fmt.Printf("i like to describe things")
 					return nil
 				},
@@ -336,7 +336,7 @@ func ExampleApp_Run_bashComplete() {
 				Name:        "next",
 				Usage:       "next example",
 				Description: "more stuff to see when generating shell completion",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					fmt.Printf("the next example")
 					return nil
 				},
@@ -367,7 +367,7 @@ func ExampleApp_Run_zshComplete() {
 			Aliases:     []string{"d"},
 			Usage:       "use it to see a description",
 			Description: "This is how we describe describeit the function",
-			Action: func(c *Context) error {
+			Action: func(c Context) error {
 				fmt.Printf("i like to describe things")
 				return nil
 			},
@@ -375,7 +375,7 @@ func ExampleApp_Run_zshComplete() {
 			Name:        "next",
 			Usage:       "next example",
 			Description: "more stuff to see when generating bash completion",
-			Action: func(c *Context) error {
+			Action: func(c Context) error {
 				fmt.Printf("the next example")
 				return nil
 			},
@@ -395,7 +395,7 @@ func TestApp_Run(t *testing.T) {
 	s := ""
 
 	app := &App{
-		Action: func(c *Context) error {
+		Action: func(c Context) error {
 			s = s + c.Args().First()
 			return nil
 		},
@@ -440,13 +440,13 @@ func TestApp_Setup_defaultsWriter(t *testing.T) {
 }
 
 func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
-	var context *Context
+	var context Context
 
 	a := &App{
 		Commands: []*Command{
 			{
 				Name: "foo",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					context = c
 					return nil
 				},
@@ -457,7 +457,7 @@ func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
 						Usage: "language for the greeting",
 					},
 				},
-				Before: func(_ *Context) error { return nil },
+				Before: func(_ Context) error { return nil },
 			},
 		},
 	}
@@ -478,7 +478,7 @@ func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {
 
 	set := flag.NewFlagSet("", flag.ContinueOnError)
 	_ = set.Parse([]string{"", "---foo"})
-	c := &Context{flagSet: set}
+	c := &defaultContext{flagSet: set}
 
 	err := a.RunAsSubcommand(c)
 
@@ -496,7 +496,7 @@ func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {
 				Flags: []Flag{
 					&StringFlag{Name: "option", Value: "", Usage: "some option"},
 				},
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					parsedOption = c.String("option")
 					args = c.Args()
 					return nil
@@ -520,7 +520,7 @@ func TestApp_CommandWithDash(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "cmd",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					args = c.Args()
 					return nil
 				},
@@ -541,7 +541,7 @@ func TestApp_CommandWithNoFlagBeforeTerminator(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "cmd",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					args = c.Args()
 					return nil
 				},
@@ -562,13 +562,13 @@ func TestApp_VisibleCommands(t *testing.T) {
 			{
 				Name:     "frob",
 				HelpName: "foo frob",
-				Action:   func(_ *Context) error { return nil },
+				Action:   func(_ Context) error { return nil },
 			},
 			{
 				Name:     "frib",
 				HelpName: "foo frib",
 				Hidden:   true,
-				Action:   func(_ *Context) error { return nil },
+				Action:   func(_ Context) error { return nil },
 			},
 		},
 	}
@@ -619,7 +619,7 @@ func TestApp_UseShortOptionHandling(t *testing.T) {
 		&BoolFlag{Name: "two", Aliases: []string{"t"}},
 		&StringFlag{Name: "name", Aliases: []string{"n"}},
 	}
-	app.Action = func(c *Context) error {
+	app.Action = func(c Context) error {
 		one = c.Bool("one")
 		two = c.Bool("two")
 		name = c.String("name")
@@ -657,7 +657,7 @@ func TestApp_UseShortOptionHandlingCommand(t *testing.T) {
 			&BoolFlag{Name: "two", Aliases: []string{"t"}},
 			&StringFlag{Name: "name", Aliases: []string{"n"}},
 		},
-		Action: func(c *Context) error {
+		Action: func(c Context) error {
 			one = c.Bool("one")
 			two = c.Bool("two")
 			name = c.String("name")
@@ -704,7 +704,7 @@ func TestApp_UseShortOptionHandlingSubCommand(t *testing.T) {
 			&BoolFlag{Name: "two", Aliases: []string{"t"}},
 			&StringFlag{Name: "name", Aliases: []string{"n"}},
 		},
-		Action: func(c *Context) error {
+		Action: func(c Context) error {
 			one = c.Bool("one")
 			two = c.Bool("two")
 			name = c.String("name")
@@ -747,7 +747,7 @@ func TestApp_Float64Flag(t *testing.T) {
 		Flags: []Flag{
 			&Float64Flag{Name: "height", Value: 1.5, Usage: "Set the height, in meters"},
 		},
-		Action: func(c *Context) error {
+		Action: func(c Context) error {
 			meters = c.Float64("height")
 			return nil
 		},
@@ -769,7 +769,7 @@ func TestApp_ParseSliceFlags(t *testing.T) {
 					&IntSliceFlag{Name: "p", Value: NewIntSlice(), Usage: "set one or more ip addr"},
 					&StringSliceFlag{Name: "ip", Value: NewStringSlice(), Usage: "set one or more ports to open"},
 				},
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					parsedIntSlice = c.IntSlice("p")
 					parsedStringSlice = c.StringSlice("ip")
 					return nil
@@ -827,7 +827,7 @@ func TestApp_ParseSliceFlagsWithMissingValue(t *testing.T) {
 					&IntSliceFlag{Name: "a", Usage: "set numbers"},
 					&StringSliceFlag{Name: "str", Usage: "set strings"},
 				},
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					parsedIntSlice = c.IntSlice("a")
 					parsedStringSlice = c.StringSlice("str")
 					return nil
@@ -884,7 +884,7 @@ func TestApp_BeforeFunc(t *testing.T) {
 	var err error
 
 	app := &App{
-		Before: func(c *Context) error {
+		Before: func(c Context) error {
 			counts.Total++
 			counts.Before = counts.Total
 			s := c.String("opt")
@@ -897,7 +897,7 @@ func TestApp_BeforeFunc(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "sub",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					counts.Total++
 					counts.SubCommand = counts.Total
 					return nil
@@ -948,7 +948,7 @@ func TestApp_BeforeFunc(t *testing.T) {
 	counts = &opCounts{}
 
 	afterError := errors.New("fail again")
-	app.After = func(_ *Context) error {
+	app.After = func(_ Context) error {
 		return afterError
 	}
 
@@ -975,7 +975,7 @@ func TestApp_AfterFunc(t *testing.T) {
 	var err error
 
 	app := &App{
-		After: func(c *Context) error {
+		After: func(c Context) error {
 			counts.Total++
 			counts.After = counts.Total
 			s := c.String("opt")
@@ -988,7 +988,7 @@ func TestApp_AfterFunc(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "sub",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					counts.Total++
 					counts.SubCommand = counts.Total
 					return nil
@@ -1216,7 +1216,7 @@ func TestApp_VersionPrinter(t *testing.T) {
 	}()
 
 	var wasCalled = false
-	VersionPrinter = func(c *Context) {
+	VersionPrinter = func(c Context) {
 		wasCalled = true
 	}
 
@@ -1232,14 +1232,14 @@ func TestApp_VersionPrinter(t *testing.T) {
 func TestApp_CommandNotFound(t *testing.T) {
 	counts := &opCounts{}
 	app := &App{
-		CommandNotFound: func(c *Context, command string) {
+		CommandNotFound: func(c Context, command string) {
 			counts.Total++
 			counts.CommandNotFound = counts.Total
 		},
 		Commands: []*Command{
 			{
 				Name: "bar",
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					counts.Total++
 					counts.SubCommand = counts.Total
 					return nil
@@ -1262,11 +1262,11 @@ func TestApp_OrderOfOperations(t *testing.T) {
 
 	app := &App{
 		EnableBashCompletion: true,
-		BashComplete: func(c *Context) {
+		BashComplete: func(c Context) {
 			counts.Total++
 			counts.ShellComplete = counts.Total
 		},
-		OnUsageError: func(c *Context, err error, isSubcommand bool) error {
+		OnUsageError: func(c Context, err error, isSubcommand bool) error {
 			counts.Total++
 			counts.OnUsageError = counts.Total
 			return errors.New("hay OnUsageError")
@@ -1274,31 +1274,31 @@ func TestApp_OrderOfOperations(t *testing.T) {
 		Writer: ioutil.Discard,
 	}
 
-	beforeNoError := func(c *Context) error {
+	beforeNoError := func(c Context) error {
 		counts.Total++
 		counts.Before = counts.Total
 		return nil
 	}
 
-	beforeError := func(c *Context) error {
+	beforeError := func(c Context) error {
 		counts.Total++
 		counts.Before = counts.Total
 		return errors.New("hay Before")
 	}
 
 	app.Before = beforeNoError
-	app.CommandNotFound = func(c *Context, command string) {
+	app.CommandNotFound = func(c Context, command string) {
 		counts.Total++
 		counts.CommandNotFound = counts.Total
 	}
 
-	afterNoError := func(c *Context) error {
+	afterNoError := func(c Context) error {
 		counts.Total++
 		counts.After = counts.Total
 		return nil
 	}
 
-	afterError := func(c *Context) error {
+	afterError := func(c Context) error {
 		counts.Total++
 		counts.After = counts.Total
 		return errors.New("hay After")
@@ -1308,7 +1308,7 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	app.Commands = []*Command{
 		{
 			Name: "bar",
-			Action: func(c *Context) error {
+			Action: func(c Context) error {
 				counts.Total++
 				counts.SubCommand = counts.Total
 				return nil
@@ -1316,7 +1316,7 @@ func TestApp_OrderOfOperations(t *testing.T) {
 		},
 	}
 
-	app.Action = func(c *Context) error {
+	app.Action = func(c Context) error {
 		counts.Total++
 		counts.Action = counts.Total
 		return nil
@@ -1423,7 +1423,7 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 				Name:        "foo",
 				Description: "descriptive wall of text about how it does foo things",
 				Subcommands: []*Command{subCmdBar, subCmdBaz},
-				Action:      func(c *Context) error { return nil },
+				Action:      func(c Context) error { return nil },
 			}
 
 			app.Commands = []*Command{cmd}
@@ -1602,7 +1602,7 @@ func TestApp_Run_Help(t *testing.T) {
 				Name:   "boom",
 				Usage:  "make an explosive entrance",
 				Writer: buf,
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					buf.WriteString("boom I say!")
 					return nil
 				},
@@ -1635,7 +1635,7 @@ func TestApp_Run_Version(t *testing.T) {
 				Usage:   "make an explosive entrance",
 				Version: "0.1.0",
 				Writer:  buf,
-				Action: func(c *Context) error {
+				Action: func(c Context) error {
 					buf.WriteString("boom I say!")
 					return nil
 				},
@@ -1816,9 +1816,9 @@ func TestApp_VisibleCategories(t *testing.T) {
 
 func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 	app := &App{
-		Action: func(c *Context) error { return nil },
-		Before: func(c *Context) error { return fmt.Errorf("before error") },
-		After:  func(c *Context) error { return fmt.Errorf("after error") },
+		Action: func(c Context) error { return nil },
+		Before: func(c Context) error { return fmt.Errorf("before error") },
+		After:  func(c Context) error { return fmt.Errorf("after error") },
 		Writer: ioutil.Discard,
 	}
 
@@ -1845,8 +1845,8 @@ func TestApp_Run_SubcommandDoesNotOverwriteErrorFromBefore(t *testing.T) {
 					},
 				},
 				Name:   "bar",
-				Before: func(c *Context) error { return fmt.Errorf("before error") },
-				After:  func(c *Context) error { return fmt.Errorf("after error") },
+				Before: func(c Context) error { return fmt.Errorf("before error") },
+				After:  func(c Context) error { return fmt.Errorf("after error") },
 			},
 		},
 	}
@@ -1869,7 +1869,7 @@ func TestApp_OnUsageError_WithWrongFlagValue(t *testing.T) {
 		Flags: []Flag{
 			&IntFlag{Name: "flag"},
 		},
-		OnUsageError: func(c *Context, err error, isSubcommand bool) error {
+		OnUsageError: func(c Context, err error, isSubcommand bool) error {
 			if isSubcommand {
 				t.Errorf("Expect no subcommand")
 			}
@@ -1900,7 +1900,7 @@ func TestApp_OnUsageError_WithWrongFlagValue_ForSubcommand(t *testing.T) {
 		Flags: []Flag{
 			&IntFlag{Name: "flag"},
 		},
-		OnUsageError: func(c *Context, err error, isSubcommand bool) error {
+		OnUsageError: func(c Context, err error, isSubcommand bool) error {
 			if isSubcommand {
 				t.Errorf("Expect subcommand")
 			}
@@ -2029,7 +2029,7 @@ func TestHandleExitCoder_Custom(t *testing.T) {
 		t.Errorf("error creating FlagSet: %s", err)
 	}
 
-	app.ExitErrHandler = func(_ *Context, _ error) {
+	app.ExitErrHandler = func(_ Context, _ error) {
 		_, _ = fmt.Fprintln(ErrWriter, "I'm a Custom error handler, I print what I want!")
 	}
 
@@ -2050,18 +2050,18 @@ func TestShellCompletionForIncompleteFlags(t *testing.T) {
 			},
 		},
 		EnableBashCompletion: true,
-		BashComplete: func(ctx *Context) {
-			for _, command := range ctx.App.Commands {
+		BashComplete: func(ctx Context) {
+			for _, command := range ctx.App().Commands {
 				if command.Hidden {
 					continue
 				}
 
 				for _, name := range command.Names() {
-					_, _ = fmt.Fprintln(ctx.App.Writer, name)
+					_, _ = fmt.Fprintln(ctx.App().Writer, name)
 				}
 			}
 
-			for _, fl := range ctx.App.Flags {
+			for _, fl := range ctx.App().Flags {
 				for _, name := range fl.Names() {
 					if name == BashCompletionFlag.Names()[0] {
 						continue
@@ -2070,14 +2070,14 @@ func TestShellCompletionForIncompleteFlags(t *testing.T) {
 					switch name = strings.TrimSpace(name); len(name) {
 					case 0:
 					case 1:
-						_, _ = fmt.Fprintln(ctx.App.Writer, "-"+name)
+						_, _ = fmt.Fprintln(ctx.App().Writer, "-"+name)
 					default:
-						_, _ = fmt.Fprintln(ctx.App.Writer, "--"+name)
+						_, _ = fmt.Fprintln(ctx.App().Writer, "--"+name)
 					}
 				}
 			}
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			return fmt.Errorf("should not get here")
 		},
 		Writer: ioutil.Discard,
@@ -2098,7 +2098,7 @@ func TestWhenExitSubCommandWithCodeThenAppQuitUnexpectedly(t *testing.T) {
 			Subcommands: []*Command{
 				{
 					Name: "subcmd",
-					Action: func(c *Context) error {
+					Action: func(c Context) error {
 						return NewExitError("exit error", testCode)
 					},
 				},
@@ -2108,7 +2108,7 @@ func TestWhenExitSubCommandWithCodeThenAppQuitUnexpectedly(t *testing.T) {
 
 	// set user function as ExitErrHandler
 	var exitCodeFromExitErrHandler int
-	app.ExitErrHandler = func(c *Context, err error) {
+	app.ExitErrHandler = func(c Context, err error) {
 		if exitErr, ok := err.(ExitCoder); ok {
 			exitCodeFromExitErrHandler = exitErr.ExitCode()
 		}

--- a/build.go
+++ b/build.go
@@ -58,11 +58,11 @@ func runCmd(arg string, args ...string) error {
 	return cmd.Run()
 }
 
-func VetActionFunc(_ *cli.Context) error {
+func VetActionFunc(_ cli.Context) error {
 	return runCmd("go", "vet")
 }
 
-func TestActionFunc(c *cli.Context) error {
+func TestActionFunc(c cli.Context) error {
 	for _, pkg := range packages {
 		var packageName string
 
@@ -127,7 +127,7 @@ func testCleanup() error {
 	return nil
 }
 
-func GfmrunActionFunc(c *cli.Context) error {
+func GfmrunActionFunc(c cli.Context) error {
 	filename := c.Args().Get(0)
 	if filename == "" {
 		filename = "README.md"
@@ -160,7 +160,7 @@ func GfmrunActionFunc(c *cli.Context) error {
 	return runCmd("gfmrun", "-c", fmt.Sprint(counter), "-s", filename)
 }
 
-func TocActionFunc(c *cli.Context) error {
+func TocActionFunc(c cli.Context) error {
 	filename := c.Args().Get(0)
 	if filename == "" {
 		filename = "README.md"

--- a/cli.go
+++ b/cli.go
@@ -10,7 +10,7 @@
 //     app := &cli.App{
 //			 Name: "greet",
 //			 Usage: "say a greeting",
-//			 Action: func(c *cli.defaultContext) error {
+//			 Action: func(c *cli.cliContext) error {
 //				 fmt.Println("Greetings")
 //				 return nil
 //			 },

--- a/cli.go
+++ b/cli.go
@@ -10,7 +10,7 @@
 //     app := &cli.App{
 //			 Name: "greet",
 //			 Usage: "say a greeting",
-//			 Action: func(c *cli.Context) error {
+//			 Action: func(c *cli.defaultContext) error {
 //				 fmt.Println("Greetings")
 //				 return nil
 //			 },
@@ -19,5 +19,3 @@
 //     app.Run(os.Args)
 //   }
 package cli
-
-//go:generate go run flag-gen/main.go flag-gen/assets_vfsdata.go

--- a/command.go
+++ b/command.go
@@ -103,7 +103,7 @@ func (c *Command) Run(ctx Context) (err error) {
 	set, err := c.parseFlags(ctx.Args(), ctx.ShellComplete())
 
 	//context := NewContext(ctx.App(), set, ctx)
-	context := NewContext().WithApp(ctx.App()).WithFlagset(set).WithParent(ctx).WithCommand(c)
+	context := NewContext().WithApp(ctx.App()).WithFlagSet(set).WithParent(ctx).WithCommand(c)
 	if checkCommandCompletions(context, c.Name) {
 		return nil
 	}

--- a/command.go
+++ b/command.go
@@ -102,8 +102,9 @@ func (c *Command) Run(ctx Context) (err error) {
 
 	set, err := c.parseFlags(ctx.Args(), ctx.ShellComplete())
 
-	context := NewContext(ctx.App(), set, ctx)
-	context.SetCommand(c)
+	//context := NewContext(ctx.App(), set, ctx)
+	context := NewContext().WithApp(ctx.App()).WithFlagset(set).WithParent(ctx)
+	context.setCommand(c)
 	if checkCommandCompletions(context, c.Name) {
 		return nil
 	}
@@ -157,7 +158,7 @@ func (c *Command) Run(ctx Context) (err error) {
 		c.Action = helpSubcommand.Action
 	}
 
-	context.SetCommand(c)
+	context.setCommand(c)
 	err = c.Action(context)
 
 	if err != nil {

--- a/command.go
+++ b/command.go
@@ -103,8 +103,7 @@ func (c *Command) Run(ctx Context) (err error) {
 	set, err := c.parseFlags(ctx.Args(), ctx.ShellComplete())
 
 	//context := NewContext(ctx.App(), set, ctx)
-	context := NewContext().WithApp(ctx.App()).WithFlagset(set).WithParent(ctx)
-	context.setCommand(c)
+	context := NewContext().WithApp(ctx.App()).WithFlagset(set).WithParent(ctx).WithCommand(c)
 	if checkCommandCompletions(context, c.Name) {
 		return nil
 	}
@@ -158,7 +157,7 @@ func (c *Command) Run(ctx Context) (err error) {
 		c.Action = helpSubcommand.Action
 	}
 
-	context.setCommand(c)
+	context = context.WithCommand(c)
 	err = c.Action(context)
 
 	if err != nil {

--- a/command_test.go
+++ b/command_test.go
@@ -30,7 +30,7 @@ func TestCommandFlagParsing(t *testing.T) {
 		set := flag.NewFlagSet("test", 0)
 		_ = set.Parse(c.testArgs)
 
-		context := NewContext().WithApp(app).WithFlagset(set)
+		context := NewContext().WithApp(app).WithFlagSet(set)
 
 		command := Command{
 			Name:            "test-cmd",

--- a/command_test.go
+++ b/command_test.go
@@ -37,7 +37,7 @@ func TestCommandFlagParsing(t *testing.T) {
 			Aliases:         []string{"tc"},
 			Usage:           "this is for testing",
 			Description:     "testing",
-			Action:          func(_ *Context) error { return nil },
+			Action:          func(_ Context) error { return nil },
 			SkipFlagParsing: c.skipFlagParsing,
 		}
 
@@ -80,7 +80,7 @@ func TestParseAndRunShortOpts(t *testing.T) {
 			Name:        "test",
 			Usage:       "this is for testing",
 			Description: "testing",
-			Action: func(c *Context) error {
+			Action: func(c Context) error {
 				args = c.Args()
 				return nil
 			},
@@ -108,10 +108,10 @@ func TestCommand_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "bar",
-				Before: func(c *Context) error {
+				Before: func(c Context) error {
 					return fmt.Errorf("before error")
 				},
-				After: func(c *Context) error {
+				After: func(c Context) error {
 					return fmt.Errorf("after error")
 				},
 			},
@@ -140,20 +140,20 @@ func TestCommand_Run_BeforeSavesMetadata(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "bar",
-				Before: func(c *Context) error {
-					c.App.Metadata["msg"] = "hello world"
+				Before: func(c Context) error {
+					c.App().Metadata["msg"] = "hello world"
 					return nil
 				},
-				Action: func(c *Context) error {
-					msg, ok := c.App.Metadata["msg"]
+				Action: func(c Context) error {
+					msg, ok := c.App().Metadata["msg"]
 					if !ok {
 						return errors.New("msg not found")
 					}
 					receivedMsgFromAction = msg.(string)
 					return nil
 				},
-				After: func(c *Context) error {
-					msg, ok := c.App.Metadata["msg"]
+				After: func(c Context) error {
+					msg, ok := c.App().Metadata["msg"]
 					if !ok {
 						return errors.New("msg not found")
 					}
@@ -189,8 +189,8 @@ func TestCommand_OnUsageError_hasCommandContext(t *testing.T) {
 				Flags: []Flag{
 					&IntFlag{Name: "flag"},
 				},
-				OnUsageError: func(c *Context, err error, _ bool) error {
-					return fmt.Errorf("intercepted in %s: %s", c.Command.Name, err.Error())
+				OnUsageError: func(c Context, err error, _ bool) error {
+					return fmt.Errorf("intercepted in %s: %s", c.Command().Name, err.Error())
 				},
 			},
 		},
@@ -214,7 +214,7 @@ func TestCommand_OnUsageError_WithWrongFlagValue(t *testing.T) {
 				Flags: []Flag{
 					&IntFlag{Name: "flag"},
 				},
-				OnUsageError: func(c *Context, err error, _ bool) error {
+				OnUsageError: func(c Context, err error, _ bool) error {
 					if !strings.HasPrefix(err.Error(), "invalid value \"wrong\"") {
 						t.Errorf("Expect an invalid value error, but got \"%v\"", err)
 					}
@@ -247,7 +247,7 @@ func TestCommand_OnUsageError_WithSubcommand(t *testing.T) {
 				Flags: []Flag{
 					&IntFlag{Name: "flag"},
 				},
-				OnUsageError: func(c *Context, err error, _ bool) error {
+				OnUsageError: func(c Context, err error, _ bool) error {
 					if !strings.HasPrefix(err.Error(), "invalid value \"wrong\"") {
 						t.Errorf("Expect an invalid value error, but got \"%v\"", err)
 					}
@@ -278,8 +278,8 @@ func TestCommand_Run_SubcommandsCanUseErrWriter(t *testing.T) {
 					{
 						Name:  "baz",
 						Usage: "this is for testing",
-						Action: func(c *Context) error {
-							if c.App.ErrWriter != ioutil.Discard {
+						Action: func(c Context) error {
+							if c.App().ErrWriter != ioutil.Discard {
 								return fmt.Errorf("ErrWriter not passed")
 							}
 
@@ -317,7 +317,7 @@ func TestCommandSkipFlagParsing(t *testing.T) {
 					Flags: []Flag{
 						&StringFlag{Name: "flag"},
 					},
-					Action: func(c *Context) error {
+					Action: func(c Context) error {
 						args = c.Args()
 						return nil
 					},
@@ -359,8 +359,8 @@ func TestCommand_Run_CustomShellCompleteAcceptsMalformedFlags(t *testing.T) {
 							Usage: "A number to parse",
 						},
 					},
-					BashComplete: func(c *Context) {
-						fmt.Fprintf(c.App.Writer, "found %d args", c.NArg())
+					BashComplete: func(c Context) {
+						fmt.Fprintf(c.App().Writer, "found %d args", c.NArg())
 					},
 				},
 			},

--- a/command_test.go
+++ b/command_test.go
@@ -30,7 +30,7 @@ func TestCommandFlagParsing(t *testing.T) {
 		set := flag.NewFlagSet("test", 0)
 		_ = set.Parse(c.testArgs)
 
-		context := NewContext(app, set, nil)
+		context := NewContext().WithApp(app).WithFlagset(set)
 
 		command := Command{
 			Name:            "test-cmd",

--- a/context.go
+++ b/context.go
@@ -22,7 +22,6 @@ type Context interface {
 	WithFlagset(set *flag.FlagSet) Context
 	// Functions to be able to manage Context type
 	App() *App
-	setCommand(command *Command)
 	Command() *Command
 	Context() context.Context
 	ParentContext() Context

--- a/context.go
+++ b/context.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	ctx "context"
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -18,7 +18,7 @@ type Context interface {
 	App() *App
 	SetCommand(command *Command)
 	Command() *Command
-	Context() ctx.Context
+	Context() context.Context
 	ParentContext() Context
 	SetShellComplete(shellComplete bool)
 	ShellComplete() bool
@@ -52,7 +52,7 @@ type Context interface {
 }
 
 type cliContext struct {
-	context       ctx.Context
+	context       context.Context
 	app           *App
 	command       *Command
 	shellComplete bool
@@ -74,14 +74,14 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx Context) Context {
 	c.command = &Command{}
 
 	if c.context == nil {
-		c.context = ctx.Background()
+		c.context = context.Background()
 	}
 
 	return c
 }
 
 // NewWrappedContext creates a Context which wraps ctx.Context
-func NewWrappedContext(context ctx.Context) Context {
+func NewWrappedContext(context context.Context) Context {
 	return &cliContext{context: context}
 }
 
@@ -101,7 +101,7 @@ func (c *cliContext) Command() *Command {
 }
 
 // Returns the context.Context wrapped inside the current context
-func (c *cliContext) Context() ctx.Context {
+func (c *cliContext) Context() context.Context {
 	return c.context
 }
 

--- a/context.go
+++ b/context.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Context is an interface that is passed through to
-// each Handler action in a cli application. defaultContext
+// each Handler action in a cli application. It
 // can be used to retrieve context-specific args and
 // parsed command-line options.
 type Context interface {
@@ -80,42 +80,52 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx Context) Context {
 	return c
 }
 
-func NewParentContext(ctx context.Context) Context {
+// NewWrappedContext creates a Context which wraps context.Context
+func NewWrappedContext(ctx context.Context) Context {
 	return &defaultContext{context: ctx}
 }
 
+// Returns the App associated with the current context
 func (c *defaultContext) App() *App {
 	return c.app
 }
 
+// Associates a command with the current context
 func (c *defaultContext) SetCommand(command *Command) {
 	c.command = command
 }
 
+// Returns the Command associated with the current context
 func (c *defaultContext) Command() *Command {
 	return c.command
 }
 
+// Returns the context.Context wrapped inside the current context
 func (c *defaultContext) Context() context.Context {
 	return c.context
 }
 
+// Returns the parent of the current context
 func (c *defaultContext) ParentContext() Context {
 	return c.parentContext
 }
 
+// Sets the shellComplete boolean for the current context
 func (c *defaultContext) SetShellComplete(shellComplete bool) {
 	c.shellComplete = shellComplete
 }
 
+// Returns the value of shellComplete boolean for the current context
 func (c *defaultContext) ShellComplete() bool {
 	return c.shellComplete
 }
 
+// Associates a flagset with the current context
 func (c *defaultContext) SetFlagSet(set *flag.FlagSet) {
 	c.flagSet = set
 }
 
+// Returns the flagset associated with the current context
 func (c *defaultContext) FlagSet() *flag.FlagSet {
 	return c.flagSet
 }

--- a/context_test.go
+++ b/context_test.go
@@ -25,8 +25,7 @@ func TestNewContext(t *testing.T) {
 	globalSet.Float64("myflag64", float64(47), "doc")
 	globalCtx := NewContext().WithFlagset(globalSet)
 	command := &Command{Name: "mycommand"}
-	c := NewContext().WithFlagset(set).WithParent(globalCtx)
-	c.setCommand(command)
+	c := NewContext().WithFlagset(set).WithParent(globalCtx).WithCommand(command)
 	expect(t, c.Int("myflag"), 12)
 	expect(t, c.Int64("myflagInt64"), int64(12))
 	expect(t, c.Uint("myflagUint"), uint(93))

--- a/context_test.go
+++ b/context_test.go
@@ -23,10 +23,10 @@ func TestNewContext(t *testing.T) {
 	globalSet.Uint("myflagUint", uint(33), "doc")
 	globalSet.Uint64("myflagUint64", uint64(33), "doc")
 	globalSet.Float64("myflag64", float64(47), "doc")
-	globalCtx := NewContext(nil, globalSet, nil)
+	globalCtx := NewContext().WithFlagset(globalSet)
 	command := &Command{Name: "mycommand"}
-	c := NewContext(nil, set, globalCtx)
-	c.SetCommand(command)
+	c := NewContext().WithFlagset(set).WithParent(globalCtx)
+	c.setCommand(command)
 	expect(t, c.Int("myflag"), 12)
 	expect(t, c.Int64("myflagInt64"), int64(12))
 	expect(t, c.Uint("myflagUint"), uint(93))
@@ -40,8 +40,8 @@ func TestContext_Int(t *testing.T) {
 	set.Int("myflag", 12, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Int("top-flag", 13, "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	c := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	c := NewContext().WithFlagset(set).WithParent(parentCtx)
 	expect(t, c.Int("myflag"), 12)
 	expect(t, c.Int("top-flag"), 13)
 }
@@ -51,8 +51,8 @@ func TestContext_Int64(t *testing.T) {
 	set.Int64("myflagInt64", 12, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Int64("top-flag", 13, "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	c := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	c := NewContext().WithFlagset(set).WithParent(parentCtx)
 	expect(t, c.Int64("myflagInt64"), int64(12))
 	expect(t, c.Int64("top-flag"), int64(13))
 }
@@ -62,8 +62,8 @@ func TestContext_Uint(t *testing.T) {
 	set.Uint("myflagUint", uint(13), "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Uint("top-flag", uint(14), "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	c := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	c := NewContext().WithFlagset(set).WithParent(parentCtx)
 	expect(t, c.Uint("myflagUint"), uint(13))
 	expect(t, c.Uint("top-flag"), uint(14))
 }
@@ -73,8 +73,8 @@ func TestContext_Uint64(t *testing.T) {
 	set.Uint64("myflagUint64", uint64(9), "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Uint64("top-flag", uint64(10), "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	c := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	c := NewContext().WithFlagset(set).WithParent(parentCtx)
 	expect(t, c.Uint64("myflagUint64"), uint64(9))
 	expect(t, c.Uint64("top-flag"), uint64(10))
 }
@@ -84,8 +84,8 @@ func TestContext_Float64(t *testing.T) {
 	set.Float64("myflag", float64(17), "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Float64("top-flag", float64(18), "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	c := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	c := NewContext().WithFlagset(set).WithParent(parentCtx)
 	expect(t, c.Float64("myflag"), float64(17))
 	expect(t, c.Float64("top-flag"), float64(18))
 }
@@ -96,9 +96,9 @@ func TestContext_Duration(t *testing.T) {
 
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Duration("top-flag", 13*time.Second, "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
+	parentCtx := NewContext().WithFlagset(parentSet)
 
-	c := NewContext(nil, set, parentCtx)
+	c := NewContext().WithFlagset(set).WithParent(parentCtx)
 	expect(t, c.Duration("myflag"), 12*time.Second)
 	expect(t, c.Duration("top-flag"), 13*time.Second)
 }
@@ -108,8 +108,8 @@ func TestContext_String(t *testing.T) {
 	set.String("myflag", "hello world", "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.String("top-flag", "hai veld", "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	c := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	c := NewContext().WithFlagset(set).WithParent(parentCtx)
 	expect(t, c.String("myflag"), "hello world")
 	expect(t, c.String("top-flag"), "hai veld")
 }
@@ -119,8 +119,8 @@ func TestContext_Path(t *testing.T) {
 	set.String("path", "path/to/file", "path to file")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.String("top-path", "path/to/top/file", "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	c := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	c := NewContext().WithFlagset(set).WithParent(parentCtx)
 	expect(t, c.Path("path"), "path/to/file")
 	expect(t, c.Path("top-path"), "path/to/top/file")
 }
@@ -130,8 +130,8 @@ func TestContext_Bool(t *testing.T) {
 	set.Bool("myflag", false, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	c := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	c := NewContext().WithFlagset(set).WithParent(parentCtx)
 	expect(t, c.Bool("myflag"), false)
 	expect(t, c.Bool("top-flag"), true)
 }
@@ -139,7 +139,7 @@ func TestContext_Bool(t *testing.T) {
 func TestContext_Args(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("myflag", false, "doc")
-	c := NewContext(nil, set, nil)
+	c := NewContext().WithFlagset(set)
 	_ = set.Parse([]string{"--myflag", "bat", "baz"})
 	expect(t, c.Args().Len(), 2)
 	expect(t, c.Bool("myflag"), true)
@@ -148,7 +148,7 @@ func TestContext_Args(t *testing.T) {
 func TestContext_NArg(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("myflag", false, "doc")
-	c := NewContext(nil, set, nil)
+	c := NewContext().WithFlagset(set)
 	_ = set.Parse([]string{"--myflag", "bat", "baz"})
 	expect(t, c.NArg(), 2)
 }
@@ -160,8 +160,8 @@ func TestContext_IsSet(t *testing.T) {
 	set.String("three-flag", "hello world", "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	ctx := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
 
 	_ = set.Parse([]string{"--one-flag", "--two-flag", "--three-flag", "frob"})
 	_ = parentSet.Parse([]string{"--top-flag"})
@@ -225,8 +225,8 @@ func TestContext_NumFlags(t *testing.T) {
 	set.String("otherflag", "hello world", "doc")
 	globalSet := flag.NewFlagSet("test", 0)
 	globalSet.Bool("myflagGlobal", true, "doc")
-	globalCtx := NewContext(nil, globalSet, nil)
-	c := NewContext(nil, set, globalCtx)
+	globalCtx := NewContext().WithFlagset(globalSet)
+	c := NewContext().WithFlagset(set).WithParent(globalCtx)
 	_ = set.Parse([]string{"--myflag", "--otherflag=foo"})
 	_ = globalSet.Parse([]string{"--myflagGlobal"})
 	expect(t, c.NumFlags(), 2)
@@ -235,7 +235,7 @@ func TestContext_NumFlags(t *testing.T) {
 func TestContext_Set(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Int("int", 5, "an int")
-	c := NewContext(nil, set, nil)
+	c := NewContext().WithFlagset(set)
 
 	expect(t, c.IsSet("int"), false)
 	_ = c.Set("int", "1")
@@ -249,8 +249,8 @@ func TestContext_LocalFlagNames(t *testing.T) {
 	set.String("two-flag", "hello world", "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	ctx := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
 	_ = set.Parse([]string{"--one-flag", "--two-flag=foo"})
 	_ = parentSet.Parse([]string{"--top-flag"})
 
@@ -266,8 +266,8 @@ func TestContext_FlagNames(t *testing.T) {
 	set.String("two-flag", "hello world", "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	ctx := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
 	_ = set.Parse([]string{"--one-flag", "--two-flag=foo"})
 	_ = parentSet.Parse([]string{"--top-flag"})
 
@@ -282,8 +282,8 @@ func TestContext_Lineage(t *testing.T) {
 	set.Bool("local-flag", false, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	ctx := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
 	_ = set.Parse([]string{"--local-flag"})
 	_ = parentSet.Parse([]string{"--top-flag"})
 
@@ -298,8 +298,8 @@ func TestContext_lookupFlagSet(t *testing.T) {
 	set.Bool("local-flag", false, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext(nil, parentSet, nil)
-	ctx := NewContext(nil, set, parentCtx)
+	parentCtx := NewContext().WithFlagset(parentSet)
+	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
 	_ = set.Parse([]string{"--local-flag"})
 	_ = parentSet.Parse([]string{"--top-flag"})
 
@@ -315,7 +315,7 @@ func TestContext_lookupFlagSet(t *testing.T) {
 }
 
 func TestNonNilContext(t *testing.T) {
-	ctx := NewContext(nil, nil, nil)
+	ctx := NewContext()
 	if ctx.Context() == nil {
 		t.Fatal("expected a non nil context when no parent is present")
 	}
@@ -324,8 +324,8 @@ func TestNonNilContext(t *testing.T) {
 // TestContextPropagation tests that
 // cli.Context always has a valid context.Context
 func TestContextPropagation(t *testing.T) {
-	parent := NewContext(nil, nil, NewWrappedContext(context.WithValue(context.Background(), "key", "val")))
-	ctx := NewContext(nil, nil, parent)
+	parent := NewContext().WithContext(context.WithValue(context.Background(), "key", "val"))
+	ctx := NewContext().WithParent(parent)
 	val := ctx.Context().Value("key")
 	if val == nil {
 		t.Fatal("expected a parent context to be inherited but got nil")
@@ -334,8 +334,8 @@ func TestContextPropagation(t *testing.T) {
 	if valstr != "val" {
 		t.Fatalf("expected the context value to be %q but got %q", "val", valstr)
 	}
-	parent = NewContext(nil, nil, nil)
-	ctx = NewContext(nil, nil, parent)
+	parent = NewContext()
+	ctx = NewContext().WithParent(parent)
 	if ctx.Context() == nil {
 		t.Fatal("expected context to not be nil even if the parent's context is nil")
 	}
@@ -403,7 +403,7 @@ func TestContextAttributeAccessing(t *testing.T) {
 			// setup
 			set := flag.NewFlagSet("some-flag-set-name", 0)
 			set.Bool(test.setBoolInput, false, "usage documentation")
-			ctx := NewContext(nil, set, test.newContextInput)
+			ctx := NewContext().WithFlagset(set).WithParent(test.newContextInput)
 
 			// logic under test
 			value := ctx.Bool(test.ctxBoolInput)
@@ -547,7 +547,7 @@ func TestCheckRequiredFlags(t *testing.T) {
 			_ = set.Parse(test.parseInput)
 
 			c := &cliContext{}
-			ctx := NewContext(c.App(), set, c)
+			ctx := NewContext().WithApp(c.App()).WithFlagset(set).WithParent(c)
 			ctx.Command().Flags = test.flags
 
 			// logic under test

--- a/context_test.go
+++ b/context_test.go
@@ -266,7 +266,7 @@ func TestContext_FlagNames(t *testing.T) {
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
 	parentCtx := NewContext().WithFlagSet(parentSet)
-	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
+	ctx := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	_ = set.Parse([]string{"--one-flag", "--two-flag=foo"})
 	_ = parentSet.Parse([]string{"--top-flag"})
 

--- a/context_test.go
+++ b/context_test.go
@@ -322,10 +322,9 @@ func TestNonNilContext(t *testing.T) {
 }
 
 // TestContextPropagation tests that
-// *cli.defaultContext always has a valid
-// context.defaultContext
+// cli.Context always has a valid context.Context
 func TestContextPropagation(t *testing.T) {
-	parent := NewContext(nil, nil, NewParentContext(context.WithValue(context.Background(), "key", "val")))
+	parent := NewContext(nil, nil, NewWrappedContext(context.WithValue(context.Background(), "key", "val")))
 	ctx := NewContext(nil, nil, parent)
 	val := ctx.Context().Value("key")
 	if val == nil {

--- a/context_test.go
+++ b/context_test.go
@@ -23,9 +23,9 @@ func TestNewContext(t *testing.T) {
 	globalSet.Uint("myflagUint", uint(33), "doc")
 	globalSet.Uint64("myflagUint64", uint64(33), "doc")
 	globalSet.Float64("myflag64", float64(47), "doc")
-	globalCtx := NewContext().WithFlagset(globalSet)
+	globalCtx := NewContext().WithFlagSet(globalSet)
 	command := &Command{Name: "mycommand"}
-	c := NewContext().WithFlagset(set).WithParent(globalCtx).WithCommand(command)
+	c := NewContext().WithFlagSet(set).WithParent(globalCtx).WithCommand(command)
 	expect(t, c.Int("myflag"), 12)
 	expect(t, c.Int64("myflagInt64"), int64(12))
 	expect(t, c.Uint("myflagUint"), uint(93))
@@ -39,8 +39,8 @@ func TestContext_Int(t *testing.T) {
 	set.Int("myflag", 12, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Int("top-flag", 13, "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	c := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	c := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	expect(t, c.Int("myflag"), 12)
 	expect(t, c.Int("top-flag"), 13)
 }
@@ -50,8 +50,8 @@ func TestContext_Int64(t *testing.T) {
 	set.Int64("myflagInt64", 12, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Int64("top-flag", 13, "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	c := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	c := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	expect(t, c.Int64("myflagInt64"), int64(12))
 	expect(t, c.Int64("top-flag"), int64(13))
 }
@@ -61,8 +61,8 @@ func TestContext_Uint(t *testing.T) {
 	set.Uint("myflagUint", uint(13), "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Uint("top-flag", uint(14), "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	c := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	c := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	expect(t, c.Uint("myflagUint"), uint(13))
 	expect(t, c.Uint("top-flag"), uint(14))
 }
@@ -72,8 +72,8 @@ func TestContext_Uint64(t *testing.T) {
 	set.Uint64("myflagUint64", uint64(9), "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Uint64("top-flag", uint64(10), "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	c := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	c := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	expect(t, c.Uint64("myflagUint64"), uint64(9))
 	expect(t, c.Uint64("top-flag"), uint64(10))
 }
@@ -83,8 +83,8 @@ func TestContext_Float64(t *testing.T) {
 	set.Float64("myflag", float64(17), "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Float64("top-flag", float64(18), "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	c := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	c := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	expect(t, c.Float64("myflag"), float64(17))
 	expect(t, c.Float64("top-flag"), float64(18))
 }
@@ -95,9 +95,9 @@ func TestContext_Duration(t *testing.T) {
 
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Duration("top-flag", 13*time.Second, "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
+	parentCtx := NewContext().WithFlagSet(parentSet)
 
-	c := NewContext().WithFlagset(set).WithParent(parentCtx)
+	c := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	expect(t, c.Duration("myflag"), 12*time.Second)
 	expect(t, c.Duration("top-flag"), 13*time.Second)
 }
@@ -107,8 +107,8 @@ func TestContext_String(t *testing.T) {
 	set.String("myflag", "hello world", "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.String("top-flag", "hai veld", "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	c := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	c := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	expect(t, c.String("myflag"), "hello world")
 	expect(t, c.String("top-flag"), "hai veld")
 }
@@ -118,8 +118,8 @@ func TestContext_Path(t *testing.T) {
 	set.String("path", "path/to/file", "path to file")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.String("top-path", "path/to/top/file", "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	c := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	c := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	expect(t, c.Path("path"), "path/to/file")
 	expect(t, c.Path("top-path"), "path/to/top/file")
 }
@@ -129,8 +129,8 @@ func TestContext_Bool(t *testing.T) {
 	set.Bool("myflag", false, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	c := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	c := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	expect(t, c.Bool("myflag"), false)
 	expect(t, c.Bool("top-flag"), true)
 }
@@ -138,7 +138,7 @@ func TestContext_Bool(t *testing.T) {
 func TestContext_Args(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("myflag", false, "doc")
-	c := NewContext().WithFlagset(set)
+	c := NewContext().WithFlagSet(set)
 	_ = set.Parse([]string{"--myflag", "bat", "baz"})
 	expect(t, c.Args().Len(), 2)
 	expect(t, c.Bool("myflag"), true)
@@ -147,7 +147,7 @@ func TestContext_Args(t *testing.T) {
 func TestContext_NArg(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("myflag", false, "doc")
-	c := NewContext().WithFlagset(set)
+	c := NewContext().WithFlagSet(set)
 	_ = set.Parse([]string{"--myflag", "bat", "baz"})
 	expect(t, c.NArg(), 2)
 }
@@ -159,8 +159,8 @@ func TestContext_IsSet(t *testing.T) {
 	set.String("three-flag", "hello world", "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	ctx := NewContext().WithFlagSet(set).WithParent(parentCtx)
 
 	_ = set.Parse([]string{"--one-flag", "--two-flag", "--three-flag", "frob"})
 	_ = parentSet.Parse([]string{"--top-flag"})
@@ -224,8 +224,8 @@ func TestContext_NumFlags(t *testing.T) {
 	set.String("otherflag", "hello world", "doc")
 	globalSet := flag.NewFlagSet("test", 0)
 	globalSet.Bool("myflagGlobal", true, "doc")
-	globalCtx := NewContext().WithFlagset(globalSet)
-	c := NewContext().WithFlagset(set).WithParent(globalCtx)
+	globalCtx := NewContext().WithFlagSet(globalSet)
+	c := NewContext().WithFlagSet(set).WithParent(globalCtx)
 	_ = set.Parse([]string{"--myflag", "--otherflag=foo"})
 	_ = globalSet.Parse([]string{"--myflagGlobal"})
 	expect(t, c.NumFlags(), 2)
@@ -234,7 +234,7 @@ func TestContext_NumFlags(t *testing.T) {
 func TestContext_Set(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Int("int", 5, "an int")
-	c := NewContext().WithFlagset(set)
+	c := NewContext().WithFlagSet(set)
 
 	expect(t, c.IsSet("int"), false)
 	_ = c.Set("int", "1")
@@ -248,8 +248,8 @@ func TestContext_LocalFlagNames(t *testing.T) {
 	set.String("two-flag", "hello world", "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	ctx := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	_ = set.Parse([]string{"--one-flag", "--two-flag=foo"})
 	_ = parentSet.Parse([]string{"--top-flag"})
 
@@ -265,7 +265,7 @@ func TestContext_FlagNames(t *testing.T) {
 	set.String("two-flag", "hello world", "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
+	parentCtx := NewContext().WithFlagSet(parentSet)
 	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
 	_ = set.Parse([]string{"--one-flag", "--two-flag=foo"})
 	_ = parentSet.Parse([]string{"--top-flag"})
@@ -281,8 +281,8 @@ func TestContext_Lineage(t *testing.T) {
 	set.Bool("local-flag", false, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	ctx := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	_ = set.Parse([]string{"--local-flag"})
 	_ = parentSet.Parse([]string{"--top-flag"})
 
@@ -297,8 +297,8 @@ func TestContext_lookupFlagSet(t *testing.T) {
 	set.Bool("local-flag", false, "doc")
 	parentSet := flag.NewFlagSet("test", 0)
 	parentSet.Bool("top-flag", true, "doc")
-	parentCtx := NewContext().WithFlagset(parentSet)
-	ctx := NewContext().WithFlagset(set).WithParent(parentCtx)
+	parentCtx := NewContext().WithFlagSet(parentSet)
+	ctx := NewContext().WithFlagSet(set).WithParent(parentCtx)
 	_ = set.Parse([]string{"--local-flag"})
 	_ = parentSet.Parse([]string{"--top-flag"})
 
@@ -402,7 +402,7 @@ func TestContextAttributeAccessing(t *testing.T) {
 			// setup
 			set := flag.NewFlagSet("some-flag-set-name", 0)
 			set.Bool(test.setBoolInput, false, "usage documentation")
-			ctx := NewContext().WithFlagset(set).WithParent(test.newContextInput)
+			ctx := NewContext().WithFlagSet(set).WithParent(test.newContextInput)
 
 			// logic under test
 			value := ctx.Bool(test.ctxBoolInput)
@@ -546,7 +546,7 @@ func TestCheckRequiredFlags(t *testing.T) {
 			_ = set.Parse(test.parseInput)
 
 			c := &cliContext{}
-			ctx := NewContext().WithApp(c.App()).WithFlagset(set).WithParent(c)
+			ctx := NewContext().WithApp(c.App()).WithFlagSet(set).WithParent(c)
 			ctx.Command().Flags = test.flags
 
 			// logic under test

--- a/context_test.go
+++ b/context_test.go
@@ -358,7 +358,7 @@ func TestContextAttributeAccessing(t *testing.T) {
 			testCase:        "empty_with_background_context",
 			setBoolInput:    "",
 			ctxBoolInput:    "",
-			newContextInput: &defaultContext{context: context.Background()},
+			newContextInput: &cliContext{context: context.Background()},
 		},
 		{
 			testCase:        "empty_set_bool_and_present_ctx_bool",
@@ -370,7 +370,7 @@ func TestContextAttributeAccessing(t *testing.T) {
 			testCase:        "present_set_bool_and_present_ctx_bool_with_background_context",
 			setBoolInput:    "",
 			ctxBoolInput:    "ctx-bool",
-			newContextInput: &defaultContext{context: context.Background()},
+			newContextInput: &cliContext{context: context.Background()},
 		},
 		{
 			testCase:        "present_set_bool_and_present_ctx_bool",
@@ -382,7 +382,7 @@ func TestContextAttributeAccessing(t *testing.T) {
 			testCase:        "present_set_bool_and_present_ctx_bool_with_background_context",
 			setBoolInput:    "ctx-bool",
 			ctxBoolInput:    "ctx-bool",
-			newContextInput: &defaultContext{context: context.Background()},
+			newContextInput: &cliContext{context: context.Background()},
 		},
 		{
 			testCase:        "present_set_bool_and_different_ctx_bool",
@@ -394,7 +394,7 @@ func TestContextAttributeAccessing(t *testing.T) {
 			testCase:        "present_set_bool_and_different_ctx_bool_with_background_context",
 			setBoolInput:    "ctx-bool",
 			ctxBoolInput:    "not-ctx-bool",
-			newContextInput: &defaultContext{context: context.Background()},
+			newContextInput: &cliContext{context: context.Background()},
 		},
 	}
 
@@ -546,7 +546,7 @@ func TestCheckRequiredFlags(t *testing.T) {
 			}
 			_ = set.Parse(test.parseInput)
 
-			c := &defaultContext{}
+			c := &cliContext{}
 			ctx := NewContext(c.App(), set, c)
 			ctx.Command().Flags = test.flags
 

--- a/flag_bool.go
+++ b/flag_bool.go
@@ -86,7 +86,7 @@ func (f *BoolFlag) Apply(set *flag.FlagSet) error {
 
 // Bool looks up the value of a local BoolFlag, returns
 // false if not found
-func (c *defaultContext) Bool(name string) bool {
+func (c *cliContext) Bool(name string) bool {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupBool(name, fs)
 	}

--- a/flag_bool.go
+++ b/flag_bool.go
@@ -86,7 +86,7 @@ func (f *BoolFlag) Apply(set *flag.FlagSet) error {
 
 // Bool looks up the value of a local BoolFlag, returns
 // false if not found
-func (c *Context) Bool(name string) bool {
+func (c *defaultContext) Bool(name string) bool {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupBool(name, fs)
 	}

--- a/flag_duration.go
+++ b/flag_duration.go
@@ -85,7 +85,7 @@ func (f *DurationFlag) Apply(set *flag.FlagSet) error {
 
 // Duration looks up the value of a local DurationFlag, returns
 // 0 if not found
-func (c *defaultContext) Duration(name string) time.Duration {
+func (c *cliContext) Duration(name string) time.Duration {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupDuration(name, fs)
 	}

--- a/flag_duration.go
+++ b/flag_duration.go
@@ -85,7 +85,7 @@ func (f *DurationFlag) Apply(set *flag.FlagSet) error {
 
 // Duration looks up the value of a local DurationFlag, returns
 // 0 if not found
-func (c *Context) Duration(name string) time.Duration {
+func (c *defaultContext) Duration(name string) time.Duration {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupDuration(name, fs)
 	}

--- a/flag_float64.go
+++ b/flag_float64.go
@@ -86,7 +86,7 @@ func (f *Float64Flag) Apply(set *flag.FlagSet) error {
 
 // Float64 looks up the value of a local Float64Flag, returns
 // 0 if not found
-func (c *defaultContext) Float64(name string) float64 {
+func (c *cliContext) Float64(name string) float64 {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupFloat64(name, fs)
 	}

--- a/flag_float64.go
+++ b/flag_float64.go
@@ -86,7 +86,7 @@ func (f *Float64Flag) Apply(set *flag.FlagSet) error {
 
 // Float64 looks up the value of a local Float64Flag, returns
 // 0 if not found
-func (c *Context) Float64(name string) float64 {
+func (c *defaultContext) Float64(name string) float64 {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupFloat64(name, fs)
 	}

--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -145,7 +145,7 @@ func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error {
 
 // Float64Slice looks up the value of a local Float64SliceFlag, returns
 // nil if not found
-func (c *defaultContext) Float64Slice(name string) []float64 {
+func (c *cliContext) Float64Slice(name string) []float64 {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupFloat64Slice(name, fs)
 	}

--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -145,7 +145,7 @@ func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error {
 
 // Float64Slice looks up the value of a local Float64SliceFlag, returns
 // nil if not found
-func (c *Context) Float64Slice(name string) []float64 {
+func (c *defaultContext) Float64Slice(name string) []float64 {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupFloat64Slice(name, fs)
 	}

--- a/flag_generic.go
+++ b/flag_generic.go
@@ -88,7 +88,7 @@ func (f GenericFlag) Apply(set *flag.FlagSet) error {
 
 // Generic looks up the value of a local GenericFlag, returns
 // nil if not found
-func (c *Context) Generic(name string) interface{} {
+func (c *defaultContext) Generic(name string) interface{} {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupGeneric(name, fs)
 	}

--- a/flag_generic.go
+++ b/flag_generic.go
@@ -88,7 +88,7 @@ func (f GenericFlag) Apply(set *flag.FlagSet) error {
 
 // Generic looks up the value of a local GenericFlag, returns
 // nil if not found
-func (c *defaultContext) Generic(name string) interface{} {
+func (c *cliContext) Generic(name string) interface{} {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupGeneric(name, fs)
 	}

--- a/flag_int.go
+++ b/flag_int.go
@@ -86,7 +86,7 @@ func (f *IntFlag) Apply(set *flag.FlagSet) error {
 
 // Int looks up the value of a local IntFlag, returns
 // 0 if not found
-func (c *Context) Int(name string) int {
+func (c *defaultContext) Int(name string) int {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupInt(name, fs)
 	}

--- a/flag_int.go
+++ b/flag_int.go
@@ -86,7 +86,7 @@ func (f *IntFlag) Apply(set *flag.FlagSet) error {
 
 // Int looks up the value of a local IntFlag, returns
 // 0 if not found
-func (c *defaultContext) Int(name string) int {
+func (c *cliContext) Int(name string) int {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupInt(name, fs)
 	}

--- a/flag_int64.go
+++ b/flag_int64.go
@@ -85,7 +85,7 @@ func (f *Int64Flag) Apply(set *flag.FlagSet) error {
 
 // Int64 looks up the value of a local Int64Flag, returns
 // 0 if not found
-func (c *Context) Int64(name string) int64 {
+func (c *defaultContext) Int64(name string) int64 {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupInt64(name, fs)
 	}

--- a/flag_int64.go
+++ b/flag_int64.go
@@ -85,7 +85,7 @@ func (f *Int64Flag) Apply(set *flag.FlagSet) error {
 
 // Int64 looks up the value of a local Int64Flag, returns
 // 0 if not found
-func (c *defaultContext) Int64(name string) int64 {
+func (c *cliContext) Int64(name string) int64 {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupInt64(name, fs)
 	}

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -144,7 +144,7 @@ func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error {
 
 // Int64Slice looks up the value of a local Int64SliceFlag, returns
 // nil if not found
-func (c *Context) Int64Slice(name string) []int64 {
+func (c *defaultContext) Int64Slice(name string) []int64 {
 	return lookupInt64Slice(name, c.flagSet)
 }
 

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -144,7 +144,7 @@ func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error {
 
 // Int64Slice looks up the value of a local Int64SliceFlag, returns
 // nil if not found
-func (c *defaultContext) Int64Slice(name string) []int64 {
+func (c *cliContext) Int64Slice(name string) []int64 {
 	return lookupInt64Slice(name, c.flagSet)
 }
 

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -155,7 +155,7 @@ func (f *IntSliceFlag) Apply(set *flag.FlagSet) error {
 
 // IntSlice looks up the value of a local IntSliceFlag, returns
 // nil if not found
-func (c *defaultContext) IntSlice(name string) []int {
+func (c *cliContext) IntSlice(name string) []int {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupIntSlice(name, c.flagSet)
 	}

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -155,7 +155,7 @@ func (f *IntSliceFlag) Apply(set *flag.FlagSet) error {
 
 // IntSlice looks up the value of a local IntSliceFlag, returns
 // nil if not found
-func (c *Context) IntSlice(name string) []int {
+func (c *defaultContext) IntSlice(name string) []int {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupIntSlice(name, c.flagSet)
 	}

--- a/flag_path.go
+++ b/flag_path.go
@@ -74,7 +74,7 @@ func (f *PathFlag) Apply(set *flag.FlagSet) error {
 
 // Path looks up the value of a local PathFlag, returns
 // "" if not found
-func (c *Context) Path(name string) string {
+func (c *defaultContext) Path(name string) string {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupPath(name, fs)
 	}

--- a/flag_path.go
+++ b/flag_path.go
@@ -74,7 +74,7 @@ func (f *PathFlag) Apply(set *flag.FlagSet) error {
 
 // Path looks up the value of a local PathFlag, returns
 // "" if not found
-func (c *defaultContext) Path(name string) string {
+func (c *cliContext) Path(name string) string {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupPath(name, fs)
 	}

--- a/flag_string.go
+++ b/flag_string.go
@@ -75,7 +75,7 @@ func (f *StringFlag) Apply(set *flag.FlagSet) error {
 
 // String looks up the value of a local StringFlag, returns
 // "" if not found
-func (c *defaultContext) String(name string) string {
+func (c *cliContext) String(name string) string {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupString(name, fs)
 	}

--- a/flag_string.go
+++ b/flag_string.go
@@ -75,7 +75,7 @@ func (f *StringFlag) Apply(set *flag.FlagSet) error {
 
 // String looks up the value of a local StringFlag, returns
 // "" if not found
-func (c *Context) String(name string) string {
+func (c *defaultContext) String(name string) string {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupString(name, fs)
 	}

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -139,7 +139,7 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 
 // StringSlice looks up the value of a local StringSliceFlag, returns
 // nil if not found
-func (c *Context) StringSlice(name string) []string {
+func (c *defaultContext) StringSlice(name string) []string {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupStringSlice(name, fs)
 	}

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -139,7 +139,7 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 
 // StringSlice looks up the value of a local StringSliceFlag, returns
 // nil if not found
-func (c *defaultContext) StringSlice(name string) []string {
+func (c *cliContext) StringSlice(name string) []string {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupStringSlice(name, fs)
 	}

--- a/flag_test.go
+++ b/flag_test.go
@@ -120,7 +120,7 @@ func TestFlagsFromEnv(t *testing.T) {
 
 		a := App{
 			Flags: []Flag{test.flag},
-			Action: func(ctx *Context) error {
+			Action: func(ctx Context) error {
 				if !reflect.DeepEqual(ctx.Value(test.flag.Names()[0]), test.output) {
 					t.Errorf("ex:%01d expected %q to be parsed as %#v, instead was %#v", i, test.input, test.output, ctx.Value(test.flag.Names()[0]))
 				}
@@ -813,7 +813,7 @@ func TestParseMultiString(t *testing.T) {
 		Flags: []Flag{
 			&StringFlag{Name: "serve", Aliases: []string{"s"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.String("serve") != "10" {
 				t.Errorf("main name not set")
 			}
@@ -834,7 +834,7 @@ func TestParseDestinationString(t *testing.T) {
 				Destination: &dest,
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if dest != "10" {
 				t.Errorf("expected destination String 10")
 			}
@@ -850,7 +850,7 @@ func TestParseMultiStringFromEnv(t *testing.T) {
 		Flags: []Flag{
 			&StringFlag{Name: "count", Aliases: []string{"c"}, EnvVars: []string{"APP_COUNT"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.String("count") != "20" {
 				t.Errorf("main name not set")
 			}
@@ -869,7 +869,7 @@ func TestParseMultiStringFromEnvCascade(t *testing.T) {
 		Flags: []Flag{
 			&StringFlag{Name: "count", Aliases: []string{"c"}, EnvVars: []string{"COMPAT_COUNT", "APP_COUNT"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.String("count") != "20" {
 				t.Errorf("main name not set")
 			}
@@ -886,7 +886,7 @@ func TestParseMultiStringSlice(t *testing.T) {
 		Flags: []Flag{
 			&StringSliceFlag{Name: "serve", Aliases: []string{"s"}, Value: NewStringSlice()},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			expected := []string{"10", "20"}
 			if !reflect.DeepEqual(ctx.StringSlice("serve"), expected) {
 				t.Errorf("main name not set: %v != %v", expected, ctx.StringSlice("serve"))
@@ -904,7 +904,7 @@ func TestParseMultiStringSliceWithDefaults(t *testing.T) {
 		Flags: []Flag{
 			&StringSliceFlag{Name: "serve", Aliases: []string{"s"}, Value: NewStringSlice("9", "2")},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			expected := []string{"10", "20"}
 			if !reflect.DeepEqual(ctx.StringSlice("serve"), expected) {
 				t.Errorf("main name not set: %v != %v", expected, ctx.StringSlice("serve"))
@@ -922,7 +922,7 @@ func TestParseMultiStringSliceWithDefaultsUnset(t *testing.T) {
 		Flags: []Flag{
 			&StringSliceFlag{Name: "serve", Aliases: []string{"s"}, Value: NewStringSlice("9", "2")},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.StringSlice("serve"), []string{"9", "2"}) {
 				t.Errorf("main name not set: %v", ctx.StringSlice("serve"))
 			}
@@ -942,7 +942,7 @@ func TestParseMultiStringSliceFromEnv(t *testing.T) {
 		Flags: []Flag{
 			&StringSliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewStringSlice(), EnvVars: []string{"APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
 				t.Errorf("main name not set from env")
 			}
@@ -962,7 +962,7 @@ func TestParseMultiStringSliceFromEnvWithDefaults(t *testing.T) {
 		Flags: []Flag{
 			&StringSliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewStringSlice("1", "2", "5"), EnvVars: []string{"APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
 				t.Errorf("main name not set from env")
 			}
@@ -982,7 +982,7 @@ func TestParseMultiStringSliceFromEnvCascade(t *testing.T) {
 		Flags: []Flag{
 			&StringSliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewStringSlice(), EnvVars: []string{"COMPAT_INTERVALS", "APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1002,7 +1002,7 @@ func TestParseMultiStringSliceFromEnvCascadeWithDefaults(t *testing.T) {
 		Flags: []Flag{
 			&StringSliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewStringSlice("1", "2", "5"), EnvVars: []string{"COMPAT_INTERVALS", "APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1019,7 +1019,7 @@ func TestParseMultiInt(t *testing.T) {
 		Flags: []Flag{
 			&IntFlag{Name: "serve", Aliases: []string{"s"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Int("serve") != 10 {
 				t.Errorf("main name not set")
 			}
@@ -1040,7 +1040,7 @@ func TestParseDestinationInt(t *testing.T) {
 				Destination: &dest,
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if dest != 10 {
 				t.Errorf("expected destination Int 10")
 			}
@@ -1056,7 +1056,7 @@ func TestParseMultiIntFromEnv(t *testing.T) {
 		Flags: []Flag{
 			&IntFlag{Name: "timeout", Aliases: []string{"t"}, EnvVars: []string{"APP_TIMEOUT_SECONDS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Int("timeout") != 10 {
 				t.Errorf("main name not set")
 			}
@@ -1075,7 +1075,7 @@ func TestParseMultiIntFromEnvCascade(t *testing.T) {
 		Flags: []Flag{
 			&IntFlag{Name: "timeout", Aliases: []string{"t"}, EnvVars: []string{"COMPAT_TIMEOUT_SECONDS", "APP_TIMEOUT_SECONDS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Int("timeout") != 10 {
 				t.Errorf("main name not set")
 			}
@@ -1092,7 +1092,7 @@ func TestParseMultiIntSlice(t *testing.T) {
 		Flags: []Flag{
 			&IntSliceFlag{Name: "serve", Aliases: []string{"s"}, Value: NewIntSlice()},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.IntSlice("serve"), []int{10, 20}) {
 				t.Errorf("main name not set")
 			}
@@ -1109,7 +1109,7 @@ func TestParseMultiIntSliceWithDefaults(t *testing.T) {
 		Flags: []Flag{
 			&IntSliceFlag{Name: "serve", Aliases: []string{"s"}, Value: NewIntSlice(9, 2)},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.IntSlice("serve"), []int{10, 20}) {
 				t.Errorf("main name not set")
 			}
@@ -1126,7 +1126,7 @@ func TestParseMultiIntSliceWithDefaultsUnset(t *testing.T) {
 		Flags: []Flag{
 			&IntSliceFlag{Name: "serve", Aliases: []string{"s"}, Value: NewIntSlice(9, 2)},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.IntSlice("serve"), []int{9, 2}) {
 				t.Errorf("main name not set")
 			}
@@ -1146,7 +1146,7 @@ func TestParseMultiIntSliceFromEnv(t *testing.T) {
 		Flags: []Flag{
 			&IntSliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewIntSlice(), EnvVars: []string{"APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1166,7 +1166,7 @@ func TestParseMultiIntSliceFromEnvWithDefaults(t *testing.T) {
 		Flags: []Flag{
 			&IntSliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewIntSlice(1, 2, 5), EnvVars: []string{"APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1186,7 +1186,7 @@ func TestParseMultiIntSliceFromEnvCascade(t *testing.T) {
 		Flags: []Flag{
 			&IntSliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewIntSlice(), EnvVars: []string{"COMPAT_INTERVALS", "APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1203,7 +1203,7 @@ func TestParseMultiInt64Slice(t *testing.T) {
 		Flags: []Flag{
 			&Int64SliceFlag{Name: "serve", Aliases: []string{"s"}, Value: NewInt64Slice()},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.Int64Slice("serve"), []int64{10, 17179869184}) {
 				t.Errorf("main name not set")
 			}
@@ -1223,7 +1223,7 @@ func TestParseMultiInt64SliceFromEnv(t *testing.T) {
 		Flags: []Flag{
 			&Int64SliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewInt64Slice(), EnvVars: []string{"APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.Int64Slice("intervals"), []int64{20, 30, 17179869184}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1243,7 +1243,7 @@ func TestParseMultiInt64SliceFromEnvCascade(t *testing.T) {
 		Flags: []Flag{
 			&Int64SliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewInt64Slice(), EnvVars: []string{"COMPAT_INTERVALS", "APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.Int64Slice("intervals"), []int64{20, 30, 17179869184}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1260,7 +1260,7 @@ func TestParseMultiFloat64(t *testing.T) {
 		Flags: []Flag{
 			&Float64Flag{Name: "serve", Aliases: []string{"s"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Float64("serve") != 10.2 {
 				t.Errorf("main name not set")
 			}
@@ -1281,7 +1281,7 @@ func TestParseDestinationFloat64(t *testing.T) {
 				Destination: &dest,
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if dest != 10.2 {
 				t.Errorf("expected destination Float64 10.2")
 			}
@@ -1297,7 +1297,7 @@ func TestParseMultiFloat64FromEnv(t *testing.T) {
 		Flags: []Flag{
 			&Float64Flag{Name: "timeout", Aliases: []string{"t"}, EnvVars: []string{"APP_TIMEOUT_SECONDS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Float64("timeout") != 15.5 {
 				t.Errorf("main name not set")
 			}
@@ -1316,7 +1316,7 @@ func TestParseMultiFloat64FromEnvCascade(t *testing.T) {
 		Flags: []Flag{
 			&Float64Flag{Name: "timeout", Aliases: []string{"t"}, EnvVars: []string{"COMPAT_TIMEOUT_SECONDS", "APP_TIMEOUT_SECONDS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Float64("timeout") != 15.5 {
 				t.Errorf("main name not set")
 			}
@@ -1336,7 +1336,7 @@ func TestParseMultiFloat64SliceFromEnv(t *testing.T) {
 		Flags: []Flag{
 			&Float64SliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewFloat64Slice(), EnvVars: []string{"APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{0.1, -10.5}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1356,7 +1356,7 @@ func TestParseMultiFloat64SliceFromEnvCascade(t *testing.T) {
 		Flags: []Flag{
 			&Float64SliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewFloat64Slice(), EnvVars: []string{"COMPAT_INTERVALS", "APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{0.1234, -10.5}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1373,7 +1373,7 @@ func TestParseMultiBool(t *testing.T) {
 		Flags: []Flag{
 			&BoolFlag{Name: "serve", Aliases: []string{"s"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Bool("serve") != true {
 				t.Errorf("main name not set")
 			}
@@ -1391,7 +1391,7 @@ func TestParseBoolShortOptionHandle(t *testing.T) {
 			{
 				Name:                   "foobar",
 				UseShortOptionHandling: true,
-				Action: func(ctx *Context) error {
+				Action: func(ctx Context) error {
 					if ctx.Bool("serve") != true {
 						t.Errorf("main name not set")
 					}
@@ -1418,7 +1418,7 @@ func TestParseDestinationBool(t *testing.T) {
 				Destination: &dest,
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if dest != true {
 				t.Errorf("expected destination Bool true")
 			}
@@ -1434,7 +1434,7 @@ func TestParseMultiBoolFromEnv(t *testing.T) {
 		Flags: []Flag{
 			&BoolFlag{Name: "debug", Aliases: []string{"d"}, EnvVars: []string{"APP_DEBUG"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Bool("debug") != true {
 				t.Errorf("main name not set from env")
 			}
@@ -1453,7 +1453,7 @@ func TestParseMultiBoolFromEnvCascade(t *testing.T) {
 		Flags: []Flag{
 			&BoolFlag{Name: "debug", Aliases: []string{"d"}, EnvVars: []string{"COMPAT_DEBUG", "APP_DEBUG"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Bool("debug") != true {
 				t.Errorf("main name not set from env")
 			}
@@ -1483,7 +1483,7 @@ func TestParseBoolFromEnv(t *testing.T) {
 			Flags: []Flag{
 				&BoolFlag{Name: "debug", Aliases: []string{"d"}, EnvVars: []string{"DEBUG"}},
 			},
-			Action: func(ctx *Context) error {
+			Action: func(ctx Context) error {
 				if ctx.Bool("debug") != test.output {
 					t.Errorf("expected %+v to be parsed as %+v, instead was %+v", test.input, test.output, ctx.Bool("debug"))
 				}
@@ -1501,7 +1501,7 @@ func TestParseMultiBoolT(t *testing.T) {
 		Flags: []Flag{
 			&BoolFlag{Name: "implode", Aliases: []string{"i"}, Value: true},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Bool("implode") {
 				t.Errorf("main name not set")
 			}
@@ -1540,7 +1540,7 @@ func TestParseGeneric(t *testing.T) {
 		Flags: []Flag{
 			&GenericFlag{Name: "serve", Aliases: []string{"s"}, Value: &Parser{}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.Generic("serve"), &Parser{"10", "20"}) {
 				t.Errorf("main name not set")
 			}
@@ -1564,7 +1564,7 @@ func TestParseGenericFromEnv(t *testing.T) {
 				EnvVars: []string{"APP_SERVE"},
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.Generic("serve"), &Parser{"20", "30"}) {
 				t.Errorf("main name not set from env")
 			}
@@ -1587,7 +1587,7 @@ func TestParseGenericFromEnvCascade(t *testing.T) {
 				EnvVars: []string{"COMPAT_FOO", "APP_FOO"},
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if !reflect.DeepEqual(ctx.Generic("foos"), &Parser{"99", "2000"}) {
 				t.Errorf("value not set from env")
 			}

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -135,7 +135,7 @@ func (f *TimestampFlag) Apply(set *flag.FlagSet) error {
 }
 
 // Timestamp gets the timestamp from a flag name
-func (c *defaultContext) Timestamp(name string) *time.Time {
+func (c *cliContext) Timestamp(name string) *time.Time {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupTimestamp(name, fs)
 	}

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -135,7 +135,7 @@ func (f *TimestampFlag) Apply(set *flag.FlagSet) error {
 }
 
 // Timestamp gets the timestamp from a flag name
-func (c *Context) Timestamp(name string) *time.Time {
+func (c *defaultContext) Timestamp(name string) *time.Time {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupTimestamp(name, fs)
 	}

--- a/flag_uint.go
+++ b/flag_uint.go
@@ -85,7 +85,7 @@ func (f *UintFlag) GetValue() string {
 
 // Uint looks up the value of a local UintFlag, returns
 // 0 if not found
-func (c *Context) Uint(name string) uint {
+func (c *defaultContext) Uint(name string) uint {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupUint(name, fs)
 	}

--- a/flag_uint.go
+++ b/flag_uint.go
@@ -85,7 +85,7 @@ func (f *UintFlag) GetValue() string {
 
 // Uint looks up the value of a local UintFlag, returns
 // 0 if not found
-func (c *defaultContext) Uint(name string) uint {
+func (c *cliContext) Uint(name string) uint {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupUint(name, fs)
 	}

--- a/flag_uint64.go
+++ b/flag_uint64.go
@@ -85,7 +85,7 @@ func (f *Uint64Flag) GetValue() string {
 
 // Uint64 looks up the value of a local Uint64Flag, returns
 // 0 if not found
-func (c *defaultContext) Uint64(name string) uint64 {
+func (c *cliContext) Uint64(name string) uint64 {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupUint64(name, fs)
 	}

--- a/flag_uint64.go
+++ b/flag_uint64.go
@@ -85,7 +85,7 @@ func (f *Uint64Flag) GetValue() string {
 
 // Uint64 looks up the value of a local Uint64Flag, returns
 // 0 if not found
-func (c *Context) Uint64(name string) uint64 {
+func (c *defaultContext) Uint64(name string) uint64 {
 	if fs := lookupFlagSet(name, c); fs != nil {
 		return lookupUint64(name, fs)
 	}

--- a/funcs.go
+++ b/funcs.go
@@ -1,31 +1,31 @@
 package cli
 
 // BashCompleteFunc is an action to execute when the shell completion flag is set
-type BashCompleteFunc func(*Context)
+type BashCompleteFunc func(Context)
 
 // BeforeFunc is an action to execute before any subcommands are run, but after
 // the context is ready if a non-nil error is returned, no subcommands are run
-type BeforeFunc func(*Context) error
+type BeforeFunc func(Context) error
 
 // AfterFunc is an action to execute after any subcommands are run, but after the
 // subcommand has finished it is run even if Action() panics
-type AfterFunc func(*Context) error
+type AfterFunc func(Context) error
 
 // ActionFunc is the action to execute when no subcommands are specified
-type ActionFunc func(*Context) error
+type ActionFunc func(Context) error
 
 // CommandNotFoundFunc is executed if the proper command cannot be found
-type CommandNotFoundFunc func(*Context, string)
+type CommandNotFoundFunc func(Context, string)
 
 // OnUsageErrorFunc is executed if an usage error occurs. This is useful for displaying
 // customized usage error messages.  This function is able to replace the
 // original error messages.  If this function is not set, the "Incorrect usage"
 // is displayed and the execution is interrupted.
-type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
+type OnUsageErrorFunc func(context Context, err error, isSubcommand bool) error
 
 // ExitErrHandlerFunc is executed if provided in order to handle exitError values
 // returned by Actions and Before/After functions.
-type ExitErrHandlerFunc func(context *Context, err error)
+type ExitErrHandlerFunc func(context Context, err error)
 
 // FlagStringFunc is used by the help generation to display a flag, which is
 // expected to be a single line.

--- a/help_test.go
+++ b/help_test.go
@@ -69,7 +69,7 @@ func Test_Help_Custom_Flags(t *testing.T) {
 		Flags: []Flag{
 			&BoolFlag{Name: "foo", Aliases: []string{"h"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Bool("h") != true {
 				t.Errorf("custom help flag not set")
 			}
@@ -100,7 +100,7 @@ func Test_Version_Custom_Flags(t *testing.T) {
 		Flags: []Flag{
 			&BoolFlag{Name: "foo", Aliases: []string{"v"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(ctx Context) error {
 			if ctx.Bool("v") != true {
 				t.Errorf("custom version flag not set")
 			}
@@ -194,7 +194,7 @@ func TestShowAppHelp_CommandAliases(t *testing.T) {
 			{
 				Name:    "frobbly",
 				Aliases: []string{"fr", "frob"},
-				Action: func(ctx *Context) error {
+				Action: func(ctx Context) error {
 					return nil
 				},
 			},
@@ -390,7 +390,7 @@ func TestShowCommandHelp_CommandAliases(t *testing.T) {
 			{
 				Name:    "frobbly",
 				Aliases: []string{"fr", "frob", "bork"},
-				Action: func(ctx *Context) error {
+				Action: func(ctx Context) error {
 					return nil
 				},
 			},
@@ -416,7 +416,7 @@ func TestShowSubcommandHelp_CommandAliases(t *testing.T) {
 			{
 				Name:    "frobbly",
 				Aliases: []string{"fr", "frob", "bork"},
-				Action: func(ctx *Context) error {
+				Action: func(ctx Context) error {
 					return nil
 				},
 			},
@@ -437,7 +437,7 @@ func TestShowCommandHelp_Customtemplate(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "frobbly",
-				Action: func(ctx *Context) error {
+				Action: func(ctx Context) error {
 					return nil
 				},
 				HelpName: "foo frobbly",
@@ -523,14 +523,14 @@ func TestShowAppHelp_HiddenCommand(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "frobbly",
-				Action: func(ctx *Context) error {
+				Action: func(ctx Context) error {
 					return nil
 				},
 			},
 			{
 				Name:   "secretfrob",
 				Hidden: true,
-				Action: func(ctx *Context) error {
+				Action: func(ctx Context) error {
 					return nil
 				},
 			},
@@ -693,14 +693,14 @@ func TestShowAppHelp_CustomAppTemplate(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "frobbly",
-				Action: func(ctx *Context) error {
+				Action: func(ctx Context) error {
 					return nil
 				},
 			},
 			{
 				Name:   "secretfrob",
 				Hidden: true,
-				Action: func(ctx *Context) error {
+				Action: func(ctx Context) error {
 					return nil
 				},
 			},

--- a/help_test.go
+++ b/help_test.go
@@ -14,7 +14,7 @@ func Test_ShowAppHelp_NoAuthor(t *testing.T) {
 	output := new(bytes.Buffer)
 	app := &App{Writer: output}
 
-	c := NewContext(app, nil, nil)
+	c := NewContext().WithApp(app)
 
 	_ = ShowAppHelp(c)
 
@@ -29,7 +29,7 @@ func Test_ShowAppHelp_NoVersion(t *testing.T) {
 
 	app.Version = ""
 
-	c := NewContext(app, nil, nil)
+	c := NewContext().WithApp(app)
 
 	_ = ShowAppHelp(c)
 
@@ -44,7 +44,7 @@ func Test_ShowAppHelp_HideVersion(t *testing.T) {
 
 	app.HideVersion = true
 
-	c := NewContext(app, nil, nil)
+	c := NewContext().WithApp(app)
 
 	_ = ShowAppHelp(c)
 
@@ -121,7 +121,7 @@ func Test_helpCommand_Action_ErrorIfNoTopic(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	_ = set.Parse([]string{"foo"})
 
-	c := NewContext(app, set, nil)
+	c := NewContext().WithApp(app).WithFlagset(set)
 
 	err := helpCommand.Action(c)
 
@@ -166,7 +166,7 @@ func Test_helpSubcommand_Action_ErrorIfNoTopic(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	_ = set.Parse([]string{"foo"})
 
-	c := NewContext(app, set, nil)
+	c := NewContext().WithApp(app).WithFlagset(set)
 
 	err := helpSubcommand.Action(c)
 

--- a/help_test.go
+++ b/help_test.go
@@ -121,7 +121,7 @@ func Test_helpCommand_Action_ErrorIfNoTopic(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	_ = set.Parse([]string{"foo"})
 
-	c := NewContext().WithApp(app).WithFlagset(set)
+	c := NewContext().WithApp(app).WithFlagSet(set)
 
 	err := helpCommand.Action(c)
 
@@ -166,7 +166,7 @@ func Test_helpSubcommand_Action_ErrorIfNoTopic(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	_ = set.Parse([]string{"foo"})
 
-	c := NewContext().WithApp(app).WithFlagset(set)
+	c := NewContext().WithApp(app).WithFlagSet(set)
 
 	err := helpSubcommand.Action(c)
 


### PR DESCRIPTION
## What type of PR is this?

- cleanup  

## What this PR does / why we need it:

In response to the discussion here (https://github.com/urfave/cli/issues/833#issuecomment-574171962) this is an attempt to try to extract the `cli.Context` into its own interface. This is currently a WIP.