### PR TITLE
Fix description of subcommand more consistent

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1567,7 +1567,8 @@ func TestApp_Run_CommandSubcommandHelpName(t *testing.T) {
 	}
 	cmd := &Command{
 		Name:        "foo",
-		Description: "foo commands",
+		Usage:       "foo commands",
+		Description: "This is a description",
 		Subcommands: []*Command{subCmd},
 	}
 	app.Commands = []*Command{cmd}
@@ -1580,6 +1581,11 @@ func TestApp_Run_CommandSubcommandHelpName(t *testing.T) {
 	output := buf.String()
 
 	expected := "base foo - foo commands"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected %q in output: %q", expected, output)
+	}
+
+	expected = "DESCRIPTION:\n   This is a description\n"
 	if !strings.Contains(output, expected) {
 		t.Errorf("expected %q in output: %q", expected, output)
 	}

--- a/template.go
+++ b/template.go
@@ -56,10 +56,13 @@ OPTIONS:
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
 var SubcommandHelpTemplate = `NAME:
-   {{.HelpName}} - {{if .Description}}{{.Description}}{{else}}{{.Usage}}{{end}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
    {{.Name}}:{{range .VisibleCommands}}


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Consider a cli with subcommands. I want to specify descriptions for both `cmd task -h` and `cmd task list -h`.
```go
package main

import (
	"fmt"
	"log"
	"os"

	"github.com/urfave/cli/v2"
)

func main() {
	app := &cli.App{
		Commands: []*cli.Command{
			&cli.Command{
				Name:    "task",
				Aliases: []string{"a"},
				Usage:   "task commands",
				Description: `This is a description of task.
   For example, bla bla bla...`,
				Action: func(c *cli.Context) error {
					fmt.Println("tasks")
					return nil
				},
				Subcommands: []*cli.Command{
					&cli.Command{
						Name:  "list",
						Usage: "list tasks",
						Description: `This is a description of listing tasks.
   For example, bla bla bla...`,
						Action: func(c *cli.Context) error {
							fmt.Println("list tasks")
							return nil
						},
					},
				},
			},
		},
	}

	err := app.Run(os.Args)
	if err != nil {
		log.Fatal(err)
	}
}
```

### Current behavior
When I run the command, I got the following results. **Note that the description of `go run . task -h` appears at unexpected position**.
```
 % go run . task -h
NAME:
   mycmd task - This is a description of task.
   For example, bla bla bla...

USAGE:
   mycmd task command [command options] [arguments...]

COMMANDS:
   list     list tasks
   help, h  Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help (default: false)

 % go run . task list -h # is fine!
NAME:
   mycmd task list - list tasks

USAGE:
   mycmd task list [command options] [arguments...]

DESCRIPTION:
   This is a description of listing tasks.
   For example, bla bla bla...

OPTIONS:
   --help, -h  show help (default: false)

```

### Expected bahavior
I think this is more consistent. Shows both `[command] - {{Usage}}` and `DESCRIPTION: {{Description}}`.

```
 % go run . task -h
NAME:
   mycmd task - task commands

USAGE:
   mycmd task command [command options] [arguments...]

DESCRIPTION:
   This is a description of task.
   For example, bla bla bla...

COMMANDS:
   list     list tasks
   help, h  Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help (default: false)

 % go run . task list -h
NAME:
   mycmd task list - list tasks

USAGE:
   mycmd task list [command options] [arguments...]

DESCRIPTION:
   This is a description of listing tasks.
   For example, bla bla bla...

OPTIONS:
   --help, -h  show help (default: false)

```


## Which issue(s) this PR fixes:
This pull request fixes the above problem.

## Special notes for your reviewer:

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note

```
