### PR TITLE
Make help message optional if error happen in BeforeFunc

### DIFF
--- a/app.go
+++ b/app.go
@@ -57,8 +57,8 @@ type App struct {
 	// An action to execute after any subcommands are run, but after the subcommand has finished
 	// It is run even if Action() panics
 	After AfterFunc
-	// Should the help message be displayed in case of error in the Before action
-	ShowHelpOnBeforeError bool
+	// Should the help message be hidden in case of error in the Before action
+	HideHelpOnBeforeError bool
 	// The action to execute when no subcommands are specified
 	Action ActionFunc
 	// Execute this function if the proper command cannot be found
@@ -288,7 +288,7 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
 			_, _ = fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
-			if a.ShowHelpOnBeforeError {
+			if !a.HideHelpOnBeforeError {
 				_ = ShowAppHelp(context)
 			}
 			a.handleExitCoder(context, beforeErr)

--- a/app.go
+++ b/app.go
@@ -57,6 +57,8 @@ type App struct {
 	// An action to execute after any subcommands are run, but after the subcommand has finished
 	// It is run even if Action() panics
 	After AfterFunc
+	// Should the help message be displayed in case of error in the Before action
+	ShowHelpOnBeforeError bool
 	// The action to execute when no subcommands are specified
 	Action ActionFunc
 	// Execute this function if the proper command cannot be found
@@ -286,7 +288,9 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
 			_, _ = fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
-			_ = ShowAppHelp(context)
+			if a.ShowHelpOnBeforeError {
+				_ = ShowAppHelp(context)
+			}
 			a.handleExitCoder(context, beforeErr)
 			err = beforeErr
 			return err

--- a/command.go
+++ b/command.go
@@ -31,6 +31,8 @@ type Command struct {
 	// An action to execute after any subcommands are run, but after the subcommand has finished
 	// It is run even if Action() panics
 	After AfterFunc
+	// Should the help message be displayed in case of error in the Before action
+	ShowHelpOnBeforeError bool
 	// The function to call when this command is invoked
 	Action ActionFunc
 	// Execute this function if a usage error occurs.
@@ -147,7 +149,9 @@ func (c *Command) Run(ctx *Context) (err error) {
 	if c.Before != nil {
 		err = c.Before(context)
 		if err != nil {
-			_ = ShowCommandHelp(context, c.Name)
+			if c.ShowHelpOnBeforeError {
+				_ = ShowCommandHelp(context, c.Name)
+			}
 			context.App.handleExitCoder(context, err)
 			return err
 		}

--- a/command.go
+++ b/command.go
@@ -31,8 +31,8 @@ type Command struct {
 	// An action to execute after any subcommands are run, but after the subcommand has finished
 	// It is run even if Action() panics
 	After AfterFunc
-	// Should the help message be displayed in case of error in the Before action
-	ShowHelpOnBeforeError bool
+	// Should the help message be hidden in case of error in the Before action
+	HideHelpOnBeforeError bool
 	// The function to call when this command is invoked
 	Action ActionFunc
 	// Execute this function if a usage error occurs.
@@ -149,7 +149,7 @@ func (c *Command) Run(ctx *Context) (err error) {
 	if c.Before != nil {
 		err = c.Before(context)
 		if err != nil {
-			if c.ShowHelpOnBeforeError {
+			if !c.HideHelpOnBeforeError {
 				_ = ShowCommandHelp(context, c.Name)
 			}
 			context.App.handleExitCoder(context, err)


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup  
- [ ] documentation
- [X] feature

## What this PR does / why we need it:

Displaying the help message in case of error in BeforeFunc should be optional. In my case I am using the BeforeFunc to validate command context and fails if something goes wrong, and I don't want any help message displayed.

Having a flag will allow user to customize depending on his use case.

This PR is not a breaking change, since without the flag the behavior is the same as before.

## Which issue(s) this PR fixes:

Fixes #1081

## Release Notes

```release-note
Add a HideHelpOnBeforeError boolean to hide error display if something goes wrong in BeforeFunc.
```