### PR TITLE
go 1.14

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.11, 1.12, 1.13]
+        go: [1.12, 1.13, 1.14]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,7 +39,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: GOFMT Check
-        if: matrix.go == 1.13 && matrix.os == 'ubuntu-latest'
+        if: matrix.go == 1.14 && matrix.os == 'ubuntu-latest'
         run: test -z $(gofmt -l .)
 
       - name: vet
@@ -52,7 +52,7 @@ jobs:
         run: go run internal/build/build.go check-binary-size
 
       - name: Upload coverage to Codecov
-        if: success() && matrix.go == 1.13 && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.go == 1.14 && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v1
         with:
           token: 0a8cc73b-bb7c-480b-8626-38a461643761
@@ -62,10 +62,10 @@ jobs:
     name: test-docs
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
 
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage documentation exists for each major version. Don't know what version you'r
 
 ## Installation
 
-Make sure you have a working Go environment.  Go version 1.11+ is supported. [See the install instructions for Go](http://golang.org/doc/install.html).
+Using the package requires a working Go environment. [See the install instructions for Go](http://golang.org/doc/install.html).
 
 Go Modules are strongly recommended when using this package. [See the go blog guide on using Go Modules](https://blog.golang.org/using-go-modules).
 
@@ -63,4 +63,4 @@ export PATH=$PATH:$GOPATH/bin
 
 cli is tested against multiple versions of Go on Linux, and against the latest
 released version of Go on OS X and Windows. This project uses Github Actions for
-builds. For more build info, please look at the [./.github/workflows/cli.yml](https://github.com/urfave/cli/blob/master/.github/workflows/cli.yml).
+builds. To see our currently supported go versions and platforms, look at the [./.github/workflows/cli.yml](https://github.com/urfave/cli/blob/master/.github/workflows/cli.yml).

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Usage documentation exists for each major version. Don't know what version you'r
 
 ## Installation
 
-Using the package requires a working Go environment. [See the install instructions for Go](http://golang.org/doc/install.html).
+Using this package requires a working Go environment. [See the install instructions for Go](http://golang.org/doc/install.html).
 
-Go Modules are strongly recommended when using this package. [See the go blog guide on using Go Modules](https://blog.golang.org/using-go-modules).
+Go Modules are required when using this package. [See the go blog guide on using Go Modules](https://blog.golang.org/using-go-modules).
 
 ### Using `v2` releases
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature
- [x] maintenance

## What this PR does / why we need it:

Updates our go version testing to include go 1.14, and drops go 1.11 testing.

## Context

[go 1.14 has released](https://blog.golang.org/go1.14) and I'm continuing the existing pattern of supporting 3 go versions. I'm not 100% sure when this pattern was started, but I assume it's fine to continue it.
