### PR TITLE
Fix bug 'Unable to load file' in altsrc

### DIFF
--- a/altsrc/default_input_source.go
+++ b/altsrc/default_input_source.go
@@ -1,0 +1,6 @@
+package altsrc
+
+// defaultInputSource creates a default InputSourceContext.
+func defaultInputSource() (InputSourceContext, error) {
+	return &MapInputSource{file: "", valueMap: map[interface{}]interface{}{}}, nil
+}

--- a/altsrc/json_source_context.go
+++ b/altsrc/json_source_context.go
@@ -17,7 +17,11 @@ import (
 // by the given flag.
 func NewJSONSourceFromFlagFunc(flag string) func(c *cli.Context) (InputSourceContext, error) {
 	return func(context *cli.Context) (InputSourceContext, error) {
-		return NewJSONSourceFromFile(context.String(flag))
+		if context.IsSet(flag) {
+			return NewJSONSourceFromFile(context.String(flag))
+		} else {
+			return defaultInputSource()
+		}
 	}
 }
 

--- a/altsrc/json_source_context.go
+++ b/altsrc/json_source_context.go
@@ -19,9 +19,9 @@ func NewJSONSourceFromFlagFunc(flag string) func(c *cli.Context) (InputSourceCon
 	return func(context *cli.Context) (InputSourceContext, error) {
 		if context.IsSet(flag) {
 			return NewJSONSourceFromFile(context.String(flag))
-		} else {
-			return defaultInputSource()
 		}
+
+		return defaultInputSource()
 	}
 }
 

--- a/altsrc/toml_file_loader.go
+++ b/altsrc/toml_file_loader.go
@@ -87,8 +87,12 @@ func NewTomlSourceFromFile(file string) (InputSourceContext, error) {
 // NewTomlSourceFromFlagFunc creates a new TOML InputSourceContext from a provided flag name and source context.
 func NewTomlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (InputSourceContext, error) {
 	return func(context *cli.Context) (InputSourceContext, error) {
-		filePath := context.String(flagFileName)
-		return NewTomlSourceFromFile(filePath)
+		if context.IsSet(flagFileName) {
+			filePath := context.String(flagFileName)
+			return NewTomlSourceFromFile(filePath)
+		} else {
+			return defaultInputSource()
+		}
 	}
 }
 

--- a/altsrc/toml_file_loader.go
+++ b/altsrc/toml_file_loader.go
@@ -90,9 +90,9 @@ func NewTomlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (
 		if context.IsSet(flagFileName) {
 			filePath := context.String(flagFileName)
 			return NewTomlSourceFromFile(filePath)
-		} else {
-			return defaultInputSource()
 		}
+
+		return defaultInputSource()
 	}
 }
 

--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -33,8 +33,12 @@ func NewYamlSourceFromFile(file string) (InputSourceContext, error) {
 // NewYamlSourceFromFlagFunc creates a new Yaml InputSourceContext from a provided flag name and source context.
 func NewYamlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (InputSourceContext, error) {
 	return func(context *cli.Context) (InputSourceContext, error) {
-		filePath := context.String(flagFileName)
-		return NewYamlSourceFromFile(filePath)
+		if context.IsSet(flagFileName) {
+			filePath := context.String(flagFileName)
+			return NewYamlSourceFromFile(filePath)
+		} else {
+			return defaultInputSource()
+		}
 	}
 }
 

--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -36,9 +36,9 @@ func NewYamlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (
 		if context.IsSet(flagFileName) {
 			filePath := context.String(flagFileName)
 			return NewYamlSourceFromFile(filePath)
-		} else {
-			return defaultInputSource()
 		}
+
+		return defaultInputSource()
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [*] bug

## What this PR does / why we need it:

When using altsrc, an 'Unable to load Yaml/TOML/etc file' error occurs during startup of the executable file, which can only be resolved by using the flag used to specify the path to the configuration file.

For example, when you run cli app with this configuration:

```
startFlags := []cli.Flag{
	&cli.StringFlag{
		Name:  "config",
		Value: "",
		Usage: "path to the configuration file",
	},
	altsrc.NewStringFlag(
		&cli.StringFlag{
			Name:  "listen-addr",
			Value: "127.0.0.1",
			Usage: "listening address",
		}),
}

app.Commands = []*cli.Command{
	{
		Name:   "start",
		Action: startHandler,
		Before: altsrc.InitInputSourceWithContext(startFlags, altsrc.NewYamlSourceFromFlagFunc("config")),
		Flags:  startFlags,
	},
}
```

In the following cases, an error occurs:

```
[user@localhost altsrc-fix]$ ./main start
...
Error:  Unable to create input source with context: inner error: 
'Unable to load Yaml file '': inner error: 
'unable to determine how to load from path ''

[user@localhost altsrc-fix]$ ./main start --listen-addr 192.168.0.0
...
Error:  Unable to create input source with context: inner error: 
'Unable to load Yaml file '': inner error: 
'unable to determine how to load from path ''
```

And in the following cases, an error does not occur:

```
[user@localhost altsrc-fix]$ ./main start --config config.yml --listen-addr 192.168.0.0
[user@localhost altsrc-fix]$ ./main start --config config.yml
```

To solve this bug, checks were added whether the flag used to specify the path to the configuration file is set. If it is not specified, MapInputSource with default values is returned.

After applying the changes from this PR, the executable file can be run without the flag used to specify the path to the configuration file:

```
[user@localhost altsrc-fix]$ ./main start
[user@localhost altsrc-fix]$ ./main start --listen-addr 192.168.0.0
[user@localhost altsrc-fix]$ ./main start --config config.yml
[user@localhost altsrc-fix]$ ./main start --config config.yml --listen-addr 192.168.0.0
```

## Testing

Test code:

```
package main

import (
	"os"
	"fmt"

	"github.com/urfave/cli/v2"
	"github.com/urfave/cli/v2/altsrc"
)

func main() {
	app := cli.NewApp()

	startFlags := []cli.Flag{
		&cli.StringFlag{
			Name:  "config",
			Value: "",
			Usage: "path to the configuration file",
		},
		altsrc.NewStringFlag(
			&cli.StringFlag{
				Name:  "listen-addr",
				Value: "127.0.0.1",
				Usage: "listening address",
			}),
	}

	app.Commands = []*cli.Command{
		{
			Name:   "start",
			Action: startHandler,
			Before: altsrc.InitInputSourceWithContext(startFlags, altsrc.NewYamlSourceFromFlagFunc("config")),
			Flags:  startFlags,
		},
	}

	err := app.Run(os.Args)
	if err != nil {
		fmt.Println("Error: ", err)
		os.Exit(1)
	}
}

func startHandler(c *cli.Context) error {
	fmt.Println("listen-addr: ", c.String("listen-addr"))
	return nil
}
```

## Release Notes

```release-note
* Fix 'Unable to load file' error when using altsrc
```