### PR TITLE
Update docs and tests around cli.Exit

### DIFF
--- a/app.go
+++ b/app.go
@@ -76,8 +76,9 @@ type App struct {
 	Writer io.Writer
 	// ErrWriter writes error output
 	ErrWriter io.Writer
-	// Execute this function to handle ExitErrors. If not provided, HandleExitCoder is provided to
-	// function as a default, so this is optional.
+	// ExitErrHandler processes any error encountered while running an App before
+	// it is returned to the caller. If no function is provided, HandleExitCoder
+	// is used as the default behavior.
 	ExitErrHandler ExitErrHandlerFunc
 	// Other custom info
 	Metadata map[string]interface{}

--- a/errors_test.go
+++ b/errors_test.go
@@ -67,6 +67,26 @@ func TestHandleExitCoder_MultiErrorWithExitCoder(t *testing.T) {
 	expect(t, called, true)
 }
 
+func TestHandleExitCoder_MultiErrorWithoutExitCoder(t *testing.T) {
+	exitCode := 0
+	called := false
+
+	OsExiter = func(rc int) {
+		if !called {
+			exitCode = rc
+			called = true
+		}
+	}
+
+	defer func() { OsExiter = fakeOsExiter }()
+
+	err := newMultiError(errors.New("wowsa"), errors.New("egad"))
+	HandleExitCoder(err)
+
+	expect(t, exitCode, 1)
+	expect(t, called, true)
+}
+
 // make a stub to not import pkg/errors
 type ErrorWithFormat struct {
 	error


### PR DESCRIPTION

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup  
- [x] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
Some of the docs were lacking or incomplete concerning how to properly
use cli.Exit, cli.HandleExitCoder, and the ExitErrHandler field on cli.App.
This change aims to clarify the usage of those pieces.

I also noticed that we have two identical functions now: cli.Exit and
cli.NewExitError. Since the latter seems to be more recent and less well
documented, I went ahead and marked it as deprecated so that we can keep
our public interface small. If there's a reason not to do that, I can punt that
discussion until later to get the rest of these changes through.

Also added a missing test case for behavior that's been around a while
but was not documented or tested.

## Which issue(s) this PR fixes:

_(REQUIRED)_
<!--
  If this PR fixes one of more issues, list them here.
  One line each, like so:
    Fixes #123
    Fixes #39
-->

Related: #1089


## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

It's docs. I added a test case anyway to prove the behavior I was trying to document.

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Deprecated cli.NewExitError in favor of the identical function, cli.Exit
```