### PR TITLE
Remove leading whitespace in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,10 +29,11 @@ _(REQUIRED)_
 
 _(REQUIRED)_
 <!--
-  If this PR fixes one of more issues, list them here.
-  One line each, like so:
-    Fixes #123
-    Fixes #39
+If this PR fixes one of more issues, list them here.
+One line each, like so:
+
+Fixes #123
+Fixes #39
 -->
 
 ## Special notes for your reviewer:


### PR DESCRIPTION
## Motivation

I noticed via https://github.com/urfave/cli/pull/1098 that people weren't removing the leading whitespace, was was preventing Github from recognizing the closing keyword.