### PR TITLE
Set App.ErrWriter in App.Setup()

### DIFF
--- a/app.go
+++ b/app.go
@@ -118,6 +118,7 @@ func NewApp() *App {
 		Action:       helpCommand.Action,
 		Compiled:     compileTime(),
 		Writer:       os.Stdout,
+		ErrWriter:    os.Stderr,
 	}
 }
 

--- a/app.go
+++ b/app.go
@@ -163,6 +163,10 @@ func (a *App) Setup() {
 		a.Writer = os.Stdout
 	}
 
+	if a.ErrWriter == nil {
+		a.ErrWriter = os.Stderr
+	}
+
 	var newCommands []*Command
 
 	for _, c := range a.Commands {
@@ -195,10 +199,6 @@ func (a *App) Setup() {
 
 	if a.Metadata == nil {
 		a.Metadata = make(map[string]interface{})
-	}
-
-	if a.Writer == nil {
-		a.Writer = os.Stdout
 	}
 }
 
@@ -326,7 +326,7 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 // code in the cli.ExitCoder
 func (a *App) RunAndExitOnError() {
 	if err := a.Run(os.Args); err != nil {
-		_, _ = fmt.Fprintln(a.errWriter(), err)
+		_, _ = fmt.Fprintln(a.ErrWriter, err)
 		OsExiter(1)
 	}
 }
@@ -478,15 +478,6 @@ func (a *App) VisibleCommands() []*Command {
 // VisibleFlags returns a slice of the Flags with Hidden=false
 func (a *App) VisibleFlags() []Flag {
 	return visibleFlags(a.Flags)
-}
-
-func (a *App) errWriter() io.Writer {
-	// When the app ErrWriter is nil use the package level one.
-	if a.ErrWriter == nil {
-		return ErrWriter
-	}
-
-	return a.ErrWriter
 }
 
 func (a *App) appendFlag(fl Flag) {

--- a/app_test.go
+++ b/app_test.go
@@ -2152,3 +2152,34 @@ func newTestApp() *App {
 	a.Writer = ioutil.Discard
 	return a
 }
+
+func TestSetupInitializesBothWriters(t *testing.T) {
+	a := &App{}
+
+	a.Setup()
+
+	if a.ErrWriter != os.Stderr {
+		t.Errorf("expected a.ErrWriter to be os.Stderr")
+	}
+
+	if a.Writer != os.Stdout {
+		t.Errorf("expected a.Writer to be os.Stdout")
+	}
+}
+
+func TestSetupInitializesOnlyNilWriters(t *testing.T) {
+	wr := &bytes.Buffer{}
+	a := &App{
+		ErrWriter: wr,
+	}
+
+	a.Setup()
+
+	if a.ErrWriter != wr {
+		t.Errorf("expected a.ErrWriter to be a *bytes.Buffer instance")
+	}
+
+	if a.Writer != os.Stdout {
+		t.Errorf("expected a.Writer to be os.Stdout")
+	}
+}


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [x] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
This change fixes `App.ErrWriter` not being initialized in `App.Setup()` like `App.Writer`. It also removes the `App.errWriter()` private method since `App.ErrWriter` is now set directly.

## Which issue(s) this PR fixes:

_(REQUIRED)_
<!--
  If this PR fixes one of more issues, list them here.
  One line each, like so:
    Fixes #123
    Fixes #39
-->
Fixes #1096 

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
- `App.ErrWriter` now defaults to `os.Stderr` if not set.
```