### PR TITLE
Don't assume a fixed windows drive letter in tests

### DIFF
--- a/altsrc/flag_test.go
+++ b/altsrc/flag_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -190,7 +191,13 @@ func TestPathApplyInputSourceMethodSet(t *testing.T) {
 
 	expected := "/path/to/source/hello"
 	if runtime.GOOS == "windows" {
-		expected = `D:\path\to\source\hello`
+		var err error
+		// Prepend the corresponding drive letter (or UNC path?), and change
+		// to windows-style path:
+		expected, err = filepath.Abs(expected)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	expect(t, expected, c.String("test"))
 }


### PR DESCRIPTION
Prior to this change, this test was failing for me on a new windows
machine, with mismatching drive letters:

helpers_test.go:20: (C:/Users/Foo Bar/cli/altsrc/flag_test.go:195) Expected C:\path\to\source\hello (type string) - Got D:\path\to\source\hello (type string)

Rather than hard-coding the drive letter in the expected path, we can
expect the filepath.Abs'ed version.


<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

`go test ./...` fails on windows with two errors, this fixes one of them.

## Which issue(s) this PR fixes:

_(REQUIRED)_

This should fix part of #1105.

## Testing

I tested this with `go test ./...` on a fresh windows machine, with go 1.14.2.

## Release Notes

_(REQUIRED)_

```NONE
```