### PR TITLE
Save the temp dir before clearing environment variables

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 )
 
+var osTempDir = os.TempDir()
+
 var boolFlagTests = []struct {
 	name     string
 	expected string
@@ -1662,7 +1664,7 @@ func TestFlagFromFile(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("APP_FOO", "123")
 
-	temp, err := ioutil.TempFile("", "urfave_cli_test")
+	temp, err := ioutil.TempFile(osTempDir, "urfave_cli_test")
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
In some windows setups, os.TempDir() will return something like
"C:\WINDOWS" if none of the expected environment variables (TMP, TEMP,
USERPROFILE) are set, and then functions that try to create temporary
files or directories will fail since this is not writable.

Several tests in flag_test.go clear the environment and then set a small
number of specific environment variables for the test, triggering the
following error in TestFlagFromFile when I run `go test ./...` on a new
windows machine:

flag_test.go:1667: open C:\WINDOWS\urfave_cli_test851254863: Access is denied.

To work around this, we can check the temp directory before calling
os.Clearenv() and use that directory explcitly in functions that
take the temp directory.

Another alternative might be to defer a function that resets the environment after
each call to os.Clearenv().

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

This fixes one of the failures on windows in `go test ./...`

## Which issue(s) this PR fixes:

_(REQUIRED)_

This fixes part of #1105.

## Testing

Tested with `go test ./...` with go 1.14.2 on a new windows machine.

## Release Notes

_(REQUIRED)_

```NONE
```
