### PR TITLE
Add support for comma separated IntSliceFlag and Int64SliceFlag

### DIFF
--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -33,12 +33,13 @@ func (f *Float64Slice) Set(value string) error {
 		return nil
 	}
 
-	tmp, err := strconv.ParseFloat(value, 64)
-	if err != nil {
-		return err
+	for _, v := range strings.Split(value, ",") {
+		tmp, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return err
+		}
+		f.slice = append(f.slice, tmp)
 	}
-
-	f.slice = append(f.slice, tmp)
 	return nil
 }
 

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -33,6 +33,18 @@ func (i *Int64Slice) Set(value string) error {
 		return nil
 	}
 
+	if strings.Contains(value, ",") {
+		values := strings.Split(value, ",")
+		for _, v := range values {
+			tmp, err := strconv.ParseInt(v, 0, 64)
+			if err != nil {
+				return err
+			}
+			i.slice = append(i.slice, tmp)
+		}
+		return nil
+	}
+
 	tmp, err := strconv.ParseInt(value, 0, 64)
 	if err != nil {
 		return err

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -33,25 +33,13 @@ func (i *Int64Slice) Set(value string) error {
 		return nil
 	}
 
-	if strings.Contains(value, ",") {
-		values := strings.Split(value, ",")
-		for _, v := range values {
-			tmp, err := strconv.ParseInt(v, 0, 64)
-			if err != nil {
-				return err
-			}
-			i.slice = append(i.slice, tmp)
+	for _, v := range strings.Split(value, ",") {
+		tmp, err := strconv.ParseInt(v, 0, 64)
+		if err != nil {
+			return err
 		}
-		return nil
+		i.slice = append(i.slice, tmp)
 	}
-
-	tmp, err := strconv.ParseInt(value, 0, 64)
-	if err != nil {
-		return err
-	}
-
-	i.slice = append(i.slice, tmp)
-
 	return nil
 }
 

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -44,25 +44,13 @@ func (i *IntSlice) Set(value string) error {
 		return nil
 	}
 
-	if strings.Contains(value, ",") {
-		values := strings.Split(value, ",")
-		for _, v := range values {
-			tmp, err := strconv.ParseInt(v, 0, 64)
-			if err != nil {
-				return err
-			}
-			i.slice = append(i.slice, int(tmp))
+	for _, v := range strings.Split(value, ",") {
+		tmp, err := strconv.ParseInt(v, 0, 64)
+		if err != nil {
+			return err
 		}
-		return nil
+		i.slice = append(i.slice, int(tmp))
 	}
-
-	tmp, err := strconv.ParseInt(value, 0, 64)
-	if err != nil {
-		return err
-	}
-
-	i.slice = append(i.slice, int(tmp))
-
 	return nil
 }
 

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -44,6 +44,18 @@ func (i *IntSlice) Set(value string) error {
 		return nil
 	}
 
+	if strings.Contains(value, ",") {
+		values := strings.Split(value, ",")
+		for _, v := range values {
+			tmp, err := strconv.ParseInt(v, 0, 64)
+			if err != nil {
+				return err
+			}
+			i.slice = append(i.slice, int(tmp))
+		}
+		return nil
+	}
+
 	tmp, err := strconv.ParseInt(value, 0, 64)
 	if err != nil {
 		return err

--- a/flag_test.go
+++ b/flag_test.go
@@ -1196,6 +1196,28 @@ func TestParseMultiIntSlice(t *testing.T) {
 	}).Run([]string{"run", "-s", "10", "-s", "20"})
 }
 
+func TestParseMultiIntSliceCommaSeperated(t *testing.T) {
+	//Need to check for error since the parsing fails before it gets into the Action
+	//Then this test will fail without being noticed
+	err := (&App{
+		Flags: []Flag{
+			&IntSliceFlag{Name: "serve", Aliases: []string{"s"}, Value: NewIntSlice()},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.IntSlice("serve"), []int{10, 20}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.IntSlice("s"), []int{10, 20}) {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "10,20"})
+	if err != nil {
+		t.Errorf("failed to parse flags : %s", err)
+	}
+}
+
 func TestParseMultiIntSliceWithDefaults(t *testing.T) {
 	_ = (&App{
 		Flags: []Flag{
@@ -1308,6 +1330,28 @@ func TestParseMultiInt64Slice(t *testing.T) {
 			return nil
 		},
 	}).Run([]string{"run", "-s", "10", "-s", "17179869184"})
+}
+
+func TestParseMultiInt64SliceCommaSeperated(t *testing.T) {
+	//Need to check for error since the parsing fails before it gets into the Action
+	//Then this test will fail without being noticed
+	err := (&App{
+		Flags: []Flag{
+			&Int64SliceFlag{Name: "serve", Aliases: []string{"s"}, Value: NewInt64Slice()},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Int64Slice("serve"), []int64{10, 17179869184}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.Int64Slice("s"), []int64{10, 17179869184}) {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "10,17179869184"})
+	if err != nil {
+		t.Errorf("failed to parse flags : %s", err)
+	}
 }
 
 func TestParseMultiInt64SliceFromEnv(t *testing.T) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -1478,10 +1478,10 @@ func TestParseMultiFloat64Slice(t *testing.T) {
 		},
 		Action: func(ctx *Context) error {
 			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{0.1, -10.5}) {
-				t.Errorf("main name not set from env")
+				t.Errorf("main name not set")
 			}
 			if !reflect.DeepEqual(ctx.Float64Slice("i"), []float64{0.1, -10.5}) {
-				t.Errorf("short name not set from env")
+				t.Errorf("short name not set")
 			}
 			return nil
 		},
@@ -1497,10 +1497,10 @@ func TestParseMultiFloat64SliceCommaSeparated(t *testing.T) {
 		},
 		Action: func(ctx *Context) error {
 			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{0.1, -10.5}) {
-				t.Errorf("main name not set from env")
+				t.Errorf("main name not set")
 			}
 			if !reflect.DeepEqual(ctx.Float64Slice("i"), []float64{0.1, -10.5}) {
-				t.Errorf("short name not set from env")
+				t.Errorf("short name not set")
 			}
 			return nil
 		},
@@ -1517,10 +1517,10 @@ func TestParseMultiFloat64SliceWithDefaults(t *testing.T) {
 		},
 		Action: func(ctx *Context) error {
 			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{0.1, -10.5}) {
-				t.Errorf("main name not set from env")
+				t.Errorf("main name not set")
 			}
 			if !reflect.DeepEqual(ctx.Float64Slice("i"), []float64{0.1, -10.5}) {
-				t.Errorf("short name not set from env")
+				t.Errorf("short name not set")
 			}
 			return nil
 		},
@@ -1534,10 +1534,10 @@ func TestParseMultiFloat64SliceWithDefaultsUnset(t *testing.T) {
 		},
 		Action: func(ctx *Context) error {
 			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{2.3, -3.4}) {
-				t.Errorf("main name not set from env")
+				t.Errorf("main name not set")
 			}
 			if !reflect.DeepEqual(ctx.Float64Slice("i"), []float64{2.3, -3.4}) {
-				t.Errorf("short name not set from env")
+				t.Errorf("short name not set")
 			}
 			return nil
 		},

--- a/flag_test.go
+++ b/flag_test.go
@@ -1196,7 +1196,7 @@ func TestParseMultiIntSlice(t *testing.T) {
 	}).Run([]string{"run", "-s", "10", "-s", "20"})
 }
 
-func TestParseMultiIntSliceCommaSeperated(t *testing.T) {
+func TestParseMultiIntSliceCommaSeparated(t *testing.T) {
 	//Need to check for error since the parsing fails before it gets into the Action
 	//Then this test will fail without being noticed
 	err := (&App{
@@ -1332,7 +1332,7 @@ func TestParseMultiInt64Slice(t *testing.T) {
 	}).Run([]string{"run", "-s", "10", "-s", "17179869184"})
 }
 
-func TestParseMultiInt64SliceCommaSeperated(t *testing.T) {
+func TestParseMultiInt64SliceCommaSeparated(t *testing.T) {
 	//Need to check for error since the parsing fails before it gets into the Action
 	//Then this test will fail without being noticed
 	err := (&App{
@@ -1488,7 +1488,7 @@ func TestParseMultiFloat64Slice(t *testing.T) {
 	}).Run([]string{"run", "-i", "0.1", "-i", "-10.5"})
 }
 
-func TestParseMultiFloat64SliceCommaSeperated(t *testing.T) {
+func TestParseMultiFloat64SliceCommaSeparated(t *testing.T) {
 	//Need to check for error since the parsing fails before it gets into the Action
 	//Then this test will fail without being noticed
 	err := (&App{

--- a/flag_test.go
+++ b/flag_test.go
@@ -1488,6 +1488,28 @@ func TestParseMultiFloat64Slice(t *testing.T) {
 	}).Run([]string{"run", "-i", "0.1", "-i", "-10.5"})
 }
 
+func TestParseMultiFloat64SliceCommaSeperated(t *testing.T) {
+	//Need to check for error since the parsing fails before it gets into the Action
+	//Then this test will fail without being noticed
+	err := (&App{
+		Flags: []Flag{
+			&Float64SliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewFloat64Slice()},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{0.1, -10.5}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.Float64Slice("i"), []float64{0.1, -10.5}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-i", "0.1,-10.5"})
+	if err != nil {
+		t.Errorf("failed to parse flags : %s", err)
+	}
+}
+
 func TestParseMultiFloat64SliceWithDefaults(t *testing.T) {
 	_ = (&App{
 		Flags: []Flag{

--- a/flag_test.go
+++ b/flag_test.go
@@ -1471,6 +1471,57 @@ func TestParseMultiFloat64FromEnvCascade(t *testing.T) {
 	}).Run([]string{"run"})
 }
 
+func TestParseMultiFloat64Slice(t *testing.T) {
+	_ = (&App{
+		Flags: []Flag{
+			&Float64SliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewFloat64Slice()},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{0.1, -10.5}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.Float64Slice("i"), []float64{0.1, -10.5}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-i", "0.1", "-i", "-10.5"})
+}
+
+func TestParseMultiFloat64SliceWithDefaults(t *testing.T) {
+	_ = (&App{
+		Flags: []Flag{
+			&Float64SliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewFloat64Slice(2.3, -3.4)},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{0.1, -10.5}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.Float64Slice("i"), []float64{0.1, -10.5}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-i", "0.1", "-i", "-10.5"})
+}
+
+func TestParseMultiFloat64SliceWithDefaultsUnset(t *testing.T) {
+	_ = (&App{
+		Flags: []Flag{
+			&Float64SliceFlag{Name: "intervals", Aliases: []string{"i"}, Value: NewFloat64Slice(2.3, -3.4)},
+		},
+		Action: func(ctx *Context) error {
+			if !reflect.DeepEqual(ctx.Float64Slice("intervals"), []float64{2.3, -3.4}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.Float64Slice("i"), []float64{2.3, -3.4}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
 func TestParseMultiFloat64SliceFromEnv(t *testing.T) {
 	defer resetEnv(os.Environ())
 	os.Clearenv()


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:
IntSliceFlag can't parse comma separated  like this `-flag 1,2,3`. 
This PR adds support for that by : 
- Checking for comma in `IntSliceFlag.Set` and `Int64SliceFlag.Set` 
- If comma exists split the value string and add each number to the underlying slice 

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

Fixes #1097 

## Special notes for your reviewer:
My only knowledge of this project is from using it.
I came up with a pretty naive solution to this problem, so I would be happy to know if the change is implemented in the right place.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing
<!--
  Describe how you tested this change.
-->
Added unit tests : 
- `TestParseMultiIntSliceCommaSeperated` 
- `TestParseMultiInt64SliceCommaSeperated`

These tests wouldn't fail if the error of `Run` isn't checked.
All the other parsing tests do the checking in `Action` but these tests won't even get there if the value is not valid.

## Release Notes
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Add support for comma separated `IntSliceFlag` and `Int64SliceFlag`
```
