### PR TITLE
v2_bug_fixing_1121 :  Now StringSliceFlag, Value(default) value set in Destination

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -2182,4 +2183,39 @@ func TestSetupInitializesOnlyNilWriters(t *testing.T) {
 	if a.Writer != os.Stdout {
 		t.Errorf("expected a.Writer to be os.Stdout")
 	}
+}
+
+func TestApp_StringSliceFlag_When_defualtValueSetInDestination(t *testing.T) {
+	type config struct {
+		ActualOutput StringSlice
+	}
+	cfg := new(config)
+
+	ExpectedOutput := new(StringSlice)
+	ExpectedOutput.slice = []string{"CA", "US"}
+
+	// ExpectedOutput := new(StringSlice)
+	// ExpectedOutput.slice = []string{"CA"}
+
+	// ExpectedOutput := new(StringSlice)
+	// ExpectedOutput.slice = []string{"US"}
+
+	app := NewApp()
+	app.Flags = []Flag{
+		&StringSliceFlag{
+			Name:        "country",
+			Aliases:     []string{"c"},
+			Value:       NewStringSlice("CA", "US"),
+			Destination: &cfg.ActualOutput,
+		},
+	}
+	app.Action = func(c *Context) error {
+		log.Printf("%+v", cfg)
+		return nil
+	}
+	_ = app.Run(os.Args)
+	// _ = app.Run([]string{"", "-c", "CA"})
+	// _ = app.Run([]string{"", "-c", "US"})
+
+	expect(t, ExpectedOutput.slice, cfg.ActualOutput.slice)
 }

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -141,6 +141,8 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 		}
 
 		if f.Destination != nil {
+			f.Destination.slice = make([]string, len(f.Value.slice))
+			copy(f.Destination.slice, f.Value.slice)
 			set.Var(f.Destination, name, f.Usage)
 			continue
 		}


### PR DESCRIPTION
### Motivation

Value(default) does not set in Destination field in StringSliceFlag.

### Findings

- No slice of variables like []string, []int, []float can be set in flag.go in flag package in golang. 
- No ``` set.StringVar(f.Destination, name, f.Value, f.Usage)```  this type of method for slice of string in flag.go in flag package.

### Changes

 When Destination field set as a StringSlice in StringSliceFlag then we need to set Value(StringSlice) in Destination as default. But flag.go in flag package does not support this.
For that reason we need to set Value in Destination before call ```set.Var(f.Destination, name, f.Usage)```

Before Change :
```golang
// Apply populates the flag given the flag set and environment
func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
		f.Value = &StringSlice{}
		destination := f.Value
		if f.Destination != nil {
			destination = f.Destination
		}

		for _, s := range strings.Split(val, ",") {
			if err := destination.Set(strings.TrimSpace(s)); err != nil {
				return fmt.Errorf("could not parse %q as string value for flag %s: %s", val, f.Name, err)
			}
		}

		// Set this to false so that we reset the slice if we then set values from
		// flags that have already been set by the environment.
		destination.hasBeenSet = false
		f.HasBeenSet = true
	}

	for _, name := range f.Names() {
		if f.Value == nil {
			f.Value = &StringSlice{}
		}

		if f.Destination != nil {
			set.Var(f.Destination, name, f.Usage)
			continue
		}

		set.Var(f.Value, name, f.Usage)
	}
	return nil
}
```

After Change :

```golang
// Apply populates the flag given the flag set and environment
func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
		f.Value = &StringSlice{}
		destination := f.Value
		if f.Destination != nil {
			destination = f.Destination
		}

		for _, s := range strings.Split(val, ",") {
			if err := destination.Set(strings.TrimSpace(s)); err != nil {
				return fmt.Errorf("could not parse %q as string value for flag %s: %s", val, f.Name, err)
			}
		}

		// Set this to false so that we reset the slice if we then set values from
		// flags that have already been set by the environment.
		destination.hasBeenSet = false
		f.HasBeenSet = true
	}

	for _, name := range f.Names() {
		if f.Value == nil {
			f.Value = &StringSlice{}
		}

		if f.Destination != nil {
			f.Destination.slice = make([]string, len(f.Value.slice))
			copy(f.Destination.slice, f.Value.slice)
			set.Var(f.Destination, name, f.Usage)
			continue
		}

		set.Var(f.Value, name, f.Usage)
	}

	return nil
}
```

### Run go env

GO111MODULE="on"
GOARCH="amd64"
GOBIN=""
GOCACHE="/home/atif/.cache/go-build"
GOENV="/home/atif/.config/go/env"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="linux"
GOINSECURE=""
GONOPROXY=""
GONOSUMDB=""
GOOS="linux"
GOPATH="/home/atif/WorkStation/Lukso/CodeBase"
GOPRIVATE=""
GOPROXY="https://proxy.golang.org,direct"
GOROOT="/usr/local/go"
GOSUMDB="sum.golang.org"
GOTMPDIR=""
GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
GCCGO="gccgo"
AR="ar"
CC="gcc"
CXX="g++"
CGO_ENABLED="1"
GOMOD="/dev/null"
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fmessage-length=0 -fdebug-prefix-map=/tmp/go-build805853841=/tmp/go-build -gno-record-gcc-switches"