### PR TITLE
fix: Print the long options of the required flags missing

### DIFF
--- a/context.go
+++ b/context.go
@@ -324,11 +324,12 @@ func checkRequiredFlags(flags []Flag, context *Context) requiredFlagsErr {
 			var flagPresent bool
 			var flagName string
 			for _, key := range strings.Split(f.GetName(), ",") {
+				key = strings.TrimSpace(key)
 				if len(key) > 1 {
 					flagName = key
 				}
 
-				if context.IsSet(strings.TrimSpace(key)) {
+				if context.IsSet(key) {
 					flagPresent = true
 				}
 			}

--- a/context_test.go
+++ b/context_test.go
@@ -576,6 +576,14 @@ func TestCheckRequiredFlags(t *testing.T) {
 			},
 			parseInput: []string{"-n", "asd", "-n", "qwe"},
 		},
+		{
+			testCase: "required_flag_with_short_alias_not_printed_on_error",
+			expectedAnError: true,
+			expectedErrorContents: []string{"Required flag \"names\" not set"},
+			flags: []Flag{
+				StringSliceFlag{Name: "names, n", Required: true},
+			},
+		},
 	}
 	for _, test := range tdata {
 		t.Run(test.testCase, func(t *testing.T) {


### PR DESCRIPTION

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [ x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

This fixes a formatting bug in the v1 required flags error message

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Formatting error in the requireflags error message
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

I at least think this is a bug. The short option behaviour is a little odd.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

Only tested manually, see the commit message for output.

<!--
  Describe how you tested this change.
-->

## Release Notes


<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Changes the error message printing the long option for the required flags missing, and not the alias.
```
