### PR TITLE
fix #1121(StringSliceFlag set default value into destination)

### DIFF
--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -116,6 +116,14 @@ func (f *StringSliceFlag) GetValue() string {
 
 // Apply populates the flag given the flag set and environment
 func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
+
+	if f.Destination != nil {
+		if f.Value != nil {
+			f.Destination.slice = make([]string, len(f.Value.slice))
+			copy(f.Destination.slice, f.Value.slice)
+		}
+	}
+
 	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
 		f.Value = &StringSlice{}
 		destination := f.Value

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -117,11 +117,10 @@ func (f *StringSliceFlag) GetValue() string {
 // Apply populates the flag given the flag set and environment
 func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 
-	if f.Destination != nil {
-		if f.Value != nil {
-			f.Destination.slice = make([]string, len(f.Value.slice))
-			copy(f.Destination.slice, f.Value.slice)
-		}
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]string, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+
 	}
 
 	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {

--- a/flag_test.go
+++ b/flag_test.go
@@ -386,6 +386,18 @@ func TestStringSliceFlagApply_SetsAllNames(t *testing.T) {
 	expect(t, err, nil)
 }
 
+func TestStringSliceFlagApply_DefaultValueWithDestination(t *testing.T) {
+	defValue := []string{"UA", "US"}
+
+	fl := StringSliceFlag{Name: "country", Value: NewStringSlice(defValue...), Destination: NewStringSlice("CA")}
+	set := flag.NewFlagSet("test", 0)
+	_ = fl.Apply(set)
+
+	err := set.Parse([]string{})
+	expect(t, err, nil)
+	expect(t, defValue, fl.Destination.Value())
+}
+
 var intFlagTests = []struct {
 	name     string
 	expected string


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

default value does not set in Destination field in StringSliceFlag.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

https://github.com/urfave/cli/issues/1121
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
 - fix bug, default value does not set in Destination field in StringSliceFlag.
```
