### PR TITLE
Add ShowDefaultValue option to prevent default to be printed for BoolFlag

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -2183,3 +2183,63 @@ func TestSetupInitializesOnlyNilWriters(t *testing.T) {
 		t.Errorf("expected a.Writer to be os.Stdout")
 	}
 }
+
+func TestApp_PreventDefaultPrint_When_BoolFlag(t *testing.T) {
+
+	app := App{
+		Name:  "greet",
+		Usage: "fight the loneliness!",
+		Flags: []Flag{
+			&BoolFlag{
+				Name:             "verbose",
+				Aliases:          []string{"v"},
+				Usage:            "Increase verbosity",
+				ShowDefaultValue: true,
+				DefaultText:      "default text",
+			},
+			&BoolFlag{
+				Name:             "extract",
+				Aliases:          []string{"e"},
+				Usage:            "Extract only, do not execute the service",
+				ShowDefaultValue: false,
+			},
+			&BoolFlag{
+				Name:    "keep",
+				Aliases: []string{"k"},
+				Usage:   " Do not delete the temp dir after execution",
+			},
+			&StringFlag{
+				Name:  "lang",
+				Value: "english",
+				Usage: "language for the greeting",
+			},
+		},
+
+		Action: func(c *Context) error {
+			return nil
+		},
+	}
+
+	err := app.Run([]string{"", "-h"})
+	if err != nil {
+		t.Error(err)
+	}
+	/*
+		OUTPUT :
+			NAME:
+			greet - fight the loneliness!
+
+			USAGE:
+			debug.test [global options] command [command options] [arguments...]
+
+			COMMANDS:
+			help, h  Shows a list of commands or help for one command
+
+			GLOBAL OPTIONS:
+			--verbose, -v  Increase verbosity (default: default text)
+			--extract, -e  Extract only, do not execute the service
+			--keep, -k     Do not delete the temp dir after execution
+			--lang value   language for the greeting (default: "english")
+			--help, -h     show help
+	*/
+}

--- a/app_test.go
+++ b/app_test.go
@@ -2191,7 +2191,7 @@ func TestApp_PreventDefaultPrint_When_BoolFlag(t *testing.T) {
    greet - fight the loneliness!
 
 USAGE:
-   cli.test [global options] command [command options] [arguments...]
+   [global options] command [command options] [arguments...]
 
 COMMANDS:
    help, h  Shows a list of commands or help for one command
@@ -2251,7 +2251,7 @@ GLOBAL OPTIONS:
 			greet - fight the loneliness!
 
 			USAGE:
-			cli.test [global options] command [command options] [arguments...]
+			[global options] command [command options] [arguments...]
 
 			COMMANDS:
 			help, h  Shows a list of commands or help for one command

--- a/app_test.go
+++ b/app_test.go
@@ -2191,7 +2191,7 @@ func TestApp_PreventDefaultPrint_When_BoolFlag(t *testing.T) {
    greet - fight the loneliness!
 
 USAGE:
-   [global options] command [command options] [arguments...]
+   cli.test [global options] command [command options] [arguments...]
 
 COMMANDS:
    help, h  Shows a list of commands or help for one command
@@ -2251,7 +2251,7 @@ GLOBAL OPTIONS:
 			greet - fight the loneliness!
 
 			USAGE:
-			[global options] command [command options] [arguments...]
+			cli.test [global options] command [command options] [arguments...]
 
 			COMMANDS:
 			help, h  Shows a list of commands or help for one command

--- a/flag.go
+++ b/flag.go
@@ -271,16 +271,16 @@ func stringifyFlag(f Flag) string {
 	needsPlaceholder := false
 	defaultValueString := ""
 	val := fv.FieldByName("Value")
+	hideDefaultValue := false
 
-	showDefaultValue := true
 	if boolFlag, ok := f.(*BoolFlag); ok {
-		showDefaultValue = boolFlag.ShowDefaultValue
+		hideDefaultValue = boolFlag.HideDefaultValue
 	}
 
 	if val.IsValid() {
 		needsPlaceholder = val.Kind() != reflect.Bool
 		defaultValueString = fmt.Sprintf(formatDefault("%v"), val.Interface())
-		if !showDefaultValue {
+		if hideDefaultValue {
 			defaultValueString = ""
 		}
 
@@ -293,7 +293,7 @@ func stringifyFlag(f Flag) string {
 	if helpText.IsValid() && helpText.String() != "" {
 		needsPlaceholder = val.Kind() != reflect.Bool
 		defaultValueString = fmt.Sprintf(formatDefault("%s"), helpText.String())
-		if !showDefaultValue {
+		if hideDefaultValue {
 			defaultValueString = ""
 		}
 	}

--- a/flag.go
+++ b/flag.go
@@ -271,10 +271,13 @@ func stringifyFlag(f Flag) string {
 	needsPlaceholder := false
 	defaultValueString := ""
 	val := fv.FieldByName("Value")
+	showDefaultValue := fv.FieldByName("ShowDefaultValue")
 	if val.IsValid() {
 		needsPlaceholder = val.Kind() != reflect.Bool
 		defaultValueString = fmt.Sprintf(formatDefault("%v"), val.Interface())
-
+		if val.Kind() == reflect.Bool && !showDefaultValue.Bool() {
+			defaultValueString = ""
+		}
 		if val.Kind() == reflect.String && val.String() != "" {
 			defaultValueString = fmt.Sprintf(formatDefault("%q"), val.String())
 		}
@@ -284,6 +287,9 @@ func stringifyFlag(f Flag) string {
 	if helpText.IsValid() && helpText.String() != "" {
 		needsPlaceholder = val.Kind() != reflect.Bool
 		defaultValueString = fmt.Sprintf(formatDefault("%s"), helpText.String())
+		if val.Kind() == reflect.Bool && !showDefaultValue.Bool() {
+			defaultValueString = ""
+		}
 	}
 
 	if defaultValueString == formatDefault("") {

--- a/flag_bool.go
+++ b/flag_bool.go
@@ -8,17 +8,18 @@ import (
 
 // BoolFlag is a flag with type bool
 type BoolFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       bool
-	DefaultText string
-	Destination *bool
-	HasBeenSet  bool
+	Name             string
+	Aliases          []string
+	Usage            string
+	EnvVars          []string
+	FilePath         string
+	Required         bool
+	Hidden           bool
+	Value            bool
+	DefaultText      string
+	Destination      *bool
+	HasBeenSet       bool
+	ShowDefaultValue bool
 }
 
 // IsSet returns whether or not the flag has been set through env or file

--- a/flag_bool.go
+++ b/flag_bool.go
@@ -19,7 +19,7 @@ type BoolFlag struct {
 	DefaultText      string
 	Destination      *bool
 	HasBeenSet       bool
-	ShowDefaultValue bool
+	HideDefaultValue bool
 }
 
 // IsSet returns whether or not the flag has been set through env or file


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

There is an issue #1122  which requires an extra option like (ShowDefaultVlaue) to prevent default to be printed for BoolFlag. 

Example 
```
GLOBAL OPTIONS:
   --verbose, -v  Increase verbosity (default: false)
   --extract, -e  Extract only, do not execute the service (default: false)
   --keep, -k     Do not delete the temp dir after execution (default: false)
   --help, -h     show help (default: false)
   --version, -V  print the version (default: false)
```

Needs an option for BoolFlag to prevent printing ```(default: false)```. 

## Which issue(s) this PR fixes:

Fixes #1122

## Testing
- Only effects on BoolFlag
- Set option ShowDefaultValue true then it shows default value in BoolFlag.
- Set option ShowDefaultValue false then it does not show default value in BoolFlag.
- Other flag behavior remains as is.

Before - 
```
GLOBAL OPTIONS:
   --verbose, -v  Increase verbosity (default: false)
   --extract, -e  Extract only, do not execute the service (default: false)
   --keep, -k     Do not delete the temp dir after execution (default: false)
   --help, -h     show help (default: false)
   --version, -V  print the version (default: false)
```
After - When sets ShowDefaultValue option false.
```
GLOBAL OPTIONS:
   --verbose, -v  Increase verbosity
   --extract, -e  Extract only, do not execute the service
   --keep, -k     Do not delete the temp dir after execution
   --help, -h     show help
   --version, -V  print the version
```
