### PR TITLE
fix(zsh_autocomplete): List files on tab with no completion options

### DIFF
--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -13,6 +13,8 @@ _cli_zsh_autocomplete() {
 
   if [[ "${opts[1]}" != "" ]]; then
     _describe 'values' opts
+  else
+    _files
   fi
 
   return


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- [x ] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Aligns zsh auto-completion functionality with the bash auto-completion

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:



<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

Tested manually

New functionality: https://asciinema.org/a/EAYRIEVGTGNSS2gCGwSJ4Zw1i

Old functionality: https://asciinema.org/a/BfOZz4BHUGwjXMFptbmDHZocH

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
List files on tab with zsh auto-completion when no completion candidates are available.
```
