### PR TITLE
StringSlice flags set to default Value

### DIFF
--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -148,7 +148,7 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 		set.Var(f.Value, name, f.Usage)
 	}
 
-	if !f.HasBeenSet && f.Value != nil {
+	if !f.HasBeenSet && f.Value != nil && f.Destination != nil {
 		for _, v := range f.Value.Value() {
 			f.Destination.Set(v)
 		}

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -142,7 +142,7 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 
 		if f.Destination != nil {
 			set.Var(f.Destination, name, f.Usage)
-			for _, v := range f.Value.Value(){
+			for _, v := range f.Value.Value() {
 				f.Destination.Set(v)
 			}
 			continue

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -142,6 +142,9 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 
 		if f.Destination != nil {
 			set.Var(f.Destination, name, f.Usage)
+			for _, v := range f.Value.Value(){
+				f.Destination.Set(v)
+			}
 			continue
 		}
 

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -142,13 +142,16 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 
 		if f.Destination != nil {
 			set.Var(f.Destination, name, f.Usage)
-			for _, v := range f.Value.Value() {
-				f.Destination.Set(v)
-			}
 			continue
 		}
 
 		set.Var(f.Value, name, f.Usage)
+	}
+
+	if !f.HasBeenSet && f.Value != nil {
+		for _, v := range f.Value.Value() {
+			f.Destination.Set(v)
+		}
 	}
 
 	return nil

--- a/flag_test.go
+++ b/flag_test.go
@@ -347,6 +347,19 @@ var stringSliceFlagTests = []struct {
 	{"dee", []string{"d"}, NewStringSlice("Inka", "Dinka", "dooo"), "--dee value, -d value\t(default: \"Inka\", \"Dinka\", \"dooo\")"},
 }
 
+func TestStringSliceFlagDefaultValue(t *testing.T) {
+	destination := new(StringSlice)
+	defaultValue := NewStringSlice("foo")
+	fl := StringSliceFlag{Name: "goat", Aliases: []string{"G", "gooots"}, Value: defaultValue, Destination: destination}
+	set := flag.NewFlagSet("test", 0)
+	_ = fl.Apply(set)
+
+	err := set.Parse([]string{""})
+	expect(t, err, nil)
+
+	expect(t, destination.slice, defaultValue.slice)
+}
+
 func TestStringSliceFlagHelpOutput(t *testing.T) {
 	for _, test := range stringSliceFlagTests {
 		f := &StringSliceFlag{Name: test.name, Aliases: test.aliases, Value: test.value}


### PR DESCRIPTION
StringSliceFlag types do not set the destination to the value if no env/arg is set.

For example if the argument `--arg` is not set and env variable `ARG` is not set you would expect the destination to be set to `cli.NewStringSlice("foo")`
```go
                 var arg = cli.NewStringSlice()
		...
                  &cli.StringSliceFlag{
			Name:        "arg",
			EnvVars:     []string{"ARG"},
			Value:       cli.NewStringSlice("foo"),
			Destination: arg,
		},
```

I have quickly looked at how the string flag achieves this and tried to do similar. 