### PR TITLE
Fix regression in handling flag-values starting with hyphen

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -546,8 +546,7 @@ func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {
 
 	expect(t, parsedOption, "my-option")
 	expect(t, args[0], "my-arg")
-	expect(t, args[1], "--")
-	expect(t, args[2], "--notARealFlag")
+	expect(t, args[1], "--notARealFlag")
 }
 
 func TestApp_CommandWithDash(t *testing.T) {
@@ -585,8 +584,7 @@ func TestApp_CommandWithNoFlagBeforeTerminator(t *testing.T) {
 	_ = app.Run([]string{"", "cmd", "my-arg", "--", "notAFlagAtAll"})
 
 	expect(t, args[0], "my-arg")
-	expect(t, args[1], "--")
-	expect(t, args[2], "notAFlagAtAll")
+	expect(t, args[1], "notAFlagAtAll")
 }
 
 func TestApp_VisibleCommands(t *testing.T) {

--- a/command.go
+++ b/command.go
@@ -226,18 +226,23 @@ func reorderArgs(commandFlags []Flag, args []string) []string {
 	nextIndexMayContainValue := false
 	for i, arg := range args {
 
-		// dont reorder any args after a --
-		// read about -- here:
-		// https://unix.stackexchange.com/questions/11376/what-does-double-dash-mean-also-known-as-bare-double-dash
-		if arg == "--" {
-			remainingArgs = append(remainingArgs, args[i:]...)
-			break
-
-			// checks if this arg is a value that should be re-ordered next to its associated flag
-		} else if nextIndexMayContainValue && !argIsFlag(commandFlags, arg) {
+		// if we're expecting an option-value, check if this arg is a value, in
+		// which case it should be re-ordered next to its associated flag
+		if nextIndexMayContainValue && !argIsFlag(commandFlags, arg) {
 			nextIndexMayContainValue = false
 			reorderedArgs = append(reorderedArgs, arg)
+		} else if arg == "--" {
+			// don't reorder any args after the -- delimiter As described in the POSIX spec:
+			// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02
+			// > Guideline 10:
+			// >   The first -- argument that is not an option-argument should be accepted
+			// >   as a delimiter indicating the end of options. Any following arguments
+			// >   should be treated as operands, even if they begin with the '-' character.
 
+			// make sure the "--" delimiter itself is at the start
+			remainingArgs = append([]string{"--"}, remainingArgs...)
+			remainingArgs = append(remainingArgs, args[i+1:]...)
+			break
 			// checks if this is an arg that should be re-ordered
 		} else if argIsFlag(commandFlags, arg) {
 			// we have determined that this is a flag that we should re-order
@@ -256,8 +261,9 @@ func reorderArgs(commandFlags []Flag, args []string) []string {
 
 // argIsFlag checks if an arg is one of our command flags
 func argIsFlag(commandFlags []Flag, arg string) bool {
-	// checks if this is just a `-`, and so definitely not a flag
-	if arg == "-" {
+	if arg == "-" || arg == "--"{
+		// `-` is never a flag
+		// `--` is an option-value when following a flag, and a delimiter indicating the end of options in other cases.
 		return false
 	}
 	// flags always start with a -

--- a/command.go
+++ b/command.go
@@ -234,7 +234,7 @@ func reorderArgs(commandFlags []Flag, args []string) []string {
 			break
 
 			// checks if this arg is a value that should be re-ordered next to its associated flag
-		} else if nextIndexMayContainValue && !strings.HasPrefix(arg, "-") {
+		} else if nextIndexMayContainValue && !argIsFlag(commandFlags, arg) {
 			nextIndexMayContainValue = false
 			reorderedArgs = append(reorderedArgs, arg)
 

--- a/command_test.go
+++ b/command_test.go
@@ -114,6 +114,71 @@ func TestParseAndRunShortOpts(t *testing.T) {
 	}
 }
 
+// test-case for https://github.com/urfave/cli/issues/1092
+func TestParseAndRunHyphenValues(t *testing.T) {
+	cases := []struct {
+		testArgs     []string
+		expectedArgs []string
+		expectedOpt string
+	}{
+		{[]string{"foo", "test", "argz"}, []string{"argz"}, ""},
+		{[]string{"foo", "test", "argz", "arga"}, []string{"argz", "arga"}, ""},
+		{[]string{"foo", "test", "--opt", "opt-value"}, []string{}, "opt-value"},
+		{[]string{"foo", "test", "--opt", "opt-value", "argz"}, []string{"argz"}, "opt-value"},
+		{[]string{"foo", "test", "--opt", "opt-value", "argz", "arga"}, []string{"argz", "arga"}, "opt-value"},
+		{[]string{"foo", "test", "argz", "--opt", "opt-value"}, []string{"argz"}, "opt-value"},
+		{[]string{"foo", "test", "argz", "--opt", "opt-value", "arga"}, []string{"argz", "arga"}, "opt-value"},
+
+		{[]string{"foo", "test", "--opt", "-opt-value"}, []string{}, "-opt-value"},
+		{[]string{"foo", "test", "--opt", "-opt-value", "argz"}, []string{"argz"}, "-opt-value"},
+		{[]string{"foo", "test", "--opt", "-opt-value", "argz", "arga"}, []string{"argz", "arga"}, "-opt-value"},
+		{[]string{"foo", "test", "argz", "--opt", "-opt-value"}, []string{"argz"}, "-opt-value"},
+		{[]string{"foo", "test", "argz", "--opt", "-opt-value", "arga"}, []string{"argz", "arga"}, "-opt-value"},
+
+		{[]string{"foo", "test", "--opt", "--opt-value"}, []string{}, "--opt-value"},
+		{[]string{"foo", "test", "--opt", "--opt-value", "argz"}, []string{"argz"}, "--opt-value"},
+		{[]string{"foo", "test", "--opt", "--opt-value", "argz", "arga"}, []string{"argz", "arga"}, "--opt-value"},
+		{[]string{"foo", "test", "argz", "--opt", "--opt-value"}, []string{"argz"}, "--opt-value"},
+		{[]string{"foo", "test", "argz", "--opt", "--opt-value", "arga"}, []string{"argz", "arga"}, "--opt-value"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(strings.Join(tc.testArgs, "_"), func(t *testing.T){
+			var (
+				args []string
+				opt string
+			)
+
+			cmd := Command{
+				Name:        "test",
+				Usage:       "this is for testing",
+				Description: "testing",
+				Action: func(c *Context) error {
+					args = c.Args()
+					opt = c.String("opt")
+					return nil
+				},
+				Flags: []Flag{
+					StringFlag{Name:  "opt"},
+				},
+			}
+
+			app := NewApp()
+			app.Writer = ioutil.Discard
+			app.ErrWriter = ioutil.Discard
+			app.Commands = []Command{cmd}
+
+			err := app.Run(tc.testArgs)
+
+			expect(t, err, nil)
+			expect(t, args, tc.expectedArgs)
+			expect(t, opt, tc.expectedOpt)
+		})
+
+	}
+}
+
 func TestCommand_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 	app := NewApp()
 	app.Commands = []Command{

--- a/command_test.go
+++ b/command_test.go
@@ -140,6 +140,17 @@ func TestParseAndRunHyphenValues(t *testing.T) {
 		{[]string{"foo", "test", "--opt", "--opt-value", "argz", "arga"}, []string{"argz", "arga"}, "--opt-value"},
 		{[]string{"foo", "test", "argz", "--opt", "--opt-value"}, []string{"argz"}, "--opt-value"},
 		{[]string{"foo", "test", "argz", "--opt", "--opt-value", "arga"}, []string{"argz", "arga"}, "--opt-value"},
+
+		// Tests below test handling of the "--" delimiter
+		{[]string{"foo", "test", "--", "--opt", "--opt-value", "argz"}, []string{"--opt", "--opt-value", "argz"}, ""},
+		{[]string{"foo", "test", "--", "argz", "--opt", "--opt-value", "arga"}, []string{"argz", "--opt", "--opt-value", "arga"}, ""},
+		{[]string{"foo", "test", "argz", "--", "--opt", "--opt-value", "arga"}, []string{"argz", "--opt", "--opt-value", "arga"}, ""},
+		{[]string{"foo", "test", "argz", "--opt", "--", "--opt-value", "arga"}, []string{"argz", "--opt-value", "arga"}, "--"},
+
+		// first "--" is an option-value for "--opt", second "--" is the delimiter indicating the end of options.
+		{[]string{"foo", "test", "argz", "--opt", "--", "--", "--opt2", "--opt-value", "arga"}, []string{"argz", "--opt2", "--opt-value", "arga"}, "--"},
+		{[]string{"foo", "test", "argz", "--opt", "--opt-value", "--", "arga"}, []string{"argz", "arga"}, "--opt-value"},
+		{[]string{"foo", "test", "argz", "--opt", "--opt-value", "arga", "--"}, []string{"argz", "arga"}, "--opt-value"},
 	}
 
 	for _, tc := range cases {
@@ -161,6 +172,7 @@ func TestParseAndRunHyphenValues(t *testing.T) {
 				},
 				Flags: []Flag{
 					StringFlag{Name:  "opt"},
+					StringFlag{Name:  "opt2"},
 				},
 			}
 


### PR DESCRIPTION
fixes https://github.com/urfave/cli/issues/1092

Fix for a regression between v1.22.1 and v1.22.2, where
flag values starting with a hyphen would be parsed as a flag:

    runc update test_update --memory-swap -1
    Incorrect Usage: flag provided but not defined: -1

This problem was caused by `reorderArgs()` not properly checking
if the next arg in the list was a value for the flag (and not
the next flag);

Before this patch:

    args before reordering: --opt,--opt-value,arg1
    args after reordering:  --opt,arg1,--opt-value
    args before reordering: --opt,--opt-value,arg1,arg2
    args after reordering:  --opt,arg1,--opt-value,arg2
    args before reordering: arg1,--opt,--opt-value,arg2
    args after reordering:  --opt,arg2,arg1,--opt-value

After this patch is applied:

    args before reordering: --opt,--opt-value,arg1
    args after reordering:  --opt,--opt-value,arg1
    args before reordering: --opt,--opt-value,arg1,arg2
    args after reordering:  --opt,--opt-value,arg1,arg2
    args before reordering: arg1,--opt,--opt-value,arg2
    args after reordering:  --opt,--opt-value,arg1,arg2


<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

see description above

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

fixes https://github.com/urfave/cli/issues/1092
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

Test was added

<!--
  Describe how you tested this change.
-->

## Release Notes


<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Fix a regression where flag values starting with a hyphen would be parsed as a flag instead of a value for a flag
```
