### PR TITLE
Allow default values to be set for TimestampFlag

### DIFF
--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -45,7 +45,7 @@ func (t *Timestamp) Set(value string) error {
 
 // String returns a readable representation of this value (for usage defaults)
 func (t *Timestamp) String() string {
-	return fmt.Sprintf(t.timestamp.Format(t.layout))
+	return fmt.Sprintf("%#v", t.timestamp)
 }
 
 // Value returns the timestamp value stored in the flag
@@ -115,14 +115,14 @@ func (f *TimestampFlag) GetValue() string {
 
 // Apply populates the flag given the flag set and environment
 func (f *TimestampFlag) Apply(set *flag.FlagSet) error {
+	if f.Value == nil {
+		f.Value = &Timestamp{}
+	}
+
 	if f.Layout == "" {
 		return fmt.Errorf("timestamp Layout is required")
 	}
 	f.Value.SetLayout(f.Layout)
-
-	if f.Value == nil {
-		f.Value = &Timestamp{}
-	}
 
 	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
 		if err := f.Value.Set(val); err != nil {

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -118,7 +118,6 @@ func (f *TimestampFlag) Apply(set *flag.FlagSet) error {
 	if f.Layout == "" {
 		return fmt.Errorf("timestamp Layout is required")
 	}
-	f.Value = &Timestamp{}
 	f.Value.SetLayout(f.Layout)
 
 	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -120,6 +120,10 @@ func (f *TimestampFlag) Apply(set *flag.FlagSet) error {
 	}
 	f.Value.SetLayout(f.Layout)
 
+	if f.Value == nil {
+		f.Value = &Timestamp{}
+	}
+
 	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
 		if err := f.Value.Set(val); err != nil {
 			return fmt.Errorf("could not parse %q as timestamp value for flag %s: %s", val, f.Name, err)

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -45,7 +45,7 @@ func (t *Timestamp) Set(value string) error {
 
 // String returns a readable representation of this value (for usage defaults)
 func (t *Timestamp) String() string {
-	return fmt.Sprintf("%#v", t.timestamp)
+	return fmt.Sprintf(t.timestamp.Format(t.layout))
 }
 
 // Value returns the timestamp value stored in the flag


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Currently, TimestampFlags are not taking their default `Value` set in the Flag slice, and is nil even if `Value` is set to `cli.NewTimestamp(time.Now())`.

Used https://github.com/urfave/cli/blob/477292c8d462a3f51cd18bc77c0542193a62274d/flag_string.go#L58-L74 as a reference.

## Testing

Tested locally with a fork.

## Release Notes

```release-note
Fix setting a default `Value` for `TimestampFlag`.
```
