### PR TITLE
fix link to docs on v2 manual

### DIFF
--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -307,7 +307,7 @@ func main() {
 }
 ```
 
-See full list of flags at http://godoc.org/github.com/urfave/cli
+See full list of flags at https://pkg.go.dev/github.com/urfave/cli/v2
 
 #### Placeholder Values
 


### PR DESCRIPTION
What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup  
- [x] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

the link was pointing to v1 docs

## Which issue(s) this PR fixes:

_(REQUIRED)_

## Release Notes

_(REQUIRED)_

```release-note
NONE
```
