### PR TITLE
Bugfix: Remove version flag from commands with subcommands

### DIFF
--- a/command.go
+++ b/command.go
@@ -241,7 +241,7 @@ func (c *Command) startApp(ctx *Context) error {
 	app.HideHelpCommand = c.HideHelpCommand
 
 	app.Version = ctx.App.Version
-	app.HideVersion = ctx.App.HideVersion
+	app.HideVersion = true
 	app.Compiled = ctx.App.Compiled
 	app.Writer = ctx.App.Writer
 	app.ErrWriter = ctx.App.ErrWriter

--- a/command_test.go
+++ b/command_test.go
@@ -389,9 +389,31 @@ func TestCommand_NoVersionFlagOnCommands(t *testing.T) {
 				HideHelp:    true,
 				Action: func(c *Context) error {
 					if len(c.App.VisibleFlags()) != 0 {
-						t.Fatalf("unexpected flag on command")
+						t.Fatal("unexpected flag on command")
 					}
 					return nil
+				},
+			},
+		},
+	}
+
+	err := app.Run([]string{"foo", "bar"})
+	expect(t, err, nil)
+}
+
+func TestCommand_CanAddVFlagOnCommands(t *testing.T) {
+	app := &App{
+		Version: "some version",
+		Writer:  ioutil.Discard,
+		Commands: []*Command{
+			{
+				Name:        "bar",
+				Usage:       "this is for testing",
+				Subcommands: []*Command{{}}, // some subcommand
+				Flags: []Flag{
+					&BoolFlag{
+						Name: "v",
+					},
 				},
 			},
 		},

--- a/command_test.go
+++ b/command_test.go
@@ -386,11 +386,10 @@ func TestCommand_NoVersionFlagOnCommands(t *testing.T) {
 				Name:        "bar",
 				Usage:       "this is for testing",
 				Subcommands: []*Command{{}}, // some subcommand
+				HideHelp:    true,
 				Action: func(c *Context) error {
-					for _, f := range c.App.VisibleFlags() {
-						if f == VersionFlag {
-							t.Fatalf("unexpected version flag")
-						}
+					if len(c.App.VisibleFlags()) != 0 {
+						t.Fatalf("unexpected flag on command")
 					}
 					return nil
 				},

--- a/command_test.go
+++ b/command_test.go
@@ -377,3 +377,27 @@ func TestCommand_Run_CustomShellCompleteAcceptsMalformedFlags(t *testing.T) {
 	}
 
 }
+
+func TestCommand_NoVersionFlagOnCommands(t *testing.T) {
+	app := &App{
+		Version: "some version",
+		Commands: []*Command{
+			{
+				Name:        "bar",
+				Usage:       "this is for testing",
+				Subcommands: []*Command{{}}, // some subcommand
+				Action: func(c *Context) error {
+					for _, f := range c.App.VisibleFlags() {
+						if f == VersionFlag {
+							t.Fatalf("unexpected version flag")
+						}
+					}
+					return nil
+				},
+			},
+		},
+	}
+
+	err := app.Run([]string{"foo", "bar"})
+	expect(t, err, nil)
+}


### PR DESCRIPTION

## What type of PR is this?

- [X] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

This PR removes unexpected version flag on commands with subcommands.

## Which issue(s) this PR fixes:

Fixes #1073

## Testing

test added

## Release Notes

```release-note
fix: remove unexpected version flag on commands with subcommands
```
