### PR TITLE
Allow using Value with TimestampFlag

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -1836,6 +1836,17 @@ func TestTimestampFlagApply(t *testing.T) {
 	expect(t, *fl.Value.timestamp, expectedResult)
 }
 
+func TestTimestampFlagApplyValue(t *testing.T) {
+	expectedResult, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+	fl := TimestampFlag{Name: "time", Aliases: []string{"t"}, Layout: time.RFC3339, Value: NewTimestamp(expectedResult)}
+	set := flag.NewFlagSet("test", 0)
+	_ = fl.Apply(set)
+
+	err := set.Parse([]string{""})
+	expect(t, err, nil)
+	expect(t, *fl.Value.timestamp, expectedResult)
+}
+
 func TestTimestampFlagApply_Fail_Parse_Wrong_Layout(t *testing.T) {
 	fl := TimestampFlag{Name: "time", Aliases: []string{"t"}, Layout: "randomlayout"}
 	set := flag.NewFlagSet("test", 0)

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -118,7 +118,9 @@ func (f *TimestampFlag) Apply(set *flag.FlagSet) error {
 	if f.Layout == "" {
 		return fmt.Errorf("timestamp Layout is required")
 	}
-	f.Value = &Timestamp{}
+	if f.Value == nil {
+		f.Value = &Timestamp{}
+	}
 	f.Value.SetLayout(f.Layout)
 
 	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {


### PR DESCRIPTION

## What type of PR is this?


- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Allows to use default Value with TimestampFlags.
- Check if there's a Value before overriding 
- Basic unit test

## Which issue(s) this PR fixes:
fixes #1144 

## Special notes for your reviewer:

Thanks @aloababa for the tip!
cc @lynncyrin 

## Testing

Just a small unit test to check if setting a Value will led to a filled parameter when there is no cli input.

## Release Notes

```release-note
Fixed TimestampFlag to allow default Value assignment.
```
