### PR TITLE
make missing required flags an ExitCoder so that app exit code handling treats this as an error

### DIFF
--- a/app.go
+++ b/app.go
@@ -244,6 +244,7 @@ func (a *App) Run(arguments []string) (err error) {
 
 	cerr := checkRequiredFlags(a.Flags, context)
 	if cerr != nil {
+		a.handleExitCoder(context, cerr)
 		_ = ShowAppHelp(context)
 		return cerr
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -2262,3 +2262,22 @@ func TestWhenExitSubCommandWithCodeThenAppQuitUnexpectedly(t *testing.T) {
 		t.Errorf("exitCodeFromOsExiter valeu should be %v, but its value is %v", testCode, exitCodeFromExitErrHandler)
 	}
 }
+
+func TestApp_RequiredFlagExitError(t *testing.T) {
+
+	app := NewApp()
+	app.Flags = []Flag{
+		StringFlag{Name: "required", Required: true, Usage: "this flag is required"},
+	}
+	var exitCodeFromOsExiter int
+	OsExiter = func(exitCode int) {
+		exitCodeFromOsExiter = exitCode
+	}
+
+	app.Action = func(c *Context) error {
+		return nil
+	}
+
+	_ = app.Run([]string{""})
+	expect(t, exitCodeFromOsExiter, ExitCodeMissingFlag)
+}

--- a/context.go
+++ b/context.go
@@ -298,6 +298,7 @@ func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
 type requiredFlagsErr interface {
 	error
 	getMissingFlags() []string
+	ExitCode() int
 }
 
 type errRequiredFlags struct {
@@ -315,6 +316,12 @@ func (e *errRequiredFlags) Error() string {
 
 func (e *errRequiredFlags) getMissingFlags() []string {
 	return e.missingFlags
+}
+
+const ExitCodeMissingFlag = 127
+
+func (e *errRequiredFlags) ExitCode() int {
+	return ExitCodeMissingFlag
 }
 
 func checkRequiredFlags(flags []Flag, context *Context) requiredFlagsErr {


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [x] feature

## What this PR does / why we need it:


modifies errRequiredFlags so that it can be used as an ExitCoder, and then changes the error handling in app.Run so that it does not bypass the osExit handling

## Special notes for your reviewer:

I just picked a value to use for the exit status, it is hard coded
This patch is only against v1, I am not currently using v2, unsure if it is applicable there. 

## Testing

I added a simple  test to app_test that the handler is called when a required flag is not supplied

## Release Notes


```release-note
if a flag is defined as Required but is not present, app.Run will call os.Exit with 127 

```
