### PR TITLE
*Slice: don't mutate the underlying default value

### DIFF
--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -171,7 +171,9 @@ func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
 func removeFromInt64Slice(slice []int64, val int64) []int64 {
 	for i, v := range slice {
 		if v == val {
-			return append(slice[:i], slice[i+1:]...)
+			ret := append([]int64{}, slice[:i]...)
+			ret = append(ret, slice[i+1:]...)
+			return ret
 		}
 	}
 	return slice

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -170,7 +170,9 @@ func lookupIntSlice(name string, set *flag.FlagSet) []int {
 func removeFromIntSlice(slice []int, val int) []int {
 	for i, v := range slice {
 		if v == val {
-			return append(slice[:i], slice[i+1:]...)
+			ret := append([]int{}, slice[:i]...)
+			ret = append(ret, slice[i+1:]...)
+			return ret
 		}
 	}
 	return slice

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -156,7 +156,9 @@ func lookupStringSlice(name string, set *flag.FlagSet) []string {
 func removeFromStringSlice(slice []string, val string) []string {
 	for i, v := range slice {
 		if v == val {
-			return append(slice[:i], slice[i+1:]...)
+			ret := append([]string{}, slice[:i]...)
+			ret = append(ret, slice[i+1:]...)
+			return ret
 		}
 	}
 	return slice


### PR DESCRIPTION
    *Slice: don't mutate the underlying default value
    
    If the default value is present, we shouldn't mutate it. Appending slices
    as the code was before mutates the underlying value:
    
    package main
    
    import (
            "fmt"
    )
    
    func main() {
            slice := []string{"a", "b", "c"}
    
            fmt.Println(append(slice[:1], slice[2:]...))
            fmt.Println(slice)
    }
    ~ go run tester2.go
    [a c]
    [a c c]
    
    Let's fix this by creating and returning an entirely new slice.
    
    Closes #1169
    
    Signed-off-by: Tycho Andersen <tycho@tycho.ws>
