### PR TITLE
feat(docs): add UsageText to docs output for markdown and man page generation

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -68,15 +68,16 @@ func prepareCommands(commands []*Command, level int) []string {
 		if command.Hidden {
 			continue
 		}
-		usage := ""
-		if command.Usage != "" {
-			usage = command.Usage
-		}
 
-		prepared := fmt.Sprintf("%s %s\n\n%s\n",
+		usageText := prepareUsageText(command)
+
+		usage := prepareUsage(command, usageText)
+
+		prepared := fmt.Sprintf("%s %s\n\n%s%s",
 			strings.Repeat("#", level+2),
 			strings.Join(command.Names(), ", "),
 			usage,
+			usageText,
 		)
 
 		flags := prepareArgsWithValues(command.Flags)
@@ -154,4 +155,36 @@ func flagDetails(flag DocGenerationFlag) string {
 		description += " (default: " + value + ")"
 	}
 	return ": " + description
+}
+
+func prepareUsageText(command *Command) string {
+	usageText := ""
+	if command.UsageText != "" {
+		// Remove leading and trailing newlines
+		preparedUsageText := strings.TrimSuffix(command.UsageText, "\n")
+		preparedUsageText = strings.TrimPrefix(preparedUsageText, "\n")
+
+		if strings.Contains(preparedUsageText, "\n") {
+			// Format multi-line string as a code block
+			usageText = fmt.Sprintf("```\n%s\n```\n", preparedUsageText)
+		} else {
+			// Style a single line as a note
+			usageText = fmt.Sprintf(">%s\n", preparedUsageText)
+		}
+	}
+	return usageText
+}
+
+func prepareUsage(command *Command, usageText string) string {
+	usage := ""
+	if command.Usage != "" {
+		usage = fmt.Sprintf("%s\n", command.Usage)
+	}
+
+	// Add a newline to the Usage IFF there is a UsageText
+	if usageText != "" && usage != "" {
+		usage = fmt.Sprintf("%s\n", usage)
+	}
+
+	return usage
 }

--- a/docs.go
+++ b/docs.go
@@ -158,32 +158,37 @@ func flagDetails(flag DocGenerationFlag) string {
 }
 
 func prepareUsageText(command *Command) string {
-	usageText := ""
-	if command.UsageText != "" {
-		// Remove leading and trailing newlines
-		preparedUsageText := strings.TrimSuffix(command.UsageText, "\n")
-		preparedUsageText = strings.TrimPrefix(preparedUsageText, "\n")
-
-		if strings.Contains(preparedUsageText, "\n") {
-			// Format multi-line string as a code block
-			usageText = fmt.Sprintf("```\n%s\n```\n", preparedUsageText)
-		} else {
-			// Style a single line as a note
-			usageText = fmt.Sprintf(">%s\n", preparedUsageText)
-		}
+	if command.UsageText == "" {
+		return ""
 	}
+
+	// Remove leading and trailing newlines
+	preparedUsageText := strings.Trim(command.UsageText, "\n")
+
+	var usageText string
+	if strings.Contains(preparedUsageText, "\n") {
+		// Format multi-line string as a code block using the 4 space schema to allow for embedded markdown such
+		// that it will not break the continuous code block.
+		for _, ln := range strings.Split(preparedUsageText, "\n") {
+			usageText += fmt.Sprintf("    %s\n", ln)
+		}
+	} else {
+		// Style a single line as a note
+		usageText = fmt.Sprintf(">%s\n", preparedUsageText)
+	}
+
 	return usageText
 }
 
 func prepareUsage(command *Command, usageText string) string {
-	usage := ""
-	if command.Usage != "" {
-		usage = fmt.Sprintf("%s\n", command.Usage)
+	if command.Usage == "" {
+		return ""
 	}
 
+	usage := command.Usage + "\n"
 	// Add a newline to the Usage IFF there is a UsageText
-	if usageText != "" && usage != "" {
-		usage = fmt.Sprintf("%s\n", usage)
+	if usageText != "" {
+		usage += "\n"
 	}
 
 	return usage

--- a/docs_test.go
+++ b/docs_test.go
@@ -309,7 +309,7 @@ func Test_prepareUsage(t *testing.T) {
 		res := prepareUsage(&cmd, "")
 
 		// Then
-		expect(t, res, cmd.Usage + "\n")
+		expect(t, res, cmd.Usage+"\n")
 	})
 
 	t.Run("simple Usage with UsageText", func(t *testing.T) {
@@ -320,6 +320,6 @@ func Test_prepareUsage(t *testing.T) {
 		res := prepareUsage(&cmd, "a non-empty string")
 
 		// Then
-		expect(t, res, cmd.Usage + "\n\n")
+		expect(t, res, cmd.Usage+"\n\n")
 	})
 }

--- a/docs_test.go
+++ b/docs_test.go
@@ -67,6 +67,41 @@ func testApp() *App {
 	}, {
 		Name:   "hidden-command",
 		Hidden: true,
+	}, {
+		Aliases: []string{"u"},
+		Flags: []Flag{
+			&StringFlag{
+				Name:      "flag",
+				Aliases:   []string{"fl", "f"},
+				TakesFile: true,
+			},
+			&BoolFlag{
+				Name:    "another-flag",
+				Aliases: []string{"b"},
+				Usage:   "another usage text",
+			},
+		},
+		Name:  "usage",
+		Usage: "standard usage text",
+		UsageText: `
+Usage for the usage text
+- formatted:  Based on the specified ConfigMap and summon secrets.yml
+- list:       Inspect the environment for a specific process running on a Pod
+- for_effect: Compare 'namespace' environment with 'local'
+`,
+		Subcommands: []*Command{{
+			Aliases: []string{"su"},
+			Flags: []Flag{
+				&BoolFlag{
+					Name:    "sub-command-flag",
+					Aliases: []string{"s"},
+					Usage:   "some usage text",
+				},
+			},
+			Name:      "sub-usage",
+			Usage:     "standard usage text",
+			UsageText: "Single line of UsageText",
+		}},
 	}}
 	app.UsageText = "app [first_arg] [second_arg]"
 	app.Usage = "Some app"

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -89,6 +89,12 @@ Usage for the usage text
 \- list:       Inspect the environment for a specific process running on a Pod
 \- for\_effect: Compare 'namespace' environment with 'local'
 
+```
+func() { ... }
+```
+
+Should be a part of the same code block
+
 .fi
 .RE
 

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -76,3 +76,39 @@ another usage test
 retrieve generic information
 
 .SH some\-command
+.SH usage, u
+.PP
+standard usage text
+
+.PP
+.RS
+
+.nf
+Usage for the usage text
+\- formatted:  Based on the specified ConfigMap and summon secrets.yml
+\- list:       Inspect the environment for a specific process running on a Pod
+\- for\_effect: Compare 'namespace' environment with 'local'
+
+.fi
+.RE
+
+.PP
+\fB\-\-another\-flag, \-b\fP: another usage text
+
+.PP
+\fB\-\-flag, \-\-fl, \-f\fP="":
+
+.SS sub\-usage, su
+.PP
+standard usage text
+
+.PP
+.RS
+
+.PP
+Single line of UsageText
+
+.RE
+
+.PP
+\fB\-\-sub\-command\-flag, \-s\fP: some usage text

--- a/testdata/expected-doc-full.md
+++ b/testdata/expected-doc-full.md
@@ -62,12 +62,16 @@ retrieve generic information
 
 standard usage text
 
-```
-Usage for the usage text
-- formatted:  Based on the specified ConfigMap and summon secrets.yml
-- list:       Inspect the environment for a specific process running on a Pod
-- for_effect: Compare 'namespace' environment with 'local'
-```
+    Usage for the usage text
+    - formatted:  Based on the specified ConfigMap and summon secrets.yml
+    - list:       Inspect the environment for a specific process running on a Pod
+    - for_effect: Compare 'namespace' environment with 'local'
+    
+    ```
+    func() { ... }
+    ```
+    
+    Should be a part of the same code block
 
 **--another-flag, -b**: another usage text
 

--- a/testdata/expected-doc-full.md
+++ b/testdata/expected-doc-full.md
@@ -58,3 +58,25 @@ retrieve generic information
 ## some-command
 
 
+## usage, u
+
+standard usage text
+
+```
+Usage for the usage text
+- formatted:  Based on the specified ConfigMap and summon secrets.yml
+- list:       Inspect the environment for a specific process running on a Pod
+- for_effect: Compare 'namespace' environment with 'local'
+```
+
+**--another-flag, -b**: another usage text
+
+**--flag, --fl, -f**="": 
+
+### sub-usage, su
+
+standard usage text
+
+>Single line of UsageText
+
+**--sub-command-flag, -s**: some usage text

--- a/testdata/expected-doc-no-authors.md
+++ b/testdata/expected-doc-no-authors.md
@@ -62,12 +62,16 @@ retrieve generic information
 
 standard usage text
 
-```
-Usage for the usage text
-- formatted:  Based on the specified ConfigMap and summon secrets.yml
-- list:       Inspect the environment for a specific process running on a Pod
-- for_effect: Compare 'namespace' environment with 'local'
-```
+    Usage for the usage text
+    - formatted:  Based on the specified ConfigMap and summon secrets.yml
+    - list:       Inspect the environment for a specific process running on a Pod
+    - for_effect: Compare 'namespace' environment with 'local'
+    
+    ```
+    func() { ... }
+    ```
+    
+    Should be a part of the same code block
 
 **--another-flag, -b**: another usage text
 

--- a/testdata/expected-doc-no-authors.md
+++ b/testdata/expected-doc-no-authors.md
@@ -58,3 +58,25 @@ retrieve generic information
 ## some-command
 
 
+## usage, u
+
+standard usage text
+
+```
+Usage for the usage text
+- formatted:  Based on the specified ConfigMap and summon secrets.yml
+- list:       Inspect the environment for a specific process running on a Pod
+- for_effect: Compare 'namespace' environment with 'local'
+```
+
+**--another-flag, -b**: another usage text
+
+**--flag, --fl, -f**="": 
+
+### sub-usage, su
+
+standard usage text
+
+>Single line of UsageText
+
+**--sub-command-flag, -s**: some usage text

--- a/testdata/expected-doc-no-flags.md
+++ b/testdata/expected-doc-no-flags.md
@@ -47,12 +47,16 @@ retrieve generic information
 
 standard usage text
 
-```
-Usage for the usage text
-- formatted:  Based on the specified ConfigMap and summon secrets.yml
-- list:       Inspect the environment for a specific process running on a Pod
-- for_effect: Compare 'namespace' environment with 'local'
-```
+    Usage for the usage text
+    - formatted:  Based on the specified ConfigMap and summon secrets.yml
+    - list:       Inspect the environment for a specific process running on a Pod
+    - for_effect: Compare 'namespace' environment with 'local'
+    
+    ```
+    func() { ... }
+    ```
+    
+    Should be a part of the same code block
 
 **--another-flag, -b**: another usage text
 

--- a/testdata/expected-doc-no-flags.md
+++ b/testdata/expected-doc-no-flags.md
@@ -43,3 +43,25 @@ retrieve generic information
 ## some-command
 
 
+## usage, u
+
+standard usage text
+
+```
+Usage for the usage text
+- formatted:  Based on the specified ConfigMap and summon secrets.yml
+- list:       Inspect the environment for a specific process running on a Pod
+- for_effect: Compare 'namespace' environment with 'local'
+```
+
+**--another-flag, -b**: another usage text
+
+**--flag, --fl, -f**="": 
+
+### sub-usage, su
+
+standard usage text
+
+>Single line of UsageText
+
+**--sub-command-flag, -s**: some usage text

--- a/testdata/expected-fish-full.fish
+++ b/testdata/expected-fish-full.fish
@@ -2,7 +2,7 @@
 
 function __fish_greet_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i config c sub-config s ss info i in some-command
+        if contains -- $i config c sub-config s ss info i in some-command usage u sub-usage su
             return 1
         end
     end
@@ -27,3 +27,10 @@ complete -c greet -n '__fish_seen_subcommand_from info i in' -f -l help -s h -d 
 complete -r -c greet -n '__fish_greet_no_subcommand' -a 'info i in' -d 'retrieve generic information'
 complete -c greet -n '__fish_seen_subcommand_from some-command' -f -l help -s h -d 'show help'
 complete -r -c greet -n '__fish_greet_no_subcommand' -a 'some-command'
+complete -c greet -n '__fish_seen_subcommand_from usage u' -f -l help -s h -d 'show help'
+complete -r -c greet -n '__fish_greet_no_subcommand' -a 'usage u' -d 'standard usage text'
+complete -c greet -n '__fish_seen_subcommand_from usage u' -l flag -s fl -s f -r
+complete -c greet -n '__fish_seen_subcommand_from usage u' -f -l another-flag -s b -d 'another usage text'
+complete -c greet -n '__fish_seen_subcommand_from sub-usage su' -f -l help -s h -d 'show help'
+complete -r -c greet -n '__fish_seen_subcommand_from usage u' -a 'sub-usage su' -d 'standard usage text'
+complete -c greet -n '__fish_seen_subcommand_from sub-usage su' -f -l sub-command-flag -s s -d 'some usage text'


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup  
- [x] documentation
- [X] feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

As a tools developer, I find the `UsageText` field to be useful in providing details on what a command does and how to use it. A good example is with [gwsm](https://github.com/GoodwayGroup/gwsm)

For example, the command `gwsm diff` has as detailed description that helps the user know how to use the command.
```
$ gwsm diff --help
NAME:
   gwsm diff - View diff of local vs. namespace

USAGE:

View the diff of the local environment against a given command running on a pod within a namespace.

This will retrieve the stored secrets within AWS Secrets Manager and map them via
the secrets.yml file used by the 'summon' CLI tool to generate the current state of
Environment Variables for a given stage.

The AWS Secrets Manager names are assumed to be stored as '<SECRETS_GROUP>_NAME'
in the ConfigMap. Example: 'RDS_SECRET_NAME: rds/staging/service-yolo'

From the root of the service, the required files are typically found below:

The path to the configmap.yaml file is within the kubernetes deployment.
This is typically .kube/<stage>/05-configmap.yaml

The path to the secrets.yml is typically .docker/secrets.yaml

It will then grab current environment for a specific process running within a Pod in a given Namespace.

This is achieved by inspecting the /proc/<PID>/environ for the given process. This method uses
'/bin/bash -c' as the base command to perform the PID inspection via 'ps faux'.

The 'filter-prefix' flag will exclude any values that start with the flagged prefixes from display.

The 'exclude' flag will exclude any values where the KEY matches exactly from display.


OPTIONS:
   --secrets value, -s value        Path to secrets.yml (default: ".docker/secrets.yml")
   --configmap value, -c value      Path to configmap.yaml
   --namespace value, -n value      Kube Namespace list Pods from
   --cmd value                      Command to inspect (default: "node")
   --filter-prefix value, -f value  List of prefixes (csv) used to filter values from display. Set to "" to remove any filters. (default: "npm_,KUBERNETES_,API_PORT")
   --exclude value                  List (csv) of specific env vars to exclude values from display. Set to "" to remove any exclusions. (default: "PATH,SHLVL,HOSTNAME")
   --secret-suffix value            Suffix used to find ENV variables that denote the Secret Manager Secrets to lookup (default: "_NAME")
   --help, -h                       show help (default: false)
```

I would like for the docs generation (`ToMarkdown` and `ToMan`) to include this help text in the docs.

See the before and after here:

| | before | after |
|---|---|---|
| markdown | https://gist.github.com/clok/ca1452874e372b02fe597f8ad65ca7f2 |  https://gist.github.com/clok/fe5e00c973575778f8e548263b5dba44 |
| man | https://gist.github.com/clok/4ad90b19868709c86612ff76ee0e1350 | https://gist.github.com/clok/a810114a454beee90d5134e9c8c533e8 |

## Which issue(s) this PR fixes:

_(REQUIRED)_
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->
N/A - New feature

## Testing

Updated a local copy of an existing tool ([gwsm](https://github.com/GoodwayGroup/gwsm)) with the delta applied and generated before/after docs.

See the before and after here:

| | before | after |
|---|---|---|
| markdown | https://gist.github.com/clok/ca1452874e372b02fe597f8ad65ca7f2 |  https://gist.github.com/clok/fe5e00c973575778f8e548263b5dba44 |
| man | https://gist.github.com/clok/4ad90b19868709c86612ff76ee0e1350 | https://gist.github.com/clok/a810114a454beee90d5134e9c8c533e8 |

- Updated test suite
- Generated local examples

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Add UsageText to docs output for markdown and man page generation
```
