### PR TITLE
Fix v1 aliases syntax in v2 docs

### DIFF
--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -425,14 +425,17 @@ import (
 func main() {
   app := &cli.App{
     Flags: []cli.Flag{
-      &cli.StringFlag{
-        Name:  "lang, l",
-        Value: "english",
-        Usage: "Language for the greeting",
-      },
-      &cli.StringFlag{
-        Name:  "config, c",
-        Usage: "Load configuration from `FILE`",
+        &cli.StringFlag{
+            Name:    "lang",
+            Aliases: []string{"l"},
+            Value:   "english",
+            Usage:   "Language for the greeting",
+        },
+        &cli.StringFlag{
+            Name:    "config",
+            Aliases: []string{"c"},
+            Usage:   "Load configuration from `FILE`",
+        },
       },
     },
     Commands: []*cli.Command{
@@ -570,7 +573,8 @@ func main() {
 
   app.Flags = []cli.Flag {
     &cli.StringFlag{
-      Name: "password, p",
+      Name: "password",
+      Aliases: []string{"p"},
       Usage: "password for the mysql database",
       FilePath: "/etc/mysql/password",
     },
@@ -1309,7 +1313,8 @@ import (
 
 func main() {
   cli.HelpFlag = &cli.BoolFlag{
-    Name: "haaaaalp", Aliases: []string{"halp"},
+    Name: "haaaaalp",
+    Aliases: []string{"halp"},
     Usage: "HALP",
     EnvVars: []string{"SHOW_HALP", "HALPPLZ"},
   }
@@ -1344,7 +1349,8 @@ import (
 
 func main() {
   cli.VersionFlag = &cli.BoolFlag{
-    Name: "print-version", Aliases: []string{"V"},
+    Name: "print-version",
+    Aliases: []string{"V"},
     Usage: "print only the version",
   }
 

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -436,7 +436,6 @@ func main() {
             Aliases: []string{"c"},
             Usage:   "Load configuration from `FILE`",
         },
-      },
     },
     Commands: []*cli.Command{
       {


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- [ ] bug
- [ ] cleanup  
- [x] documentation
- [ ] feature

## What this PR does / why we need it:

Fix issue with v1 type aliases syntax in v2 documentation that might cause confusion.

## Which issue(s) this PR fixes:

Fixes #1172 


