### PR TITLE
Added Metadata to the `Command` struct.

### DIFF
--- a/command.go
+++ b/command.go
@@ -61,6 +61,9 @@ type Command struct {
 	// cli.go uses text/template to render templates. You can
 	// render custom help text by setting this variable.
 	CustomHelpTemplate string
+
+	// Other custom info
+	Metadata map[string]interface{}
 }
 
 type Commands []*Command


### PR DESCRIPTION
Since App based metadata was already an option, it seemed like the correct way to add the same functionality to the Commands.

## What type of PR is this?

- [ ] bug
- [ ] cleanup  
- [ ] documentation
- [X] feature

## What this PR does / why we need it:

This PR attempts to add a per-command metadata system to give commands created throughout a codebase the ability to specify info that is used by the app as a whole but only relevant to their execution. For instance, a system that takes an arbitrary interface of type `Startable` that needs to be managed in the background by the application root while a long term command is running.

## Which issue(s) this PR fixes:

No current issue is open for this.

## Testing

No testing required as the Metadata field is not used by the cli library itself.

## Release Notes

```release-note
Adds Metadata field to the command struct.
```
