### PR TITLE
Added template functions for multi-line Description formatting.

### DIFF
--- a/help.go
+++ b/help.go
@@ -72,13 +72,13 @@ func ShowAppHelpAndExit(c *Context, exitCode int) {
 
 // ShowAppHelp is an action that displays the help.
 func ShowAppHelp(c *Context) error {
-	template := c.App.CustomAppHelpTemplate
-	if template == "" {
-		template = AppHelpTemplate
+	tpl := c.App.CustomAppHelpTemplate
+	if tpl == "" {
+		tpl = AppHelpTemplate
 	}
 
 	if c.App.ExtraInfo == nil {
-		HelpPrinter(c.App.Writer, template, c.App)
+		HelpPrinter(c.App.Writer, tpl, c.App)
 		return nil
 	}
 
@@ -87,7 +87,7 @@ func ShowAppHelp(c *Context) error {
 			"ExtraInfo": c.App.ExtraInfo,
 		}
 	}
-	HelpPrinterCustom(c.App.Writer, template, c.App, customAppData())
+	HelpPrinterCustom(c.App.Writer, tpl, c.App, customAppData())
 
 	return nil
 }
@@ -263,7 +263,10 @@ func ShowCommandCompletions(ctx *Context, command string) {
 // allow using arbitrary functions in template rendering.
 func printHelpCustom(out io.Writer, templ string, data interface{}, customFuncs map[string]interface{}) {
 	funcMap := template.FuncMap{
-		"join": strings.Join,
+		"join":    strings.Join,
+		"indent":  indent,
+		"nindent": nindent,
+		"trim":    strings.TrimSpace,
 	}
 	for key, value := range customFuncs {
 		funcMap[key] = value
@@ -365,4 +368,13 @@ func checkCommandCompletions(c *Context, name string) bool {
 
 	ShowCommandCompletions(c, name)
 	return true
+}
+
+func indent(spaces int, v string) string {
+	pad := strings.Repeat(" ", spaces)
+	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+}
+
+func nindent(spaces int, v string) string {
+	return "\n" + indent(spaces, v)
 }

--- a/help_test.go
+++ b/help_test.go
@@ -54,6 +54,22 @@ func Test_ShowAppHelp_HideVersion(t *testing.T) {
 	}
 }
 
+func Test_ShowAppHelp_MultiLineDescription(t *testing.T) {
+	output := new(bytes.Buffer)
+	app := &App{Writer: output}
+
+	app.HideVersion = true
+	app.Description = "multi\n  line"
+
+	c := NewContext(app, nil, nil)
+
+	_ = ShowAppHelp(c)
+
+	if !bytes.Contains(output.Bytes(), []byte("DESCRIPTION:\n   multi\n     line")) {
+		t.Errorf("expected\n%s\nto include\n%s", output.String(), "DESCRIPTION:\n   multi\n     line")
+	}
+}
+
 func Test_Help_Custom_Flags(t *testing.T) {
 	oldFlag := HelpFlag
 	defer func() {

--- a/template.go
+++ b/template.go
@@ -13,7 +13,7 @@ VERSION:
    {{.Version}}{{end}}{{end}}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}{{if len .Authors}}
+   {{.Description | nindent 3 | trim}}{{end}}{{if len .Authors}}
 
 AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
    {{range $index, $author := .Authors}}{{if $index}}
@@ -45,7 +45,7 @@ CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}{{if .VisibleFlags}}
+   {{.Description | nindent 3 | trim}}{{end}}{{if .VisibleFlags}}
 
 OPTIONS:
    {{range .VisibleFlags}}{{.}}
@@ -62,7 +62,7 @@ USAGE:
    {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}
+   {{.Description | nindent 3 | trim}}{{end}}
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
    {{.Name}}:{{range .VisibleCommands}}


### PR DESCRIPTION
Added functions to template system for consistent multi-line Description formatting.

## What type of PR is this?

- [ ] bug
- [ ] cleanup  
- [ ] documentation
- [X] feature

## What this PR does / why we need it:

Formatting for multi-line descriptions indents the first line of the description but none of the consecutive lines. This adds functions to the templating that adjusts multi-line printing to automatically add the 3 spaces to every line while maintaining the user defined spacing.

## Which issue(s) this PR fixes:

No current issue is open for this.

## Testing

Included a test to verify the expected output.

## Release Notes

```release-note
The default help text now indents all lines in a App and Command's Description field.
```
