### PR TITLE
bugfix: don't overwrite existing stringslice refence

### DIFF
--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -124,7 +124,9 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 	}
 
 	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
-		f.Value = &StringSlice{}
+		if f.Value == nil {
+			f.Value = &StringSlice{}
+		}
 		destination := f.Value
 		if f.Destination != nil {
 			destination = f.Destination

--- a/flag_test.go
+++ b/flag_test.go
@@ -386,6 +386,20 @@ func TestStringSliceFlagApply_SetsAllNames(t *testing.T) {
 	expect(t, err, nil)
 }
 
+func TestStringSliceFlagApply_UsesEnvValues(t *testing.T) {
+	defer resetEnv(os.Environ())
+	os.Clearenv()
+	_ = os.Setenv("MY_GOAT", "vincent van goat,scape goat")
+	var val StringSlice
+	fl := StringSliceFlag{Name: "goat", EnvVars: []string{"MY_GOAT"}, Value: &val}
+	set := flag.NewFlagSet("test", 0)
+	_ = fl.Apply(set)
+
+	err := set.Parse(nil)
+	expect(t, err, nil)
+	expect(t, val.Value(), NewStringSlice("vincent van goat", "scape goat").Value())
+}
+
 func TestStringSliceFlagApply_DefaultValueWithDestination(t *testing.T) {
 	defValue := []string{"UA", "US"}
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

fixes an issue where values set by environment var are not saved to
existing stringslice reference.

## Which issue(s) this PR fixes:

No issue was opened



## Testing

Included a small unit test

## Release Notes

_(REQUIRED)_

```release-note
fixed stringsliceflag apply logic to reuse existing value reference when ENV value is defined
```
