### PR TITLE
feat(help): add ShowSubcommandHelpAndExit

### DIFF
--- a/help.go
+++ b/help.go
@@ -214,6 +214,12 @@ func ShowCommandHelp(ctx *Context, command string) error {
 	return nil
 }
 
+// ShowSubcommandHelpAndExit - Prints help for the given subcommand and exits with exit code.
+func ShowSubcommandHelpAndExit(c *Context, exitCode int) {
+	_ = ShowSubcommandHelp(c)
+	os.Exit(exitCode)
+}
+
 // ShowSubcommandHelp prints help for the given subcommand
 func ShowSubcommandHelp(c *Context) error {
 	if c == nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup  
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

- Add ShowSubcommandHelpAndExit to help.go
- It is also useful like ShowCommandHelpAndExit and ShowAppHelpAndExit

## Which issue(s) this PR fixes:

Fixes #1112 

## Special notes for your reviewer:

I didn't find any test for XXXHelpAndExit.

## Testing

I prepared a sample program.

## Release Notes

```release-note
Added ShowSubcommandHelpAndExit to print help for the given subcommand and exit with exit code.
```
