### PR TITLE
Bump gopkg.in/yaml.v2 to v2.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.11
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.3
 )

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,5 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3 h1:fvjTMHxHEw/mxHbtzPi3JCcKXQRAnQTBRo6YCJSVHKI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
## What type of PR is this?

Bumps patch version to address `gopkg.in/yaml.v2` vulnerability making library susceptible to [billion laughs attack](https://en.wikipedia.org/wiki/Billion_laughs_attack#Variations)

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

- Upstream fix: https://github.com/go-yaml/yaml/commit/bb4e33bf68bf89cad44d386192cbed201f35b241
- related vendor bump for docker cli https://github.com/docker/cli/pull/2117
- GitLab Gemnasium advisory for details
https://gitlab.com/gitlab-org/security-products/gemnasium-db/-/blob/d769b9b5f0ae0c94bba8de1f67f19d6d0cfe630a/go/gopkg.in/yaml.v2/GMS-2019-2.yml 

I took a look through the yaml loader module and I do not think the library is high risk of this flaw due to the inherent risks of untrusted user input, but it should likely be bumped to at least the fixed patch version to mitigate. While I deemed it low-risk, my apologies for the full disclosure here if not preferred. I did not find a security disclosure policy or contribution docs, but it would be excellent if a policy could be documented as a side-effect to this pull request.

## Which issue(s) this PR fixes:

No open issue.

## Special notes for your reviewer:

I bumped to only the minimum version to address the existing vulnerability, but happy to go to the latest patch ([looks like `v.2.3.0`](https://github.com/go-yaml/yaml/tags)) if desired!

## Testing

go test passes but no additional test cases ran.

## Release Notes

```release-note
- Bump dependency `gopkg.in/yaml.v2` to patch `v2.2.3`
```
