### PR TITLE
#1193 Expose constructor of MapInputSource type

### DIFF
--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -16,6 +16,11 @@ type MapInputSource struct {
 	valueMap map[interface{}]interface{}
 }
 
+//NewMapInputSource create a new MapInputSource type
+func NewMapInputSource(file string, valueMap map[interface{}]interface{}) *MapInputSource {
+	return &MapInputSource{file: file, valueMap: valueMap}
+}
+
 // nestedVal checks if the name has '.' delimiters.
 // If so, it tries to traverse the tree by the '.' delimited sections to find
 // a nested value for the key.

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -16,7 +16,7 @@ type MapInputSource struct {
 	valueMap map[interface{}]interface{}
 }
 
-//NewMapInputSource create a new MapInputSource type
+// NewMapInputSource creates a new MapInputSource for implementing custom input sources.
 func NewMapInputSource(file string, valueMap map[interface{}]interface{}) *MapInputSource {
 	return &MapInputSource{file: file, valueMap: valueMap}
 }

--- a/altsrc/map_input_source_test.go
+++ b/altsrc/map_input_source_test.go
@@ -6,14 +6,13 @@ import (
 )
 
 func TestMapDuration(t *testing.T) {
-	inputSource := &MapInputSource{
-		file: "test",
-		valueMap: map[interface{}]interface{}{
+	inputSource := NewMapInputSource(
+		"test",
+		map[interface{}]interface{}{
 			"duration_of_duration_type": time.Minute,
 			"duration_of_string_type":   "1m",
 			"duration_of_int_type":      1000,
-		},
-	}
+		})
 	d, err := inputSource.Duration("duration_of_duration_type")
 	expect(t, time.Minute, d)
 	expect(t, nil, err)


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup  
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

Expose constructor of MapInputSource type

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

v2 feature: Expose constructor of MapInputSource type #1193
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Release Notes

This PR exposing the constructor of MapInputSource type. For instance, it possible to extend your type and don't implement all interface features.
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```example
type VaultInputSourceContext struct {
	altsrc.MapInputSource
}

func NewVaultInputSourceContext(vaultClient *api.Client, secretRoot string) altsrc.InputSourceContext {
	secret := vaultClient.Logical().Read(secretRoot)
	source := altsrc.NewMapInputSource("vault", secretToMap(secret))
	return &VaultInputSourceContext{*source}
}


```
