### PR TITLE
Support PathFlag.TakesFile in fish completion

### DIFF
--- a/fish.go
+++ b/fish.go
@@ -171,6 +171,10 @@ func fishAddFileFlag(flag Flag, completion *strings.Builder) {
 		if f.TakesFile {
 			return
 		}
+	case *PathFlag:
+		if f.TakesFile {
+			return
+		}
 	}
 	completion.WriteString(" -f")
 }

--- a/fish.go
+++ b/fish.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
 	"text/template"
 )
@@ -159,17 +158,24 @@ func (a *App) prepareFishFlags(flags []Flag, previousCommands []string) []string
 }
 
 func fishAddFileFlag(flag Flag, completion *strings.Builder) {
-	val := reflect.ValueOf(flag)
-	// if flag is a non-nil pointer to a struct...
-	if val.Kind() != reflect.Invalid && val.Elem().Kind() == reflect.Struct {
-		field := val.Elem().FieldByName("TakesFile")
-		// if flag's underlying type has a bool field called TakesFile, whose value is true...
-		if field.Kind() == reflect.Bool && field.Bool() {
-			// don't append '-f'
+	switch f := flag.(type) {
+	case *GenericFlag:
+		if f.TakesFile {
+			return
+		}
+	case *StringFlag:
+		if f.TakesFile {
+			return
+		}
+	case *StringSliceFlag:
+		if f.TakesFile {
+			return
+		}
+	case *PathFlag:
+		if f.TakesFile {
 			return
 		}
 	}
-	// append '-f', indicating that arguments to this flag are *not* meant to be file paths
 	completion.WriteString(" -f")
 }
 

--- a/fish.go
+++ b/fish.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"text/template"
 )
@@ -158,24 +159,17 @@ func (a *App) prepareFishFlags(flags []Flag, previousCommands []string) []string
 }
 
 func fishAddFileFlag(flag Flag, completion *strings.Builder) {
-	switch f := flag.(type) {
-	case *GenericFlag:
-		if f.TakesFile {
-			return
-		}
-	case *StringFlag:
-		if f.TakesFile {
-			return
-		}
-	case *StringSliceFlag:
-		if f.TakesFile {
-			return
-		}
-	case *PathFlag:
-		if f.TakesFile {
+	val := reflect.ValueOf(flag)
+	// if flag is a non-nil pointer to a struct...
+	if val.Kind() != reflect.Invalid && val.Elem().Kind() == reflect.Struct {
+		field := val.Elem().FieldByName("TakesFile")
+		// if flag's underlying type has a bool field called TakesFile, whose value is true...
+		if field.Kind() == reflect.Bool && field.Bool() {
+			// don't append '-f'
 			return
 		}
 	}
+	// append '-f', indicating that arguments to this flag are *not* meant to be file paths
 	completion.WriteString(" -f")
 }
 

--- a/fish_test.go
+++ b/fish_test.go
@@ -7,6 +7,10 @@ import (
 func TestFishCompletion(t *testing.T) {
 	// Given
 	app := testApp()
+	app.Flags = append(app.Flags, &PathFlag{
+		Name:      "logfile",
+		TakesFile: true,
+	})
 
 	// When
 	res, err := app.ToFishCompletion()

--- a/testdata/expected-fish-full.fish
+++ b/testdata/expected-fish-full.fish
@@ -12,6 +12,7 @@ end
 complete -c greet -n '__fish_greet_no_subcommand' -l socket -s s -r -d 'some \'usage\' text'
 complete -c greet -n '__fish_greet_no_subcommand' -f -l flag -s fl -s f -r
 complete -c greet -n '__fish_greet_no_subcommand' -f -l another-flag -s b -d 'another usage text'
+complete -c greet -n '__fish_greet_no_subcommand' -l logfile -r
 complete -c greet -n '__fish_greet_no_subcommand' -f -l help -s h -d 'show help'
 complete -c greet -n '__fish_greet_no_subcommand' -f -l version -s v -d 'print the version'
 complete -c greet -n '__fish_seen_subcommand_from config c' -f -l help -s h -d 'show help'


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Flags of type `PathFlag` weren't processed correctly when generating fish completions—the generated `complete` command told fish that the flag doesn't take a filename, even when `TakesFile` is true.

* `fish.go` now respects the `TakesFile` field, regardless of the flag's underlying type.
  * The first commit on this branch (5bb54ac) is a simpler solution to the original bug: it simply appends `PathFlag` to the list of explicit types in the switch statement. 
  * The second commit refactors the switch statement, using reflection rather than explicit list of types. It's more flexible, but possibly harder to follow. I added some comments to offset that caveat, but I won't complain if you prefer the simpler design.
* `fish_test.go` has a test case for a `PathFlag` with `TakesFile = true`.
* `expected-fish-full.fish` has a corresponding change in its fixture data.

## Which issue(s) this PR fixes:

Fixes #1156 

## Special notes for your reviewer:

@lynncyrin had suggested a lighter-weight form of reflection, but I wasn't able to make the type assertion work. AFAIK go's type system only deals in interfaces and specific, concrete types.

## Release Notes

```release-note
fish completion now respects TakesFile on PathFlags
```
