### PR TITLE
Add Support for Go 1.15

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.12, 1.13, 1.14]
+        go: [1.13, 1.14, 1.15]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,7 +39,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: GOFMT Check
-        if: matrix.go == 1.14 && matrix.os == 'ubuntu-latest'
+        if: matrix.go == 1.15 && matrix.os == 'ubuntu-latest'
         run: test -z $(gofmt -l .)
 
       - name: vet
@@ -62,10 +62,10 @@ jobs:
     name: test-docs
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.14
+      - name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
 
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -193,7 +193,7 @@ func checkBinarySizeActionFunc(c *cli.Context) (err error) {
 		cliBuiltFilePath     = "./internal/example-cli/built-example"
 		helloSourceFilePath  = "./internal/example-hello-world/example-hello-world.go"
 		helloBuiltFilePath   = "./internal/example-hello-world/built-example"
-		desiredMinBinarySize = 2.0
+		desiredMinBinarySize = 1.9
 		desiredMaxBinarySize = 2.1
 		badNewsEmoji         = "🚨"
 		goodNewsEmoji        = "✨"


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [x] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

This PR adds support for Go 1.15 and also drops support for Go 1.12 in line with Go's Release Policy https://golang.org/doc/devel/release.html#policy

## Release Notes


```release-note
Add support for Go 1.15
```
