### PR TITLE
use Name as default to HelpName

### DIFF
--- a/app.go
+++ b/app.go
@@ -140,7 +140,7 @@ func (a *App) Setup() {
 	}
 
 	if a.HelpName == "" {
-		a.HelpName = filepath.Base(os.Args[0])
+		a.HelpName = a.Name
 	}
 
 	if a.Usage == "" {


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- [x] bug
- [x] documentation

## What this PR does / why we need it:

doc says `App.HelpName` is `Full name of command for help, defaults to Name`
current behaviour is using `filepath.Base(os.Args[0])` instead
this PR makes code do what doc says

## Which issue(s) this PR fixes:

no issue yet

## Release Notes

```
use Name as default value for HelpName
```
