### PR TITLE
errors and diagnostics should go to ErrWriter

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -189,11 +189,9 @@ func ExampleApp_Run_commandHelp() {
 }
 
 func ExampleApp_Run_noAction() {
-	output := new(bytes.Buffer)
-	app := App{ErrWriter: output}
+	app := App{ErrWriter: os.Stdout}
 	app.Name = "greet"
 	_ = app.Run([]string{"greet"})
-	fmt.Println(output.String())
 	// Output:
 	// NAME:
 	//    greet - A new cli application

--- a/app_test.go
+++ b/app_test.go
@@ -1262,7 +1262,7 @@ func TestApp_SetStdin_Subcommand(t *testing.T) {
 	}
 }
 
-func TestApp_SetStdout(t *testing.T) {
+func TestApp_SetErrWriter(t *testing.T) {
 	var w bytes.Buffer
 
 	app := &App{

--- a/app_test.go
+++ b/app_test.go
@@ -756,24 +756,6 @@ func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
 	expect(t, err.Error(), "Cannot use two forms of the same flag: language lang")
 }
 
-func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {
-	a := App{
-		Name: "cmd",
-		Flags: []Flag{
-			&StringFlag{Name: "--foo"},
-		},
-		Writer: bytes.NewBufferString(""),
-	}
-
-	set := flag.NewFlagSet("", flag.ContinueOnError)
-	_ = set.Parse([]string{"", "---foo"})
-	c := &Context{flagSet: set}
-
-	err := a.RunAsSubcommand(c)
-
-	expect(t, err, errors.New("bad flag syntax: ---foo"))
-}
-
 func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {
 	var parsedOption string
 	var args Args

--- a/app_test.go
+++ b/app_test.go
@@ -193,7 +193,6 @@ func ExampleApp_Run_noAction() {
 	app := App{ErrWriter: output}
 	app.Name = "greet"
 	_ = app.Run([]string{"greet"})
-	fmt.Println(output.String())
 	// Output:
 	// NAME:
 	//    greet - A new cli application

--- a/app_test.go
+++ b/app_test.go
@@ -1244,8 +1244,8 @@ func TestApp_SetStdout(t *testing.T) {
 	var w bytes.Buffer
 
 	app := &App{
-		Name:   "test",
-		Writer: &w,
+		Name:      "test",
+		ErrWriter: &w,
 	}
 
 	err := app.Run([]string{"help"})
@@ -1254,8 +1254,8 @@ func TestApp_SetStdout(t *testing.T) {
 		t.Fatalf("Run error: %s", err)
 	}
 
-	if w.Len() != 0 {
-		t.Error("App wrote help screen to the wrong stream.")
+	if w.Len() == 0 {
+		t.Error("App did not write output to desired writer.")
 	}
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -193,6 +193,7 @@ func ExampleApp_Run_noAction() {
 	app := App{ErrWriter: output}
 	app.Name = "greet"
 	_ = app.Run([]string{"greet"})
+	fmt.Println(output.String())
 	// Output:
 	// NAME:
 	//    greet - A new cli application

--- a/command_test.go
+++ b/command_test.go
@@ -27,7 +27,7 @@ func TestCommandFlagParsing(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		app := &App{Writer: ioutil.Discard}
+		app := &App{Writer: ioutil.Discard, ErrWriter: ioutil.Discard}
 		set := flag.NewFlagSet("test", 0)
 		_ = set.Parse(c.testArgs)
 

--- a/docs/v2/examples/flags.md
+++ b/docs/v2/examples/flags.md
@@ -151,7 +151,7 @@ For example this:
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": "&#45;&#45;config FILE, &#45;c FILE"
+  "error": "&#45;&#45;config FILE, &#45;c FILE"
 } -->
 ```go
 package main
@@ -196,7 +196,7 @@ list for the `Name`. e.g.
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": "&#45;&#45;lang value, &#45;l value.*language for the greeting.*default: \"english\""
+  "error": "&#45;&#45;lang value, &#45;l value.*language for the greeting.*default: \"english\""
 } -->
 ```go
 package main
@@ -240,7 +240,7 @@ For example this:
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": ".*Load configuration from FILE\n.*Language for the greeting.*"
+  "error": ".*Load configuration from FILE\n.*Language for the greeting.*"
 } -->
 ```go
 package main
@@ -310,7 +310,7 @@ You can also have the default value set from the environment via `EnvVars`.  e.g
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": "language for the greeting.*APP_LANG"
+  "error": "language for the greeting.*APP_LANG"
 } -->
 ```go
 package main
@@ -346,7 +346,7 @@ resolves is used.
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": "language for the greeting.*LEGACY_COMPAT_LANG.*APP_LANG.*LANG"
+  "error": "language for the greeting.*LEGACY_COMPAT_LANG.*APP_LANG.*LANG"
 } -->
 ```go
 package main
@@ -383,7 +383,7 @@ You can also have the default value set from file via `FilePath`.  e.g.
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": "password for the mysql database"
+  "error": "password for the mysql database"
 } -->
 ```go
 package main
@@ -457,7 +457,7 @@ Here is a more complete sample of a command using YAML support:
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": "&#45&#45;test value.*default: 0"
+  "error": "&#45&#45;test value.*default: 0"
 } -->
 ```go
 package main
@@ -552,7 +552,7 @@ For example this:
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": "&#45;&#45;port value"
+  "error": "&#45;&#45;port value"
 } -->
 ```go
 package main

--- a/help.go
+++ b/help.go
@@ -210,36 +210,24 @@ func DefaultCompleteWithFlags(cmd *Command) func(cCtx *Context) {
 			lastArg := os.Args[len(os.Args)-2]
 
 			if strings.HasPrefix(lastArg, "-") {
-<<<<<<< HEAD
 				if cmd != nil {
-					printFlagSuggestions(lastArg, cmd.Flags, cCtx.App.Writer)
+					printFlagSuggestions(lastArg, cmd.Flags, cCtx.App.ErrWriter)
 
 					return
-=======
-				printFlagSuggestions(lastArg, c.App.Flags, c.App.ErrWriter)
-				if cmd != nil {
-					printFlagSuggestions(lastArg, cmd.Flags, c.App.ErrWriter)
->>>>>>> errors and diagnostics should go to ErrWriter
 				}
 
-				printFlagSuggestions(lastArg, cCtx.App.Flags, cCtx.App.Writer)
+				printFlagSuggestions(lastArg, cCtx.App.Flags, cCtx.App.ErrWriter)
 
 				return
 			}
 		}
 
 		if cmd != nil {
-<<<<<<< HEAD
-			printCommandSuggestions(cmd.Subcommands, cCtx.App.Writer)
+			printCommandSuggestions(cmd.Subcommands, cCtx.App.ErrWriter)
 			return
-=======
-			printCommandSuggestions(cmd.Subcommands, c.App.ErrWriter)
-		} else {
-			printCommandSuggestions(c.App.Commands, c.App.ErrWriter)
->>>>>>> errors and diagnostics should go to ErrWriter
 		}
 
-		printCommandSuggestions(cCtx.App.Commands, cCtx.App.Writer)
+		printCommandSuggestions(cCtx.App.Commands, cCtx.App.ErrWriter)
 	}
 }
 

--- a/help.go
+++ b/help.go
@@ -74,7 +74,7 @@ var helpCommand = &Command{
 			if templ == "" {
 				templ = CommandHelpTemplate
 			}
-			HelpPrinter(cCtx.App.Writer, templ, cCtx.Command)
+			HelpPrinter(cCtx.App.ErrWriter, templ, cCtx.Command)
 			return nil
 		}
 		return ShowSubcommandHelp(cCtx)
@@ -122,8 +122,8 @@ func ShowAppHelp(cCtx *Context) error {
 		tpl = AppHelpTemplate
 	}
 
-	if c.App.ExtraInfo == nil {
-		HelpPrinter(c.App.ErrWriter, tpl, c.App)
+	if cCtx.App.ExtraInfo == nil {
+		HelpPrinter(cCtx.App.ErrWriter, tpl, cCtx.App)
 		return nil
 	}
 
@@ -293,7 +293,7 @@ func ShowSubcommandHelp(cCtx *Context) error {
 		return nil
 	}
 
-	HelpPrinter(cCtx.App.Writer, SubcommandHelpTemplate, cCtx.Command)
+	HelpPrinter(cCtx.App.ErrWriter, SubcommandHelpTemplate, cCtx.Command)
 	return nil
 }
 

--- a/help.go
+++ b/help.go
@@ -122,8 +122,8 @@ func ShowAppHelp(cCtx *Context) error {
 		tpl = AppHelpTemplate
 	}
 
-	if cCtx.App.ExtraInfo == nil {
-		HelpPrinter(cCtx.App.Writer, tpl, cCtx.App)
+	if c.App.ExtraInfo == nil {
+		HelpPrinter(c.App.ErrWriter, tpl, c.App)
 		return nil
 	}
 
@@ -132,7 +132,7 @@ func ShowAppHelp(cCtx *Context) error {
 			"ExtraInfo": cCtx.App.ExtraInfo,
 		}
 	}
-	HelpPrinterCustom(cCtx.App.Writer, tpl, cCtx.App, customAppData())
+	HelpPrinterCustom(cCtx.App.ErrWriter, tpl, cCtx.App, customAppData())
 
 	return nil
 }
@@ -210,10 +210,16 @@ func DefaultCompleteWithFlags(cmd *Command) func(cCtx *Context) {
 			lastArg := os.Args[len(os.Args)-2]
 
 			if strings.HasPrefix(lastArg, "-") {
+<<<<<<< HEAD
 				if cmd != nil {
 					printFlagSuggestions(lastArg, cmd.Flags, cCtx.App.Writer)
 
 					return
+=======
+				printFlagSuggestions(lastArg, c.App.Flags, c.App.ErrWriter)
+				if cmd != nil {
+					printFlagSuggestions(lastArg, cmd.Flags, c.App.ErrWriter)
+>>>>>>> errors and diagnostics should go to ErrWriter
 				}
 
 				printFlagSuggestions(lastArg, cCtx.App.Flags, cCtx.App.Writer)
@@ -223,8 +229,14 @@ func DefaultCompleteWithFlags(cmd *Command) func(cCtx *Context) {
 		}
 
 		if cmd != nil {
+<<<<<<< HEAD
 			printCommandSuggestions(cmd.Subcommands, cCtx.App.Writer)
 			return
+=======
+			printCommandSuggestions(cmd.Subcommands, c.App.ErrWriter)
+		} else {
+			printCommandSuggestions(c.App.Commands, c.App.ErrWriter)
+>>>>>>> errors and diagnostics should go to ErrWriter
 		}
 
 		printCommandSuggestions(cCtx.App.Commands, cCtx.App.Writer)
@@ -261,7 +273,7 @@ func ShowCommandHelp(ctx *Context, command string) error {
 				}
 			}
 
-			HelpPrinter(ctx.App.Writer, templ, c)
+			HelpPrinter(ctx.App.ErrWriter, templ, c)
 
 			return nil
 		}
@@ -303,7 +315,7 @@ func ShowVersion(cCtx *Context) {
 }
 
 func printVersion(cCtx *Context) {
-	_, _ = fmt.Fprintf(cCtx.App.Writer, "%v version %v\n", cCtx.App.Name, cCtx.App.Version)
+	_, _ = fmt.Fprintf(cCtx.App.ErrWriter, "%v version %v\n", cCtx.App.Name, cCtx.App.Version)
 }
 
 // ShowCompletions prints the lists of commands within a given context

--- a/help_test.go
+++ b/help_test.go
@@ -471,7 +471,7 @@ func TestHelpNameConsistency(t *testing.T) {
 
 	for _, tt := range tests {
 		output := &bytes.Buffer{}
-		app.Writer = output
+		app.ErrWriter = output
 		if err := app.Run(tt.args); err != nil {
 			t.Error(err)
 		}
@@ -579,7 +579,7 @@ UsageText`,
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 
 	_ = app.Run([]string{"foo", "frobbly", "--help"})
 
@@ -638,7 +638,7 @@ UsageText`,
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"foo", "frobbly", "bobbly", "--help"})
 
 	expected := `USAGE:
@@ -909,7 +909,7 @@ func TestShowAppHelp_UsageText(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 
 	_ = app.Run([]string{"foo"})
 
@@ -932,7 +932,7 @@ App UsageText`,
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 
 	_ = app.Run([]string{"foo"})
 
@@ -969,7 +969,7 @@ App UsageText`,
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 
 	_ = app.Run([]string{"foo"})
 
@@ -1199,7 +1199,7 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 	} {
 		t.Run(tc.name, func(ct *testing.T) {
 			writer := &bytes.Buffer{}
-			tc.c.App.Writer = writer
+			tc.c.App.ErrWriter = writer
 
 			os.Args = tc.argv
 			f := DefaultCompleteWithFlags(tc.cmd)
@@ -1230,7 +1230,7 @@ func TestWrappedHelp(t *testing.T) {
 
 	output := new(bytes.Buffer)
 	app := &App{
-		Writer: output,
+		ErrWriter: output,
 		Flags: []Flag{
 			&BoolFlag{Name: "foo",
 				Aliases: []string{"h"},
@@ -1324,7 +1324,7 @@ func TestWrappedCommandHelp(t *testing.T) {
 
 	output := new(bytes.Buffer)
 	app := &App{
-		Writer: output,
+		ErrWriter: output,
 		Commands: []*Command{
 			{
 				Name:        "add",
@@ -1386,8 +1386,8 @@ func TestWrappedSubcommandHelp(t *testing.T) {
 
 	output := new(bytes.Buffer)
 	app := &App{
-		Name:   "cli.test",
-		Writer: output,
+		Name:      "cli.test",
+		ErrWriter: output,
 		Commands: []*Command{
 			{
 				Name:        "bar",
@@ -1456,8 +1456,8 @@ func TestWrappedHelpSubcommand(t *testing.T) {
 
 	output := new(bytes.Buffer)
 	app := &App{
-		Name:   "cli.test",
-		Writer: output,
+		Name:      "cli.test",
+		ErrWriter: output,
 		Commands: []*Command{
 			{
 				Name:        "bar",

--- a/help_test.go
+++ b/help_test.go
@@ -14,7 +14,7 @@ import (
 
 func Test_ShowAppHelp_NoAuthor(t *testing.T) {
 	output := new(bytes.Buffer)
-	app := &App{Writer: output}
+	app := &App{ErrWriter: output}
 
 	c := NewContext(app, nil, nil)
 
@@ -27,7 +27,7 @@ func Test_ShowAppHelp_NoAuthor(t *testing.T) {
 
 func Test_ShowAppHelp_NoVersion(t *testing.T) {
 	output := new(bytes.Buffer)
-	app := &App{Writer: output}
+	app := &App{ErrWriter: output}
 
 	app.Version = ""
 
@@ -42,7 +42,7 @@ func Test_ShowAppHelp_NoVersion(t *testing.T) {
 
 func Test_ShowAppHelp_HideVersion(t *testing.T) {
 	output := new(bytes.Buffer)
-	app := &App{Writer: output}
+	app := &App{ErrWriter: output}
 
 	app.HideVersion = true
 
@@ -57,7 +57,7 @@ func Test_ShowAppHelp_HideVersion(t *testing.T) {
 
 func Test_ShowAppHelp_MultiLineDescription(t *testing.T) {
 	output := new(bytes.Buffer)
-	app := &App{Writer: output}
+	app := &App{ErrWriter: output}
 
 	app.HideVersion = true
 	app.Description = "multi\n  line"
@@ -95,7 +95,7 @@ func Test_Help_Custom_Flags(t *testing.T) {
 		},
 	}
 	output := new(bytes.Buffer)
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"test", "-h"})
 	if output.Len() > 0 {
 		t.Errorf("unexpected output: %s", output.String())
@@ -126,7 +126,7 @@ func Test_Version_Custom_Flags(t *testing.T) {
 		},
 	}
 	output := new(bytes.Buffer)
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"test", "-v"})
 	if output.Len() > 0 {
 		t.Errorf("unexpected output: %s", output.String())
@@ -164,7 +164,7 @@ func Test_helpCommand_Action_ErrorIfNoTopic(t *testing.T) {
 func Test_helpCommand_InHelpOutput(t *testing.T) {
 	app := &App{}
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"test", "--help"})
 
 	s := output.String()
@@ -220,7 +220,7 @@ func TestShowAppHelp_CommandAliases(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"foo", "--help"})
 
 	if !strings.Contains(output.String(), "frobbly, fr, frob") {
@@ -290,8 +290,8 @@ func TestShowCommandHelp_HelpPrinter(t *testing.T) {
 
 			var buf bytes.Buffer
 			app := &App{
-				Name:   "my-app",
-				Writer: &buf,
+				Name:      "my-app",
+				ErrWriter: &buf,
 				Commands: []*Command{
 					{
 						Name:               "my-command",
@@ -379,8 +379,9 @@ func TestShowCommandHelp_HelpPrinterCustom(t *testing.T) {
 
 			var buf bytes.Buffer
 			app := &App{
-				Name:   "my-app",
-				Writer: &buf,
+				Name:      "my-app",
+				Writer:    &buf,
+				ErrWriter: &buf,
 				Commands: []*Command{
 					{
 						Name:               "my-command",
@@ -416,7 +417,7 @@ func TestShowCommandHelp_CommandAliases(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"foo", "help", "fr"})
 
 	if !strings.Contains(output.String(), "frobbly") {
@@ -494,7 +495,7 @@ func TestShowSubcommandHelp_CommandAliases(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"foo", "help"})
 
 	if !strings.Contains(output.String(), "frobbly, fr, frob, bork") {
@@ -528,7 +529,7 @@ EXAMPLES:
 		},
 	}
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"foo", "help", "frobbly"})
 
 	if strings.Contains(output.String(), "2. Frobbly runs without this param locally.") {
@@ -555,7 +556,7 @@ func TestShowSubcommandHelp_CommandUsageText(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 
 	_ = app.Run([]string{"foo", "frobbly", "--help"})
 
@@ -610,7 +611,7 @@ func TestShowSubcommandHelp_SubcommandUsageText(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"foo", "frobbly", "bobbly", "--help"})
 
 	if !strings.Contains(output.String(), "this is usage text") {
@@ -672,7 +673,7 @@ func TestShowAppHelp_HiddenCommand(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"app", "--help"})
 
 	if strings.Contains(output.String(), "secretfrob") {
@@ -734,7 +735,7 @@ func TestShowAppHelp_HelpPrinter(t *testing.T) {
 			var buf bytes.Buffer
 			app := &App{
 				Name:                  "my-app",
-				Writer:                &buf,
+				ErrWriter:             &buf,
 				CustomAppHelpTemplate: tt.template,
 			}
 
@@ -805,7 +806,7 @@ func TestShowAppHelp_HelpPrinterCustom(t *testing.T) {
 			var buf bytes.Buffer
 			app := &App{
 				Name:                  "my-app",
-				Writer:                &buf,
+				ErrWriter:             &buf,
 				CustomAppHelpTemplate: tt.template,
 			}
 
@@ -868,7 +869,7 @@ VERSION:
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.ErrWriter = output
 	_ = app.Run([]string{"app", "--help"})
 
 	if strings.Contains(output.String(), "secretfrob") {
@@ -986,7 +987,7 @@ App UsageText`,
 func TestHideHelpCommand(t *testing.T) {
 	app := &App{
 		HideHelpCommand: true,
-		Writer:          ioutil.Discard,
+		ErrWriter:       ioutil.Discard,
 	}
 
 	err := app.Run([]string{"foo", "help"})
@@ -1006,7 +1007,7 @@ func TestHideHelpCommand(t *testing.T) {
 func TestHideHelpCommand_False(t *testing.T) {
 	app := &App{
 		HideHelpCommand: false,
-		Writer:          ioutil.Discard,
+		ErrWriter:       ioutil.Discard,
 	}
 
 	err := app.Run([]string{"foo", "help"})
@@ -1024,7 +1025,7 @@ func TestHideHelpCommand_WithHideHelp(t *testing.T) {
 	app := &App{
 		HideHelp:        true, // effective (hides both command and flag)
 		HideHelpCommand: true, // ignored
-		Writer:          ioutil.Discard,
+		ErrWriter:       ioutil.Discard,
 	}
 
 	err := app.Run([]string{"foo", "help"})
@@ -1053,7 +1054,7 @@ func newContextFromStringSlice(ss []string) *Context {
 func TestHideHelpCommand_RunAsSubcommand(t *testing.T) {
 	app := &App{
 		HideHelpCommand: true,
-		Writer:          ioutil.Discard,
+		ErrWriter:       ioutil.Discard,
 		Commands: []*Command{
 			{
 				Name: "dummy",
@@ -1078,7 +1079,7 @@ func TestHideHelpCommand_RunAsSubcommand(t *testing.T) {
 func TestHideHelpCommand_RunAsSubcommand_False(t *testing.T) {
 	app := &App{
 		HideHelpCommand: false,
-		Writer:          ioutil.Discard,
+		ErrWriter:       ioutil.Discard,
 		Commands: []*Command{
 			{
 				Name: "dummy",
@@ -1099,7 +1100,7 @@ func TestHideHelpCommand_RunAsSubcommand_False(t *testing.T) {
 
 func TestHideHelpCommand_WithSubcommands(t *testing.T) {
 	app := &App{
-		Writer: ioutil.Discard,
+		ErrWriter: ioutil.Discard,
 		Commands: []*Command{
 			{
 				Name: "dummy",

--- a/suggestions_test.go
+++ b/suggestions_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 )
 
@@ -123,6 +124,7 @@ func TestSuggestCommand(t *testing.T) {
 func ExampleApp_Suggest() {
 	app := &App{
 		Name:                  "greet",
+		ErrWriter:             os.Stdout,
 		Suggest:               true,
 		HideHelp:              false,
 		HideHelpCommand:       true,
@@ -148,6 +150,7 @@ func ExampleApp_Suggest() {
 func ExampleApp_Suggest_command() {
 	app := &App{
 		Name:                  "greet",
+		ErrWriter:             os.Stdout,
 		Suggest:               true,
 		HideHelpCommand:       true,
 		CustomAppHelpTemplate: "(this space intentionally left blank)\n",


### PR DESCRIPTION
As per POSIX's recommendations, diagnostics and error
messages should always be printed to the /dev/stderr.

Forked from https://github.com/urfave/cli/pull/1203

## What type of PR is this?

- bug

## What this PR does / why we need it:

- Errors and diagnostics should always go the defined ErrorWriter (default: stderr), not stdout.
