### PR TITLE
Fix Context.Value.

### DIFF
--- a/context.go
+++ b/context.go
@@ -108,7 +108,10 @@ func (c *Context) Lineage() []*Context {
 
 // Value returns the value of the flag corresponding to `name`
 func (c *Context) Value(name string) interface{} {
-	return c.flagSet.Lookup(name).Value.(flag.Getter).Get()
+	if fs := lookupFlagSet(name, c); fs != nil {
+		return fs.Lookup(name).Value.(flag.Getter).Get()
+	}
+	return nil
 }
 
 // Args returns the command line arguments associated with the context.

--- a/context_test.go
+++ b/context_test.go
@@ -136,6 +136,17 @@ func TestContext_Bool(t *testing.T) {
 	expect(t, c.Bool("top-flag"), true)
 }
 
+func TestContext_Value(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int("myflag", 12, "doc")
+	parentSet := flag.NewFlagSet("test", 0)
+	parentSet.Int("top-flag", 13, "doc")
+	parentCtx := NewContext(nil, parentSet, nil)
+	c := NewContext(nil, set, parentCtx)
+	expect(t, c.Value("myflag"), 12)
+	expect(t, c.Value("top-flag"), 13)
+}
+
 func TestContext_Args(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("myflag", false, "doc")

--- a/context_test.go
+++ b/context_test.go
@@ -145,6 +145,7 @@ func TestContext_Value(t *testing.T) {
 	c := NewContext(nil, set, parentCtx)
 	expect(t, c.Value("myflag"), 12)
 	expect(t, c.Value("top-flag"), 13)
+	expect(t, c.Value("unknown-flag"), nil)
 }
 
 func TestContext_Args(t *testing.T) {


### PR DESCRIPTION
Fix Context.Value so that it looks across all fileSets when looking for the named flag.

## What type of PR is this?

_(REQUIRED)_

- [ x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

Before this change the added test would crash on a nil
pointer dereference because the original code would
only look in the local fileSet and not across all
the fileSets.

## Which issue(s) this PR fixes:

_(REQUIRED)_

NONE

## Testing

Added a test for Value, it currently had no test in context_test.go.
Without this change the test will crash.

## Release Notes

_(REQUIRED)_

```release-note
Fix crash in Context.Value when looking for a flag that exists in a parent context.
```
