### PR TITLE
Fix workflows/cli.yml.

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -11,7 +11,6 @@ on:
       - v1
 
 jobs:
-
   test:
     strategy:
       matrix:
@@ -27,10 +26,10 @@ jobs:
 
       - name: Set GOPATH, PATH and ENV
         run: |
-          echo "::set-env name=GOPATH::$(dirname $GITHUB_WORKSPACE)"
-          echo "::set-env name=GO111MODULE::on"
-          echo "::set-env name=GOPROXY::https://proxy.golang.org"
-          echo "::add-path::$(dirname $GITHUB_WORKSPACE)/bin"
+          echo "GOPATH=$(dirname $GITHUB_WORKSPACE)" >> $GITHUB_ENV
+          echo "GO111MODULE=on" >> $GITHUB_ENV
+          echo "GOPROXY=https://proxy.golang.org" >> $GITHUB_ENV
+          echo "$(dirname $GITHUB_WORKSPACE)/bin" >> $GITHUB_PATH
         shell: bash
 
       - name: Checkout Code
@@ -74,10 +73,10 @@ jobs:
 
       - name: Set GOPATH, PATH and ENV
         run: |
-          echo "::set-env name=GOPATH::$(dirname $GITHUB_WORKSPACE)"
-          echo "::set-env name=GO111MODULE::on"
-          echo "::set-env name=GOPROXY::https://proxy.golang.org"
-          echo "::add-path::$(dirname $GITHUB_WORKSPACE)/bin"
+          echo "GOPATH=$(dirname $GITHUB_WORKSPACE)" >> $GITHUB_ENV
+          echo "GO111MODULE=on" >> $GITHUB_ENV
+          echo "GOPROXY=https://proxy.golang.org" >> $GITHUB_ENV
+          echo "$(dirname $GITHUB_WORKSPACE)/bin" >> $GITHUB_PATH
         shell: bash
 
       - name: Checkout Code


### PR DESCRIPTION
The ::set-env and ::add-path commands no longer work and need to
to be replaced. See:

    https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## What type of PR is this?

_(REQUIRED)_

- [ x ] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

PR checks currently don't run, this will fix that.

## Which issue(s) this PR fixes:

_(REQUIRED)_

NONE

## Release Notes

_(REQUIRED)_

```release-note
NONE
```
