### PR TITLE
Another approach for zsh completion

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -356,7 +356,7 @@ func ExampleApp_Run_bashComplete() {
 func ExampleApp_Run_zshComplete() {
 	// set args for examples sake
 	os.Args = []string{"greet", "--generate-bash-completion"}
-	_ = os.Setenv("_CLI_ZSH_AUTOCOMPLETE_HACK", "1")
+	_ = os.Setenv("SHELL", "/usr/bin/zsh")
 
 	app := NewApp()
 	app.Name = "greet"

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -4,9 +4,9 @@ local -a opts
 local cur
 cur=${words[-1]}
 if [[ "$cur" == "-"* ]]; then
-  opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+  opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
 else
-  opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+  opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-bash-completion)}")
 fi
 
 if [[ "${opts[1]}" != "" ]]; then

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,23 +1,16 @@
 #compdef $PROG
 
-_cli_zsh_autocomplete() {
+local -a opts
+local cur
+cur=${words[-1]}
+if [[ "$cur" == "-"* ]]; then
+  opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+else
+  opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+fi
 
-  local -a opts
-  local cur
-  cur=${words[-1]}
-  if [[ "$cur" == "-"* ]]; then
-    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
-  else
-    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
-  fi
-
-  if [[ "${opts[1]}" != "" ]]; then
-    _describe 'values' opts
-  else
-    _files
-  fi
-
-  return
-}
-
-compdef _cli_zsh_autocomplete $PROG
+if [[ "${opts[1]}" != "" ]]; then
+  _describe 'values' opts
+else
+  _files
+fi

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -1211,14 +1211,13 @@ func main() {
 
 #### ZSH Support
 Auto-completion for ZSH is also supported using the `autocomplete/zsh_autocomplete` 
-file included in this repo. Two environment variables are used, `PROG` and `_CLI_ZSH_AUTOCOMPLETE_HACK`. 
-Set `PROG` to the program name as before, set `_CLI_ZSH_AUTOCOMPLETE_HACK` to `1`, and 
-then `source path/to/autocomplete/zsh_autocomplete`. Adding the following lines to your ZSH 
-configuration file (usually `.zshrc`) will allow the auto-completion to persist across new shells:
+file included in this repo. One environment variable is used, `PROG`.  Set 
+`PROG` to the program name as before, and then `source path/to/autocomplete/zsh_autocomplete`. 
+Adding the following lines to your ZSH configuration file (usually `.zshrc`) 
+will allow the auto-completion to persist across new shells:
 
 ```
 PROG=<myprogram>
-_CLI_ZSH_AUTOCOMPLETE_HACK=1
 source  path/to/autocomplete/zsh_autocomplete
 ```
 #### ZSH default auto-complete example

--- a/help.go
+++ b/help.go
@@ -102,7 +102,7 @@ func printCommandSuggestions(commands []*Command, writer io.Writer) {
 		if command.Hidden {
 			continue
 		}
-		if os.Getenv("_CLI_ZSH_AUTOCOMPLETE_HACK") == "1" {
+		if strings.Contains(os.Getenv("SHELL"), "zsh") {
 			for _, name := range command.Names() {
 				_, _ = fmt.Fprintf(writer, "%s:%s\n", name, command.Usage)
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup  
- [x] documentation
- [x] feature

## What this PR does / why we need it:

I want to open discussion how this project provides completion for zsh. Current situation isn't right and promotes [cargo-cult approach](https://medium.com/@jzelinskie/please-dont-ship-binaries-with-shell-completion-as-commands-a8b1bcb8a0d0) to enable zsh completions.

Completion file shouldn't be sourced. It should provide only completion code (source of `_command` function) for `command`. Ideally this file should be just template/example, where developer should replace `$PROG` with name of binary and distribute it with `_command` name somewhere under project's contrib folder (alongside with man pages, vim syntax etc). As go build system isn't able to properly install this kind of stuff, it's up to package manager (homebrew, dpkg etc) to pick up this `_command` file and put it under correct `$fpath` where zsh can autoload it.

Currently this PR changes only zsh completion example. The documentation needs to be updated too. I can look into if there is agreement with current proposal.

## Special notes for your reviewer:

There is fundamental problem with this project calling "completions" as "_auto_-completions", which are different terms. See https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html and http://zsh.sourceforge.net/Doc/Release/Completion-System.html for correct terminology. You might want to fix this in future. 