### PR TITLE
chore(ci): include upcoming Go 1.16 release build matrix

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -15,13 +15,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.13, 1.14, 1.15]
+        go: [1.13, 1.14, 1.15, 1.16.0-beta1]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
+          # allow to run against pre-releases
+          stable: false 
           go-version: ${{ matrix.go }}
 
       - name: Set GOPATH, PATH and ENV

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -193,7 +193,7 @@ func checkBinarySizeActionFunc(c *cli.Context) (err error) {
 		cliBuiltFilePath     = "./internal/example-cli/built-example"
 		helloSourceFilePath  = "./internal/example-hello-world/example-hello-world.go"
 		helloBuiltFilePath   = "./internal/example-hello-world/built-example"
-		desiredMinBinarySize = 1.9
+		desiredMinBinarySize = 1.8
 		desiredMaxBinarySize = 2.1
 		badNewsEmoji         = "🚨"
 		goodNewsEmoji        = "✨"


### PR DESCRIPTION
Go 1.16 beta1 is released not too long ago and we should also build against it in the ci pipeline.