### PR TITLE
fix: Propagate App.Reader to subcommands

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -897,6 +897,39 @@ func TestApp_SetStdin(t *testing.T) {
 	}
 }
 
+func TestApp_SetStdin_Subcommand(t *testing.T) {
+	buf := make([]byte, 12)
+
+	app := &App{
+		Name:   "test",
+		Reader: strings.NewReader("Hello World!"),
+		Commands: []*Command{
+			{
+				Name: "command",
+				Subcommands: []*Command{
+					{
+						Name: "subcommand",
+						Action: func(c *Context) error {
+							_, err := c.App.Reader.Read(buf)
+							return err
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := app.Run([]string{"test", "command", "subcommand"})
+
+	if err != nil {
+		t.Fatalf("Run error: %s", err)
+	}
+
+	if string(buf) != "Hello World!" {
+		t.Error("App did not read input from desired reader.")
+	}
+}
+
 func TestApp_SetStdout(t *testing.T) {
 	var w bytes.Buffer
 

--- a/command.go
+++ b/command.go
@@ -243,6 +243,7 @@ func (c *Command) startApp(ctx *Context) error {
 	app.Version = ctx.App.Version
 	app.HideVersion = true
 	app.Compiled = ctx.App.Compiled
+	app.Reader = ctx.App.Reader
 	app.Writer = ctx.App.Writer
 	app.ErrWriter = ctx.App.ErrWriter
 	app.ExitErrHandler = ctx.App.ExitErrHandler


### PR DESCRIPTION


<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

This change copies the `Reader` set in `App` to the new `App` created for subcommands. This allows tests for subcommands to inject a reader, similar to first level commands. Previously, the reader for subcommands was reset to `Stdin`. I added a basic test to demonstrate the issue.

## Which issue(s) this PR fixes:

_(REQUIRED)_

No issue yet

## Testing

I added a test case that acts as a regression test.

## Release Notes

_(REQUIRED)_

```release-note
Propagate App.Reader to subcommands
```
