### PR TITLE
make the man page section selectable

### DIFF
--- a/docs_test.go
+++ b/docs_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"testing"
 )
@@ -142,6 +143,33 @@ func TestToMan(t *testing.T) {
 
 	// When
 	res, err := app.ToMan()
+
+	// Then
+	expect(t, err, nil)
+	expectFileContent(t, "testdata/expected-doc-full.man", res)
+}
+
+func TestToManParseError(t *testing.T) {
+	// Given
+	app := testApp()
+
+	// When
+	// temporarily change the global variable for testing
+	tmp := MarkdownDocTemplate
+	MarkdownDocTemplate = `{{ .App.Name`
+	_, err := app.ToMan()
+	MarkdownDocTemplate = tmp
+
+	// Then
+	expect(t, err, errors.New(`template: cli:1: unclosed action`))
+}
+
+func TestToManWithSection(t *testing.T) {
+	// Given
+	app := testApp()
+
+	// When
+	res, err := app.ToManWithSection(8)
 
 	// Then
 	expect(t, err, nil)

--- a/template.go
+++ b/template.go
@@ -74,7 +74,7 @@ OPTIONS:
    {{end}}{{end}}
 `
 
-var MarkdownDocTemplate = `% {{ .App.Name }} 8
+var MarkdownDocTemplate = `% {{ .App.Name }} {{ .SectionNum }}
 
 # NAME
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup  
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

The section number of the man page is fixed to 8.
This number can take other values depending on the usage.

https://www.man7.org/linux/man-pages/man7/man-pages.7.html

This fix adds a new argument to the `ToMarkdown` and `ToMan` methods so that they can be set to arbitrary values.
If you prefer other implementation, please let me know.


## Testing

Existing test code has been reused.

## Release Notes

```release-note
adds a new argument to the `ToMarkdown` and `ToMan` methods so that they can be set to arbitrary section number.
```
