### PR TITLE
fix #1239: slice flag value don't append to default values from ENV or file

### DIFF
--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -129,6 +129,9 @@ func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error {
 				}
 			}
 
+			// Set this to false so that we reset the slice if we then set values from
+			// flags that have already been set by the environment.
+			f.Value.hasBeenSet = false
 			f.HasBeenSet = true
 		}
 	}

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -129,6 +129,9 @@ func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error {
 			}
 		}
 
+		// Set this to false so that we reset the slice if we then set values from
+		// flags that have already been set by the environment.
+		f.Value.hasBeenSet = false
 		f.HasBeenSet = true
 	}
 

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -140,6 +140,9 @@ func (f *IntSliceFlag) Apply(set *flag.FlagSet) error {
 			}
 		}
 
+		// Set this to false so that we reset the slice if we then set values from
+		// flags that have already been set by the environment.
+		f.Value.hasBeenSet = false
 		f.HasBeenSet = true
 	}
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -152,7 +152,6 @@ func TestFlagsFromEnv(t *testing.T) {
 				t.Errorf("expected error to match %q, got none", test.errRegexp)
 			} else {
 				if matched, _ := regexp.MatchString(test.errRegexp, err.Error()); !matched {
-					fmt.Printf("%s\n%s\n", test.errRegexp, err.Error())
 					t.Errorf("expected error to match %q, got error %s", test.errRegexp, err)
 				}
 			}

--- a/flag_test.go
+++ b/flag_test.go
@@ -52,15 +52,21 @@ func TestBoolFlagApply_SetsAllNames(t *testing.T) {
 }
 
 func TestFlagsFromEnv(t *testing.T) {
+	newSetFloat64Slice := func(defaults ...float64) Float64Slice {
+		s := NewFloat64Slice(defaults...)
+		s.hasBeenSet = false
+		return *s
+	}
+
 	newSetIntSlice := func(defaults ...int) IntSlice {
 		s := NewIntSlice(defaults...)
-		s.hasBeenSet = true
+		s.hasBeenSet = false
 		return *s
 	}
 
 	newSetInt64Slice := func(defaults ...int64) Int64Slice {
 		s := NewInt64Slice(defaults...)
-		s.hasBeenSet = true
+		s.hasBeenSet = false
 		return *s
 	}
 
@@ -95,6 +101,9 @@ func TestFlagsFromEnv(t *testing.T) {
 		{"1", 1, &IntFlag{Name: "seconds", EnvVars: []string{"SECONDS"}}, ""},
 		{"1.2", 0, &IntFlag{Name: "seconds", EnvVars: []string{"SECONDS"}}, `could not parse "1.2" as int value for flag seconds: .*`},
 		{"foobar", 0, &IntFlag{Name: "seconds", EnvVars: []string{"SECONDS"}}, `could not parse "foobar" as int value for flag seconds: .*`},
+
+		{"1.0,2", newSetFloat64Slice(1, 2), &Float64SliceFlag{Name: "seconds", EnvVars: []string{"SECONDS"}}, ""},
+		{"foobar", newSetFloat64Slice(), &Float64SliceFlag{Name: "seconds", EnvVars: []string{"SECONDS"}}, `could not parse "\[\]float64{}" as float64 slice value for flag seconds: .*`},
 
 		{"1,2", newSetIntSlice(1, 2), &IntSliceFlag{Name: "seconds", EnvVars: []string{"SECONDS"}}, ""},
 		{"1.2,2", newSetIntSlice(), &IntSliceFlag{Name: "seconds", EnvVars: []string{"SECONDS"}}, `could not parse "1.2,2" as int slice value for flag seconds: .*`},
@@ -143,6 +152,7 @@ func TestFlagsFromEnv(t *testing.T) {
 				t.Errorf("expected error to match %q, got none", test.errRegexp)
 			} else {
 				if matched, _ := regexp.MatchString(test.errRegexp, err.Error()); !matched {
+					fmt.Printf("%s\n%s\n", test.errRegexp, err.Error())
 					t.Errorf("expected error to match %q, got error %s", test.errRegexp, err)
 				}
 			}


### PR DESCRIPTION
…r file

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

fix v2 bug: slice flag value don't append to default values from ENV or file

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->
Fixes #1239

## Special notes for your reviewer:

StringSliceFlag have been fixed this bug, 
but Float64SliceFlag, Int64SliceFlag, IntSliceFlag have the same bug.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

TestFlagsFromEnv has cover this case

<!--
  Describe how you tested this change.
-->

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```
fix #1239: slice flag value don't append to default values from ENV or file
```
