### PR TITLE
Allow same flag to be repeated by child commands. 

### DIFF
--- a/altsrc/flag_test.go
+++ b/altsrc/flag_test.go
@@ -679,7 +679,7 @@ func runTest(t *testing.T, test testApplyInputSource) *cli.Context {
 		f.Value = test.ContextValue
 	}
 	if test.ContextValueString != "" {
-		_ = set.Set(test.FlagName, test.ContextValueString)
+		_ = c.Set(test.FlagName, test.ContextValueString)
 	}
 	_ = test.Flag.ApplyInputSourceValue(c, inputSource)
 

--- a/command.go
+++ b/command.go
@@ -146,7 +146,7 @@ func (c *Command) Run(cCtx *Context, arguments ...string) (err error) {
 
 	a := args(arguments)
 	set, err := c.parseFlags(&a, cCtx.shellComplete)
-	cCtx.flagSet = set
+	cCtx.setFlagSet(set)
 
 	if c.isRoot {
 		if checkCompletions(cCtx) {

--- a/context.go
+++ b/context.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"flag"
-	"fmt"
 	"strings"
 )
 
@@ -178,44 +177,12 @@ func (cCtx *Context) NArg() int {
 	return cCtx.Args().Len()
 }
 
-func (cCtx *Context) lookupFlag(name string) Flag {
-	for _, c := range cCtx.Lineage() {
-		if c.Command == nil {
-			continue
-		}
-
-		for _, f := range c.Command.Flags {
-			for _, n := range f.Names() {
-				if n == name {
-					return f
-				}
-			}
-		}
-	}
-
-	if cCtx.App != nil {
-		for _, f := range cCtx.App.Flags {
-			for _, n := range f.Names() {
-				if n == name {
-					return f
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-<<<<<<< HEAD
-func (cCtx *Context) lookupFlagSet(name string) *flag.FlagSet {
-	for _, c := range cCtx.Lineage() {
-		if c.flagSet == nil {
-			continue
-		}
-=======
 func (c *Context) resolveFlagDeep(name string) *flag.Flag {
 	var src *flag.Flag
 	for cur := c; cur != nil; cur = cur.parentContext {
+		if cur.flagSet == nil {
+			continue
+		}
 		if f := cur.flagSet.Lookup(name); f != nil {
 			if cur.flagOnCommandLine(name) {
 				// we've found most specific instance on command line, use it
@@ -232,14 +199,13 @@ func (c *Context) resolveFlagDeep(name string) *flag.Flag {
 	return src
 }
 
-func lookupFlagSet(name string, ctx *Context) *flag.FlagSet {
+func (ctx *Context) lookupFlagSet(name string) *flag.FlagSet {
 	for _, c := range ctx.Lineage() {
->>>>>>> Allow same flag to be repeated by child commands. Reading the value or checking for presence looks at the most specific subcommand that includes the flag on the command line.
 		if f := c.flagSet.Lookup(name); f != nil {
 			return c.flagSet
 		}
 	}
-	cCtx.onInvalidFlag(name)
+	ctx.onInvalidFlag(name)
 	return nil
 }
 

--- a/context.go
+++ b/context.go
@@ -212,13 +212,16 @@ func (c *Context) resolveFlagDeep(name string) *flag.Flag {
 	return src
 }
 
-func (ctx *Context) lookupFlagSet(name string) *flag.FlagSet {
-	for _, c := range ctx.Lineage() {
+func (cCtx *Context) lookupFlagSet(name string) *flag.FlagSet {
+	for _, c := range cCtx.Lineage() {
+		if c.flagSet == nil {
+			continue
+		}
 		if f := c.flagSet.Lookup(name); f != nil {
 			return c.flagSet
 		}
 	}
-	ctx.onInvalidFlag(name)
+	cCtx.onInvalidFlag(name)
 	return nil
 }
 

--- a/flag_bool.go
+++ b/flag_bool.go
@@ -149,15 +149,11 @@ func (f *BoolFlag) Get(ctx *Context) bool {
 
 // Bool looks up the value of a local BoolFlag, returns
 // false if not found
-func (cCtx *Context) Bool(name string) bool {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupBool(name, fs)
-	}
-	return false
+func (c *Context) Bool(name string) bool {
+	return lookupBool(c.resolveFlagDeep(name))
 }
 
-func lookupBool(name string, set *flag.FlagSet) bool {
-	f := set.Lookup(name)
+func lookupBool(f *flag.Flag) bool {
 	if f != nil {
 		parsed, err := strconv.ParseBool(f.Value.String())
 		if err != nil {

--- a/flag_bool.go
+++ b/flag_bool.go
@@ -149,8 +149,8 @@ func (f *BoolFlag) Get(ctx *Context) bool {
 
 // Bool looks up the value of a local BoolFlag, returns
 // false if not found
-func (c *Context) Bool(name string) bool {
-	return lookupBool(c.resolveFlagDeep(name))
+func (cCtx *Context) Bool(name string) bool {
+	return lookupBool(cCtx.resolveFlagDeep(name))
 }
 
 func lookupBool(f *flag.Flag) bool {

--- a/flag_duration.go
+++ b/flag_duration.go
@@ -84,15 +84,11 @@ func (f *DurationFlag) RunAction(c *Context) error {
 
 // Duration looks up the value of a local DurationFlag, returns
 // 0 if not found
-func (cCtx *Context) Duration(name string) time.Duration {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupDuration(name, fs)
-	}
-	return 0
+func (c *Context) Duration(name string) time.Duration {
+	return lookupDuration(c.resolveFlagDeep(name))
 }
 
-func lookupDuration(name string, set *flag.FlagSet) time.Duration {
-	f := set.Lookup(name)
+func lookupDuration(f *flag.Flag) time.Duration {
 	if f != nil {
 		parsed, err := time.ParseDuration(f.Value.String())
 		if err != nil {

--- a/flag_duration.go
+++ b/flag_duration.go
@@ -84,8 +84,8 @@ func (f *DurationFlag) RunAction(c *Context) error {
 
 // Duration looks up the value of a local DurationFlag, returns
 // 0 if not found
-func (c *Context) Duration(name string) time.Duration {
-	return lookupDuration(c.resolveFlagDeep(name))
+func (cCtx *Context) Duration(name string) time.Duration {
+	return lookupDuration(cCtx.resolveFlagDeep(name))
 }
 
 func lookupDuration(f *flag.Flag) time.Duration {

--- a/flag_float64.go
+++ b/flag_float64.go
@@ -81,8 +81,8 @@ func (f *Float64Flag) RunAction(c *Context) error {
 
 // Float64 looks up the value of a local Float64Flag, returns
 // 0 if not found
-func (c *Context) Float64(name string) float64 {
-	return lookupFloat64(c.resolveFlagDeep(name))
+func (cCtx *Context) Float64(name string) float64 {
+	return lookupFloat64(cCtx.resolveFlagDeep(name))
 }
 
 func lookupFloat64(f *flag.Flag) float64 {

--- a/flag_float64.go
+++ b/flag_float64.go
@@ -81,15 +81,11 @@ func (f *Float64Flag) RunAction(c *Context) error {
 
 // Float64 looks up the value of a local Float64Flag, returns
 // 0 if not found
-func (cCtx *Context) Float64(name string) float64 {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupFloat64(name, fs)
-	}
-	return 0
+func (c *Context) Float64(name string) float64 {
+	return lookupFloat64(c.resolveFlagDeep(name))
 }
 
-func lookupFloat64(name string, set *flag.FlagSet) float64 {
-	f := set.Lookup(name)
+func lookupFloat64(f *flag.Flag) float64 {
 	if f != nil {
 		parsed, err := strconv.ParseFloat(f.Value.String(), 64)
 		if err != nil {

--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -188,8 +188,8 @@ func (f *Float64SliceFlag) RunAction(c *Context) error {
 
 // Float64Slice looks up the value of a local Float64SliceFlag, returns
 // nil if not found
-func (c *Context) Float64Slice(name string) []float64 {
-	return lookupFloat64Slice(c.resolveFlagDeep(name))
+func (cCtx *Context) Float64Slice(name string) []float64 {
+	return lookupFloat64Slice(cCtx.resolveFlagDeep(name))
 }
 
 func lookupFloat64Slice(f *flag.Flag) []float64 {

--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -188,15 +188,11 @@ func (f *Float64SliceFlag) RunAction(c *Context) error {
 
 // Float64Slice looks up the value of a local Float64SliceFlag, returns
 // nil if not found
-func (cCtx *Context) Float64Slice(name string) []float64 {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupFloat64Slice(name, fs)
-	}
-	return nil
+func (c *Context) Float64Slice(name string) []float64 {
+	return lookupFloat64Slice(c.resolveFlagDeep(name))
 }
 
-func lookupFloat64Slice(name string, set *flag.FlagSet) []float64 {
-	f := set.Lookup(name)
+func lookupFloat64Slice(f *flag.Flag) []float64 {
 	if f != nil {
 		if slice, ok := unwrapFlagValue(f.Value).(*Float64Slice); ok {
 			return slice.Value()

--- a/flag_generic.go
+++ b/flag_generic.go
@@ -109,8 +109,8 @@ func (f *GenericFlag) RunAction(c *Context) error {
 
 // Generic looks up the value of a local GenericFlag, returns
 // nil if not found
-func (c *Context) Generic(name string) interface{} {
-	return lookupGeneric(c.resolveFlagDeep(name))
+func (cCtx *Context) Generic(name string) interface{} {
+	return lookupGeneric(cCtx.resolveFlagDeep(name))
 }
 
 func lookupGeneric(f *flag.Flag) interface{} {

--- a/flag_generic.go
+++ b/flag_generic.go
@@ -109,15 +109,11 @@ func (f *GenericFlag) RunAction(c *Context) error {
 
 // Generic looks up the value of a local GenericFlag, returns
 // nil if not found
-func (cCtx *Context) Generic(name string) interface{} {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupGeneric(name, fs)
-	}
-	return nil
+func (c *Context) Generic(name string) interface{} {
+	return lookupGeneric(c.resolveFlagDeep(name))
 }
 
-func lookupGeneric(name string, set *flag.FlagSet) interface{} {
-	f := set.Lookup(name)
+func lookupGeneric(f *flag.Flag) interface{} {
 	if f != nil {
 		parsed, err := f.Value, error(nil)
 		if err != nil {

--- a/flag_int.go
+++ b/flag_int.go
@@ -85,15 +85,11 @@ func (f *IntFlag) RunAction(c *Context) error {
 
 // Int looks up the value of a local IntFlag, returns
 // 0 if not found
-func (cCtx *Context) Int(name string) int {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupInt(name, fs)
-	}
-	return 0
+func (c *Context) Int(name string) int {
+	return lookupInt(c.resolveFlagDeep(name))
 }
 
-func lookupInt(name string, set *flag.FlagSet) int {
-	f := set.Lookup(name)
+func lookupInt(f *flag.Flag) int {
 	if f != nil {
 		parsed, err := strconv.ParseInt(f.Value.String(), 0, 64)
 		if err != nil {

--- a/flag_int.go
+++ b/flag_int.go
@@ -85,8 +85,8 @@ func (f *IntFlag) RunAction(c *Context) error {
 
 // Int looks up the value of a local IntFlag, returns
 // 0 if not found
-func (c *Context) Int(name string) int {
-	return lookupInt(c.resolveFlagDeep(name))
+func (cCtx *Context) Int(name string) int {
+	return lookupInt(cCtx.resolveFlagDeep(name))
 }
 
 func lookupInt(f *flag.Flag) int {

--- a/flag_int64.go
+++ b/flag_int64.go
@@ -84,8 +84,8 @@ func (f *Int64Flag) RunAction(c *Context) error {
 
 // Int64 looks up the value of a local Int64Flag, returns
 // 0 if not found
-func (c *Context) Int64(name string) int64 {
-	return lookupInt64(c.resolveFlagDeep(name))
+func (cCtx *Context) Int64(name string) int64 {
+	return lookupInt64(cCtx.resolveFlagDeep(name))
 }
 
 func lookupInt64(f *flag.Flag) int64 {

--- a/flag_int64.go
+++ b/flag_int64.go
@@ -84,15 +84,11 @@ func (f *Int64Flag) RunAction(c *Context) error {
 
 // Int64 looks up the value of a local Int64Flag, returns
 // 0 if not found
-func (cCtx *Context) Int64(name string) int64 {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupInt64(name, fs)
-	}
-	return 0
+func (c *Context) Int64(name string) int64 {
+	return lookupInt64(c.resolveFlagDeep(name))
 }
 
-func lookupInt64(name string, set *flag.FlagSet) int64 {
-	f := set.Lookup(name)
+func lookupInt64(f *flag.Flag) int64 {
 	if f != nil {
 		parsed, err := strconv.ParseInt(f.Value.String(), 0, 64)
 		if err != nil {

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -187,8 +187,8 @@ func (f *Int64SliceFlag) RunAction(c *Context) error {
 
 // Int64Slice looks up the value of a local Int64SliceFlag, returns
 // nil if not found
-func (c *Context) Int64Slice(name string) []int64 {
-	return lookupInt64Slice(c.resolveFlagDeep(name))
+func (cCtx *Context) Int64Slice(name string) []int64 {
+	return lookupInt64Slice(cCtx.resolveFlagDeep(name))
 }
 
 func lookupInt64Slice(f *flag.Flag) []int64 {

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -187,15 +187,11 @@ func (f *Int64SliceFlag) RunAction(c *Context) error {
 
 // Int64Slice looks up the value of a local Int64SliceFlag, returns
 // nil if not found
-func (cCtx *Context) Int64Slice(name string) []int64 {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupInt64Slice(name, fs)
-	}
-	return nil
+func (c *Context) Int64Slice(name string) []int64 {
+	return lookupInt64Slice(c.resolveFlagDeep(name))
 }
 
-func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
-	f := set.Lookup(name)
+func lookupInt64Slice(f *flag.Flag) []int64 {
 	if f != nil {
 		if slice, ok := unwrapFlagValue(f.Value).(*Int64Slice); ok {
 			return slice.Value()

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -198,8 +198,8 @@ func (f *IntSliceFlag) RunAction(c *Context) error {
 
 // IntSlice looks up the value of a local IntSliceFlag, returns
 // nil if not found
-func (c *Context) IntSlice(name string) []int {
-	return lookupIntSlice(c.resolveFlagDeep(name))
+func (cCtx *Context) IntSlice(name string) []int {
+	return lookupIntSlice(cCtx.resolveFlagDeep(name))
 }
 
 func lookupIntSlice(f *flag.Flag) []int {

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -198,15 +198,11 @@ func (f *IntSliceFlag) RunAction(c *Context) error {
 
 // IntSlice looks up the value of a local IntSliceFlag, returns
 // nil if not found
-func (cCtx *Context) IntSlice(name string) []int {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupIntSlice(name, fs)
-	}
-	return nil
+func (c *Context) IntSlice(name string) []int {
+	return lookupIntSlice(c.resolveFlagDeep(name))
 }
 
-func lookupIntSlice(name string, set *flag.FlagSet) []int {
-	f := set.Lookup(name)
+func lookupIntSlice(f *flag.Flag) []int {
 	if f != nil {
 		if slice, ok := unwrapFlagValue(f.Value).(*IntSlice); ok {
 			return slice.Value()

--- a/flag_path.go
+++ b/flag_path.go
@@ -81,8 +81,8 @@ func (f *PathFlag) RunAction(c *Context) error {
 
 // Path looks up the value of a local PathFlag, returns
 // "" if not found
-func (c *Context) Path(name string) string {
-	return lookupPath(c.resolveFlagDeep(name))
+func (cCtx *Context) Path(name string) string {
+	return lookupPath(cCtx.resolveFlagDeep(name))
 }
 
 func lookupPath(f *flag.Flag) string {

--- a/flag_path.go
+++ b/flag_path.go
@@ -81,16 +81,11 @@ func (f *PathFlag) RunAction(c *Context) error {
 
 // Path looks up the value of a local PathFlag, returns
 // "" if not found
-func (cCtx *Context) Path(name string) string {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupPath(name, fs)
-	}
-
-	return ""
+func (c *Context) Path(name string) string {
+	return lookupPath(c.resolveFlagDeep(name))
 }
 
-func lookupPath(name string, set *flag.FlagSet) string {
-	f := set.Lookup(name)
+func lookupPath(f *flag.Flag) string {
 	if f != nil {
 		parsed, err := f.Value.String(), error(nil)
 		if err != nil {

--- a/flag_string.go
+++ b/flag_string.go
@@ -79,8 +79,8 @@ func (f *StringFlag) RunAction(c *Context) error {
 
 // String looks up the value of a local StringFlag, returns
 // "" if not found
-func (c *Context) String(name string) string {
-	return lookupString(c.resolveFlagDeep(name))
+func (cCtx *Context) String(name string) string {
+	return lookupString(cCtx.resolveFlagDeep(name))
 }
 
 func lookupString(f *flag.Flag) string {

--- a/flag_string.go
+++ b/flag_string.go
@@ -79,15 +79,11 @@ func (f *StringFlag) RunAction(c *Context) error {
 
 // String looks up the value of a local StringFlag, returns
 // "" if not found
-func (cCtx *Context) String(name string) string {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupString(name, fs)
-	}
-	return ""
+func (c *Context) String(name string) string {
+	return lookupString(c.resolveFlagDeep(name))
 }
 
-func lookupString(name string, set *flag.FlagSet) string {
-	f := set.Lookup(name)
+func lookupString(f *flag.Flag) string {
 	if f != nil {
 		parsed := f.Value.String()
 		return parsed

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -179,8 +179,8 @@ func (f *StringSliceFlag) RunAction(c *Context) error {
 
 // StringSlice looks up the value of a local StringSliceFlag, returns
 // nil if not found
-func (c *Context) StringSlice(name string) []string {
-	return lookupStringSlice(c.resolveFlagDeep(name))
+func (cCtx *Context) StringSlice(name string) []string {
+	return lookupStringSlice(cCtx.resolveFlagDeep(name))
 }
 
 func lookupStringSlice(f *flag.Flag) []string {

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -179,15 +179,11 @@ func (f *StringSliceFlag) RunAction(c *Context) error {
 
 // StringSlice looks up the value of a local StringSliceFlag, returns
 // nil if not found
-func (cCtx *Context) StringSlice(name string) []string {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupStringSlice(name, fs)
-	}
-	return nil
+func (c *Context) StringSlice(name string) []string {
+	return lookupStringSlice(c.resolveFlagDeep(name))
 }
 
-func lookupStringSlice(name string, set *flag.FlagSet) []string {
-	f := set.Lookup(name)
+func lookupStringSlice(f *flag.Flag) []string {
 	if f != nil {
 		if slice, ok := unwrapFlagValue(f.Value).(*StringSlice); ok {
 			return slice.Value()

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -183,8 +183,8 @@ func (f *TimestampFlag) RunAction(c *Context) error {
 }
 
 // Timestamp gets the timestamp from a flag name
-func (c *Context) Timestamp(name string) *time.Time {
-	return lookupTimestamp(c.resolveFlagDeep(name))
+func (cCtx *Context) Timestamp(name string) *time.Time {
+	return lookupTimestamp(cCtx.resolveFlagDeep(name))
 }
 
 // Fetches the timestamp value from the local timestampWrap

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -183,16 +183,12 @@ func (f *TimestampFlag) RunAction(c *Context) error {
 }
 
 // Timestamp gets the timestamp from a flag name
-func (cCtx *Context) Timestamp(name string) *time.Time {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupTimestamp(name, fs)
-	}
-	return nil
+func (c *Context) Timestamp(name string) *time.Time {
+	return lookupTimestamp(c.resolveFlagDeep(name))
 }
 
 // Fetches the timestamp value from the local timestampWrap
-func lookupTimestamp(name string, set *flag.FlagSet) *time.Time {
-	f := set.Lookup(name)
+func lookupTimestamp(f *flag.Flag) *time.Time {
 	if f != nil {
 		return (f.Value.(*Timestamp)).Value()
 	}

--- a/flag_uint.go
+++ b/flag_uint.go
@@ -84,15 +84,11 @@ func (f *UintFlag) Get(ctx *Context) uint {
 
 // Uint looks up the value of a local UintFlag, returns
 // 0 if not found
-func (cCtx *Context) Uint(name string) uint {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupUint(name, fs)
-	}
-	return 0
+func (c *Context) Uint(name string) uint {
+	return lookupUint(c.resolveFlagDeep(name))
 }
 
-func lookupUint(name string, set *flag.FlagSet) uint {
-	f := set.Lookup(name)
+func lookupUint(f *flag.Flag) uint {
 	if f != nil {
 		parsed, err := strconv.ParseUint(f.Value.String(), 0, 64)
 		if err != nil {

--- a/flag_uint.go
+++ b/flag_uint.go
@@ -84,8 +84,8 @@ func (f *UintFlag) Get(ctx *Context) uint {
 
 // Uint looks up the value of a local UintFlag, returns
 // 0 if not found
-func (c *Context) Uint(name string) uint {
-	return lookupUint(c.resolveFlagDeep(name))
+func (cCtx *Context) Uint(name string) uint {
+	return lookupUint(cCtx.resolveFlagDeep(name))
 }
 
 func lookupUint(f *flag.Flag) uint {

--- a/flag_uint64.go
+++ b/flag_uint64.go
@@ -84,8 +84,8 @@ func (f *Uint64Flag) Get(ctx *Context) uint64 {
 
 // Uint64 looks up the value of a local Uint64Flag, returns
 // 0 if not found
-func (c *Context) Uint64(name string) uint64 {
-	return lookupUint64(c.resolveFlagDeep(name))
+func (cCtx *Context) Uint64(name string) uint64 {
+	return lookupUint64(cCtx.resolveFlagDeep(name))
 }
 
 func lookupUint64(f *flag.Flag) uint64 {

--- a/flag_uint64.go
+++ b/flag_uint64.go
@@ -84,15 +84,11 @@ func (f *Uint64Flag) Get(ctx *Context) uint64 {
 
 // Uint64 looks up the value of a local Uint64Flag, returns
 // 0 if not found
-func (cCtx *Context) Uint64(name string) uint64 {
-	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupUint64(name, fs)
-	}
-	return 0
+func (c *Context) Uint64(name string) uint64 {
+	return lookupUint64(c.resolveFlagDeep(name))
 }
 
-func lookupUint64(name string, set *flag.FlagSet) uint64 {
-	f := set.Lookup(name)
+func lookupUint64(f *flag.Flag) uint64 {
 	if f != nil {
 		parsed, err := strconv.ParseUint(f.Value.String(), 0, 64)
 		if err != nil {

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -635,44 +635,44 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context
 func (cCtx *Context) Args() Args
     Args returns the command line arguments associated with the context.
 
-func (c *Context) Bool(name string) bool
+func (cCtx *Context) Bool(name string) bool
     Bool looks up the value of a local BoolFlag, returns false if not found
 
 func (cCtx *Context) Count(name string) int
     Count returns the num of occurences of this flag
 
-func (c *Context) Duration(name string) time.Duration
+func (cCtx *Context) Duration(name string) time.Duration
     Duration looks up the value of a local DurationFlag, returns 0 if not found
 
 func (cCtx *Context) FlagNames() []string
     FlagNames returns a slice of flag names used by the this context and all of
     its parent contexts.
 
-func (c *Context) Float64(name string) float64
+func (cCtx *Context) Float64(name string) float64
     Float64 looks up the value of a local Float64Flag, returns 0 if not found
 
-func (c *Context) Float64Slice(name string) []float64
+func (cCtx *Context) Float64Slice(name string) []float64
     Float64Slice looks up the value of a local Float64SliceFlag, returns nil if
     not found
 
-func (c *Context) Generic(name string) interface{}
+func (cCtx *Context) Generic(name string) interface{}
     Generic looks up the value of a local GenericFlag, returns nil if not found
 
-func (c *Context) Int(name string) int
+func (cCtx *Context) Int(name string) int
     Int looks up the value of a local IntFlag, returns 0 if not found
 
-func (c *Context) Int64(name string) int64
+func (cCtx *Context) Int64(name string) int64
     Int64 looks up the value of a local Int64Flag, returns 0 if not found
 
-func (c *Context) Int64Slice(name string) []int64
+func (cCtx *Context) Int64Slice(name string) []int64
     Int64Slice looks up the value of a local Int64SliceFlag, returns nil if not
     found
 
-func (c *Context) IntSlice(name string) []int
+func (cCtx *Context) IntSlice(name string) []int
     IntSlice looks up the value of a local IntSliceFlag, returns nil if not
     found
 
-func (c *Context) IsSet(name string) bool
+func (cCtx *Context) IsSet(name string) bool
     IsSet determines if the flag was actually set
 
 func (cCtx *Context) Lineage() []*Context
@@ -688,26 +688,26 @@ func (cCtx *Context) NArg() int
 func (cCtx *Context) NumFlags() int
     NumFlags returns the number of flags set
 
-func (c *Context) Path(name string) string
+func (cCtx *Context) Path(name string) string
     Path looks up the value of a local PathFlag, returns "" if not found
 
-func (c *Context) Set(name, value string) error
+func (cCtx *Context) Set(name, value string) error
     Set sets a context flag to a value.
 
-func (c *Context) String(name string) string
+func (cCtx *Context) String(name string) string
     String looks up the value of a local StringFlag, returns "" if not found
 
-func (c *Context) StringSlice(name string) []string
+func (cCtx *Context) StringSlice(name string) []string
     StringSlice looks up the value of a local StringSliceFlag, returns nil if
     not found
 
-func (c *Context) Timestamp(name string) *time.Time
+func (cCtx *Context) Timestamp(name string) *time.Time
     Timestamp gets the timestamp from a flag name
 
-func (c *Context) Uint(name string) uint
+func (cCtx *Context) Uint(name string) uint
     Uint looks up the value of a local UintFlag, returns 0 if not found
 
-func (c *Context) Uint64(name string) uint64
+func (cCtx *Context) Uint64(name string) uint64
     Uint64 looks up the value of a local Uint64Flag, returns 0 if not found
 
 func (cCtx *Context) Uint64Slice(name string) []uint64

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -635,44 +635,44 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context
 func (cCtx *Context) Args() Args
     Args returns the command line arguments associated with the context.
 
-func (cCtx *Context) Bool(name string) bool
+func (c *Context) Bool(name string) bool
     Bool looks up the value of a local BoolFlag, returns false if not found
 
 func (cCtx *Context) Count(name string) int
     Count returns the num of occurences of this flag
 
-func (cCtx *Context) Duration(name string) time.Duration
+func (c *Context) Duration(name string) time.Duration
     Duration looks up the value of a local DurationFlag, returns 0 if not found
 
 func (cCtx *Context) FlagNames() []string
     FlagNames returns a slice of flag names used by the this context and all of
     its parent contexts.
 
-func (cCtx *Context) Float64(name string) float64
+func (c *Context) Float64(name string) float64
     Float64 looks up the value of a local Float64Flag, returns 0 if not found
 
-func (cCtx *Context) Float64Slice(name string) []float64
+func (c *Context) Float64Slice(name string) []float64
     Float64Slice looks up the value of a local Float64SliceFlag, returns nil if
     not found
 
-func (cCtx *Context) Generic(name string) interface{}
+func (c *Context) Generic(name string) interface{}
     Generic looks up the value of a local GenericFlag, returns nil if not found
 
-func (cCtx *Context) Int(name string) int
+func (c *Context) Int(name string) int
     Int looks up the value of a local IntFlag, returns 0 if not found
 
-func (cCtx *Context) Int64(name string) int64
+func (c *Context) Int64(name string) int64
     Int64 looks up the value of a local Int64Flag, returns 0 if not found
 
-func (cCtx *Context) Int64Slice(name string) []int64
+func (c *Context) Int64Slice(name string) []int64
     Int64Slice looks up the value of a local Int64SliceFlag, returns nil if not
     found
 
-func (cCtx *Context) IntSlice(name string) []int
+func (c *Context) IntSlice(name string) []int
     IntSlice looks up the value of a local IntSliceFlag, returns nil if not
     found
 
-func (cCtx *Context) IsSet(name string) bool
+func (c *Context) IsSet(name string) bool
     IsSet determines if the flag was actually set
 
 func (cCtx *Context) Lineage() []*Context
@@ -688,26 +688,26 @@ func (cCtx *Context) NArg() int
 func (cCtx *Context) NumFlags() int
     NumFlags returns the number of flags set
 
-func (cCtx *Context) Path(name string) string
+func (c *Context) Path(name string) string
     Path looks up the value of a local PathFlag, returns "" if not found
 
-func (cCtx *Context) Set(name, value string) error
+func (c *Context) Set(name, value string) error
     Set sets a context flag to a value.
 
-func (cCtx *Context) String(name string) string
+func (c *Context) String(name string) string
     String looks up the value of a local StringFlag, returns "" if not found
 
-func (cCtx *Context) StringSlice(name string) []string
+func (c *Context) StringSlice(name string) []string
     StringSlice looks up the value of a local StringSliceFlag, returns nil if
     not found
 
-func (cCtx *Context) Timestamp(name string) *time.Time
+func (c *Context) Timestamp(name string) *time.Time
     Timestamp gets the timestamp from a flag name
 
-func (cCtx *Context) Uint(name string) uint
+func (c *Context) Uint(name string) uint
     Uint looks up the value of a local UintFlag, returns 0 if not found
 
-func (cCtx *Context) Uint64(name string) uint64
+func (c *Context) Uint64(name string) uint64
     Uint64 looks up the value of a local Uint64Flag, returns 0 if not found
 
 func (cCtx *Context) Uint64Slice(name string) []uint64


### PR DESCRIPTION
Reading the value or checking for presence looks at the most specific subcommand that includes the flag on the command line.

## What type of PR is this?

- feature

## What this PR does / why we need it:

Add support for duplicate flags along subcommand chain. This allows the application and (sub)commands to define the same flag. The context for the ultimate action that runs will read the most specific value.

## Which issue(s) this PR fixes:



## Testing

Added a number of units tests to cover these cases. Corrected some of the existing tests to correctly mock operation of the production code.

## Release Notes

(sub)commands can now re-declare flags defined at parent command or the app. This allows these flags to appear in either location on the command-line. During action execution, context will read value provided at most-specific (rightmost) position.

```release-note

```
