### PR TITLE
Fix data race in app.Run with reused commands

### DIFF
--- a/app.go
+++ b/app.go
@@ -177,11 +177,12 @@ func (a *App) Setup() {
 
 	var newCommands []*Command
 
-	for _, c := range a.Commands {
-		if c.HelpName == "" {
-			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+	for _, command := range a.Commands {
+		newCommand := *command // only mutate a shallow copy of the command to avoid data race in parallel tests
+		if newCommand.HelpName == "" {
+			newCommand.HelpName = fmt.Sprintf("%s %s", a.HelpName, newCommand.Name)
 		}
-		newCommands = append(newCommands, c)
+		newCommands = append(newCommands, &newCommand)
 	}
 	a.Commands = newCommands
 

--- a/command_test.go
+++ b/command_test.go
@@ -422,3 +422,24 @@ func TestCommand_CanAddVFlagOnCommands(t *testing.T) {
 	err := app.Run([]string{"foo", "bar"})
 	expect(t, err, nil)
 }
+
+func TestDataRaceSharedCommands(t *testing.T) {
+	// Verifies fix for https://github.com/urfave/cli/issues/1242
+	commands := []*Command{
+		{Name: "bar"},
+	}
+
+	t.Run("first run", func(t *testing.T) {
+		t.Parallel()
+		app := NewApp()
+		app.Commands = commands
+		_ = app.Run([]string{"foo", "bar"})
+	})
+
+	t.Run("second run", func(t *testing.T) {
+		t.Parallel()
+		app := NewApp()
+		app.Commands = commands
+		_ = app.Run([]string{"foo", "bar"})
+	})
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -79,7 +79,7 @@ func TestActionFunc(c *cli.Context) error {
 
 		coverProfile := fmt.Sprintf("--coverprofile=%s.coverprofile", pkg)
 
-		err := runCmd("go", "test", "-v", coverProfile, packageName)
+		err := runCmd("go", "test", "-race", "-v", coverProfile, packageName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Enables commands to be reused across multiple instances of `cli.App` and executed in parallel tests.

Turned out to be a pretty easy fix after all 😄 

It's likely I didn't catch all race conditions around app setup.
For example, I'm fairly certain parallel calls to `app.Run(...)` on the same `app` would fail, since they'd both call `Setup()` and mutate their commands.
I deferred fixing that since I think it's both easily avoidable in tests and unrealistic outside of tests.

(If someone does need to fix that, I'd bet a `setupOnce sync.Once` field in `*cli.App` would do the trick. Though it would make shallow copies of App fail `go vet` 🤷 )

## What type of PR is this?

- bug

## What this PR does / why we need it:

* Fixes data race described in #1242, adds new (previously failing) test
* Enables race detection flag in GitHub Actions

## Which issue(s) this PR fixes:

Fixes #1242

## Testing

Red -> Green: Added a failing test, then made it pass 🟢 

## Release Notes

This might pose an issue for folks relying on the slice of command pointers being identical before and after calling `Run()` (and `Setup()` indirectly). I imagine that could be an issue if app.Run is called more than once and an old command ptr is mutated, but I don't think that would happen outside of tests anyway.

```release-note
Fixes data race for reused commands in parallel tests
```
