### PR TITLE
UsageText to be passed from Command to App in startApp

### DIFF
--- a/command.go
+++ b/command.go
@@ -227,6 +227,7 @@ func (c *Command) startApp(ctx *Context) error {
 	}
 
 	app.Usage = c.Usage
+	app.UsageText = c.UsageText
 	app.Description = c.Description
 	app.ArgsUsage = c.ArgsUsage
 


### PR DESCRIPTION
## What type of PR is this?
- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:
startApp function assigns Command fields to App fields, but UsageText field is missing. Because of that, this field is not presented correctly when viewing help for command having subcommands.

## Which issue(s) this PR fixes:
I have found no open issues.

## Release Notes
```release-note
UsageText is now correctly displayed when viewing help for commands with subcommands
```
