### PR TITLE
Add test case for short option handling

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -2063,17 +2063,19 @@ func TestTimestampFlagApply_WithDestination(t *testing.T) {
 // Test issue #1254
 // StringSlice() with UseShortOptionHandling causes duplicated entries, depending on the ordering of the flags
 func TestSliceShortOptionHandle(t *testing.T) {
-	_ = (&App{
+	wasCalled := false
+	err := (&App{
 		Commands: []*Command{
 			{
 				Name:                   "foobar",
 				UseShortOptionHandling: true,
 				Action: func(ctx *Context) error {
+					wasCalled = true
 					if ctx.Bool("i") != true {
-						t.Errorf("bool i not set")
+						t.Error("bool i not set")
 					}
 					if ctx.Bool("t") != true {
-						t.Errorf("bool i not set")
+						t.Error("bool i not set")
 					}
 					ss := ctx.StringSlice("net")
 					if !reflect.DeepEqual(ss, []string{"foo"}) {
@@ -2089,4 +2091,10 @@ func TestSliceShortOptionHandle(t *testing.T) {
 			},
 		},
 	}).Run([]string{"run", "foobar", "--net=foo", "-it"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wasCalled {
+		t.Fatal("Action callback was never called")
+	}
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -2059,3 +2059,34 @@ func TestTimestampFlagApply_WithDestination(t *testing.T) {
 	expect(t, err, nil)
 	expect(t, *fl.Destination.timestamp, expectedResult)
 }
+
+// Test issue #1254
+// StringSlice() with UseShortOptionHandling causes duplicated entries, depending on the ordering of the flags
+func TestSliceShortOptionHandle(t *testing.T) {
+	_ = (&App{
+		Commands: []*Command{
+			{
+				Name:                   "foobar",
+				UseShortOptionHandling: true,
+				Action: func(ctx *Context) error {
+					if ctx.Bool("i") != true {
+						t.Errorf("bool i not set")
+					}
+					if ctx.Bool("t") != true {
+						t.Errorf("bool i not set")
+					}
+					ss := ctx.StringSlice("net")
+					if !reflect.DeepEqual(ss, []string{"foo"}) {
+						t.Errorf("Got different slice(%v) than expected", ss)
+					}
+					return nil
+				},
+				Flags: []Flag{
+					&StringSliceFlag{Name: "net"},
+					&BoolFlag{Name: "i"},
+					&BoolFlag{Name: "t"},
+				},
+			},
+		},
+	}).Run([]string{"run", "foobar", "--net=foo", "-it"})
+}

--- a/parse.go
+++ b/parse.go
@@ -46,9 +46,8 @@ func parseIter(set *flag.FlagSet, ip iterativeParser, args []string, shellComple
 				return err
 			}
 
-			// Start processing only from failed argument and not
-			// from beginning
-			args = append(shortOpts, args[i+1:]...)
+			// swap current argument with the split version
+			args = append(args[:i], append(shortOpts, args[i+1:]...)...)
 			argsWereSplit = true
 			break
 		}

--- a/parse.go
+++ b/parse.go
@@ -46,8 +46,9 @@ func parseIter(set *flag.FlagSet, ip iterativeParser, args []string, shellComple
 				return err
 			}
 
-			// swap current argument with the split version
-			args = append(args[:i], append(shortOpts, args[i+1:]...)...)
+			// Start processing only from failed argument and not
+			// from beginning
+			args = append(shortOpts, args[i+1:]...)
 			argsWereSplit = true
 			break
 		}


### PR DESCRIPTION
…erminated error

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

The short options handling needs to restart from failed processing rather than from beginning of arguments
## Which issue(s) this PR fixes:

Fixes #1254

## Special notes for your reviewer:

## Testing

go test -run=TestSliceShortOptionHandle ./...

## Release Notes

```release-note

```
