### PR TITLE
Allow -ve values for int, float & duration

### DIFF
--- a/altsrc/flag.go
+++ b/altsrc/flag.go
@@ -197,10 +197,8 @@ func (f *IntFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContex
 			if err != nil {
 				return err
 			}
-			if value > 0 {
-				for _, name := range f.Names() {
-					_ = f.set.Set(name, strconv.FormatInt(int64(value), 10))
-				}
+			for _, name := range f.Names() {
+				_ = f.set.Set(name, strconv.FormatInt(int64(value), 10))
 			}
 		}
 	}
@@ -215,10 +213,8 @@ func (f *DurationFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceC
 			if err != nil {
 				return err
 			}
-			if value > 0 {
-				for _, name := range f.Names() {
-					_ = f.set.Set(name, value.String())
-				}
+			for _, name := range f.Names() {
+				_ = f.set.Set(name, value.String())
 			}
 		}
 	}
@@ -233,11 +229,9 @@ func (f *Float64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceCo
 			if err != nil {
 				return err
 			}
-			if value > 0 {
-				floatStr := float64ToString(value)
-				for _, name := range f.Names() {
-					_ = f.set.Set(name, floatStr)
-				}
+			floatStr := float64ToString(value)
+			for _, name := range f.Names() {
+				_ = f.set.Set(name, floatStr)
 			}
 		}
 	}

--- a/altsrc/flag_test.go
+++ b/altsrc/flag_test.go
@@ -234,6 +234,15 @@ func TestIntApplyInputSourceMethodSet(t *testing.T) {
 	expect(t, 15, c.Int("test"))
 }
 
+func TestIntApplyInputSourceMethodSetNegativeValue(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewIntFlag(&cli.IntFlag{Name: "test"}),
+		FlagName: "test",
+		MapValue: -1,
+	})
+	expect(t, -1, c.Int("test"))
+}
+
 func TestIntApplyInputSourceMethodContextSet(t *testing.T) {
 	c := runTest(t, testApplyInputSource{
 		Flag:               NewIntFlag(&cli.IntFlag{Name: "test"}),
@@ -264,6 +273,15 @@ func TestDurationApplyInputSourceMethodSet(t *testing.T) {
 	expect(t, 30*time.Second, c.Duration("test"))
 }
 
+func TestDurationApplyInputSourceMethodSetNegativeValue(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewDurationFlag(&cli.DurationFlag{Name: "test"}),
+		FlagName: "test",
+		MapValue: -30 * time.Second,
+	})
+	expect(t, -30*time.Second, c.Duration("test"))
+}
+
 func TestDurationApplyInputSourceMethodContextSet(t *testing.T) {
 	c := runTest(t, testApplyInputSource{
 		Flag:               NewDurationFlag(&cli.DurationFlag{Name: "test"}),
@@ -292,6 +310,15 @@ func TestFloat64ApplyInputSourceMethodSet(t *testing.T) {
 		MapValue: 1.3,
 	})
 	expect(t, 1.3, c.Float64("test"))
+}
+
+func TestFloat64ApplyInputSourceMethodSetNegativeValue(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewFloat64Flag(&cli.Float64Flag{Name: "test"}),
+		FlagName: "test",
+		MapValue: -1.3,
+	})
+	expect(t, -1.3, c.Float64("test"))
 }
 
 func TestFloat64ApplyInputSourceMethodContextSet(t *testing.T) {

--- a/altsrc/flag_test.go
+++ b/altsrc/flag_test.go
@@ -321,6 +321,15 @@ func TestFloat64ApplyInputSourceMethodSetNegativeValue(t *testing.T) {
 	expect(t, -1.3, c.Float64("test"))
 }
 
+func TestFloat64ApplyInputSourceMethodSetNegativeValueNotSet(t *testing.T) {
+	c := runTest(t, testApplyInputSource{
+		Flag:     NewFloat64Flag(&cli.Float64Flag{Name: "test1"}),
+		FlagName: "test1",
+		// dont set map value
+	})
+	expect(t, 0.0, c.Float64("test1"))
+}
+
 func TestFloat64ApplyInputSourceMethodContextSet(t *testing.T) {
 	c := runTest(t, testApplyInputSource{
 		Flag:               NewFloat64Flag(&cli.Float64Flag{Name: "test"}),


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

This PR allows negative values for int64, float64 and duration flags from alternate input sources

## Which issue(s) this PR fixes:

Fixes #1199 

## Special notes for your reviewer:

## Testing

Added 3 tests
 *  TestIntApplyInputSourceMethodSetNegativeValue
 * TestDurationApplyInputSourceMethodSetNegativeValue
 * TestFloat64ApplyInputSourceMethodSetNegativeValue

## Release Notes


```release-note

```
