### PR TITLE
fix(UsageText): consistent indent for help UsageText output

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -511,6 +511,36 @@ func TestShowSubcommandHelp_CommandUsageText(t *testing.T) {
 	}
 }
 
+func TestShowSubcommandHelp_MultiLine_CommandUsageText(t *testing.T) {
+	app := &App{
+		Commands: []*Command{
+			{
+				Name: "frobbly",
+				UsageText: `This is a
+multi
+line
+UsageText`,
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	app.Writer = output
+
+	_ = app.Run([]string{"foo", "frobbly", "--help"})
+
+	expected := `USAGE:
+   This is a
+   multi
+   line
+   UsageText
+`
+
+	if !strings.Contains(output.String(), expected) {
+		t.Errorf("expected output to include usage text; got: %q", output.String())
+	}
+}
+
 func TestShowSubcommandHelp_SubcommandUsageText(t *testing.T) {
 	app := &App{
 		Commands: []*Command{
@@ -531,6 +561,40 @@ func TestShowSubcommandHelp_SubcommandUsageText(t *testing.T) {
 	_ = app.Run([]string{"foo", "frobbly", "bobbly", "--help"})
 
 	if !strings.Contains(output.String(), "this is usage text") {
+		t.Errorf("expected output to include usage text; got: %q", output.String())
+	}
+}
+
+func TestShowSubcommandHelp_MultiLine_SubcommandUsageText(t *testing.T) {
+	app := &App{
+		Commands: []*Command{
+			{
+				Name: "frobbly",
+				Subcommands: []*Command{
+					{
+						Name: "bobbly",
+						UsageText: `This is a
+multi
+line
+UsageText`,
+					},
+				},
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	app.Writer = output
+	_ = app.Run([]string{"foo", "frobbly", "bobbly", "--help"})
+
+	expected := `USAGE:
+   This is a
+   multi
+   line
+   UsageText
+`
+
+	if !strings.Contains(output.String(), expected) {
 		t.Errorf("expected output to include usage text; got: %q", output.String())
 	}
 }
@@ -777,6 +841,56 @@ VERSION:
 	if !strings.Contains(output.String(), "VERSION:") ||
 		!strings.Contains(output.String(), "2.0.0") {
 		t.Errorf("expected output to include \"VERSION:, 2.0.0\"; got: %q", output.String())
+	}
+}
+
+func TestShowAppHelp_UsageText(t *testing.T) {
+	app := &App{
+		UsageText: "This is a sinlge line of UsageText",
+		Commands: []*Command{
+			{
+				Name: "frobbly",
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	app.Writer = output
+
+	_ = app.Run([]string{"foo"})
+
+	if !strings.Contains(output.String(), "This is a sinlge line of UsageText") {
+		t.Errorf("expected output to include usage text; got: %q", output.String())
+	}
+}
+
+func TestShowAppHelp_MultiLine_UsageText(t *testing.T) {
+	app := &App{
+		UsageText: `This is a
+multi
+line
+App UsageText`,
+		Commands: []*Command{
+			{
+				Name: "frobbly",
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	app.Writer = output
+
+	_ = app.Run([]string{"foo"})
+
+	expected := `USAGE:
+   This is a
+   multi
+   line
+   App UsageText
+`
+
+	if !strings.Contains(output.String(), expected) {
+		t.Errorf("expected output to include usage text; got: %q", output.String())
 	}
 }
 

--- a/template.go
+++ b/template.go
@@ -7,7 +7,7 @@ var AppHelpTemplate = `NAME:
    {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
 
 USAGE:
-   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+   {{if .UsageText}}{{.UsageText | nindent 3 | trim}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
 
 VERSION:
    {{.Version}}{{end}}{{end}}{{if .Description}}
@@ -39,7 +39,7 @@ var CommandHelpTemplate = `NAME:
    {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
+   {{if .UsageText}}{{.UsageText | nindent 3 | trim}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
 
 CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
@@ -59,7 +59,7 @@ var SubcommandHelpTemplate = `NAME:
    {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Description}}
+   {{if .UsageText}}{{.UsageText | nindent 3 | trim}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Description}}
 
 DESCRIPTION:
    {{.Description | nindent 3 | trim}}{{end}}


### PR DESCRIPTION
## What type of PR is this?

- [X] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

This PR addresses the bug found by @codefromthecrypt and noted in #1278 

## Which issue(s) this PR fixes:

Fixes #1278

## Testing

- Added multiple unit tests that test the functionality for multi-line `UsageText` values for `App`, `Command` and `SubCommand` types.
- Spot tested with a local CLI tool integration.

## Release Notes

```release-note
fix(UsageText): consistent indent for help UsageText output
```
