### PR TITLE
Fix help used as command returns errors when required flags are missing

### DIFF
--- a/app.go
+++ b/app.go
@@ -319,7 +319,7 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 		}()
 	}
 
-	if !a.HideHelp && checkHelp(cCtx) {
+	if !a.HideHelp && (checkHelp(context) || checkHelpArguments(arguments)) {
 		_ = ShowAppHelp(cCtx)
 		return nil
 	}

--- a/app.go
+++ b/app.go
@@ -319,7 +319,7 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 		}()
 	}
 
-	if !a.HideHelp && (checkHelp(context) || checkHelpArguments(arguments)) {
+	if !a.HideHelp && (checkHelp(cCtx) || checkHelpArguments(arguments)) {
 		_ = ShowAppHelp(cCtx)
 		return nil
 	}

--- a/help.go
+++ b/help.go
@@ -424,6 +424,20 @@ func checkSubcommandHelp(cCtx *Context) bool {
 	return false
 }
 
+// help or h can be used as a command not just as a flag. This causes
+// checkRequiredFlags to return an error if the required flags are not set
+func checkHelpArguments(arguments []string) bool {
+	for _, arg := range arguments {
+		for _, help := range HelpFlag.Names() {
+			if help == arg {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
 	if !a.EnableBashCompletion {
 		return false, arguments

--- a/help_test.go
+++ b/help_test.go
@@ -102,6 +102,39 @@ func Test_Help_Custom_Flags(t *testing.T) {
 	}
 }
 
+func Test_Help_Required_Flags_Does_Not_Error(t *testing.T) {
+	oldFlag := HelpFlag
+	defer func() {
+		HelpFlag = oldFlag
+	}()
+
+	app := App{
+		Flags: []Flag{
+			&StringFlag{Name: "foo", Required: true},
+		},
+	}
+
+	output := new(bytes.Buffer)
+	app.Writer = output
+
+	tests := []struct {
+		helpFlag string
+	}{
+		{"-help"},
+		{"-h"},
+		{"help"},
+		{"h"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.helpFlag, func(t *testing.T) {
+			err := app.Run([]string{"test", tt.helpFlag})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func Test_Version_Custom_Flags(t *testing.T) {
 	oldFlag := VersionFlag
 	defer func() {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Using `app help` or `app h` without providing required flags causes `app.Run()` to return an `errRequiredFlags` error.
This does not happend if using `-help` or `-h`.

Added a function to check if any of the arguments matches `HelpFlag.Names()` to stop early and show the app help.

## Which issue(s) this PR fixes:

Fixes https://github.com/urfave/cli/issues/1247

## Special notes for your reviewer:

I'm new to the code base so perhaps there is an easier way to check if the command matches `help` or `h`  before calling `checkRequiredFlags`. However, `context.Command.Name` is empty just before `checkRequiredFlags` so I couldn't just check that first.

## Testing

Added test `Test_Help_Required_Flags_Does_Not_Error` to `help_test.go`

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Fixed https://github.com/urfave/cli/issues/1247
```
