### PR TITLE
feat(docs): Include Description and UsageText in docs output

### DIFF
--- a/docs_test.go
+++ b/docs_test.go
@@ -110,6 +110,7 @@ Should be a part of the same code block
 		}},
 	}}
 	app.UsageText = "app [first_arg] [second_arg]"
+	app.Description = `Description of the application.`
 	app.Usage = "Some app"
 	app.Authors = []*Author{
 		{Name: "Harrison", Email: "harrison@lolwut.com"},
@@ -176,6 +177,19 @@ func TestToMarkdownNoAuthors(t *testing.T) {
 	// Then
 	expect(t, err, nil)
 	expectFileContent(t, "testdata/expected-doc-no-authors.md", res)
+}
+
+func TestToMarkdownNoUsageText(t *testing.T) {
+	// Given
+	app := testApp()
+	app.UsageText = ""
+
+	// When
+	res, err := app.ToMarkdown()
+
+	// Then
+	expect(t, err, nil)
+	expectFileContent(t, "testdata/expected-doc-no-usagetext.md", res)
 }
 
 func TestToMan(t *testing.T) {

--- a/template.go
+++ b/template.go
@@ -86,16 +86,18 @@ var MarkdownDocTemplate = `% {{ .App.Name }} {{ .SectionNum }}
 {{ if .SynopsisArgs }}
 ` + "```" + `
 {{ range $v := .SynopsisArgs }}{{ $v }}{{ end }}` + "```" + `
-{{ end }}{{ if .App.UsageText }}
+{{ end }}{{ if .App.Description }}
 # DESCRIPTION
 
-{{ .App.UsageText }}
+{{ .App.Description }}
 {{ end }}
 **Usage**:
 
-` + "```" + `
+` + "```" + `{{ if .App.UsageText }}
+{{ .App.UsageText }}
+{{ else }}
 {{ .App.Name }} [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
-` + "```" + `
+{{ end }}` + "```" + `
 {{ if .GlobalArgs }}
 # GLOBAL OPTIONS
 {{ range $v := .GlobalArgs }}

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -24,7 +24,7 @@ greet
 
 .SH DESCRIPTION
 .PP
-app [first\_arg] [second\_arg]
+Description of the application.
 
 .PP
 \fBUsage\fP:
@@ -33,7 +33,7 @@ app [first\_arg] [second\_arg]
 .RS
 
 .nf
-greet [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+app [first\_arg] [second\_arg]
 
 .fi
 .RE

--- a/testdata/expected-doc-full.md
+++ b/testdata/expected-doc-full.md
@@ -16,12 +16,12 @@ greet
 
 # DESCRIPTION
 
-app [first_arg] [second_arg]
+Description of the application.
 
 **Usage**:
 
 ```
-greet [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+app [first_arg] [second_arg]
 ```
 
 # GLOBAL OPTIONS

--- a/testdata/expected-doc-no-authors.md
+++ b/testdata/expected-doc-no-authors.md
@@ -16,12 +16,12 @@ greet
 
 # DESCRIPTION
 
-app [first_arg] [second_arg]
+Description of the application.
 
 **Usage**:
 
 ```
-greet [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+app [first_arg] [second_arg]
 ```
 
 # GLOBAL OPTIONS

--- a/testdata/expected-doc-no-commands.md
+++ b/testdata/expected-doc-no-commands.md
@@ -16,12 +16,12 @@ greet
 
 # DESCRIPTION
 
-app [first_arg] [second_arg]
+Description of the application.
 
 **Usage**:
 
 ```
-greet [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+app [first_arg] [second_arg]
 ```
 
 # GLOBAL OPTIONS

--- a/testdata/expected-doc-no-usagetext.md
+++ b/testdata/expected-doc-no-usagetext.md
@@ -8,6 +8,12 @@ greet - Some app
 
 greet
 
+```
+[--another-flag|-b]
+[--flag|--fl|-f]=[value]
+[--socket|-s]=[value]
+```
+
 # DESCRIPTION
 
 Description of the application.
@@ -15,8 +21,17 @@ Description of the application.
 **Usage**:
 
 ```
-app [first_arg] [second_arg]
+greet [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 ```
+
+# GLOBAL OPTIONS
+
+**--another-flag, -b**: another usage text
+
+**--flag, --fl, -f**="": 
+
+**--socket, -s**="": some 'usage' text (default: value)
+
 
 # COMMANDS
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup  
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

Include both UsageText and Description during doc generation.

## Which issue(s) this PR fixes:

Fixes #1286

## Testing

Included updates and a new unit test.

## Release Notes

```release-note
* Include both App.Description and App.UsageText in generated documentation output.

```
