### PR TITLE
Keep indentation in help/usage text

### DIFF
--- a/help.go
+++ b/help.go
@@ -269,10 +269,11 @@ func ShowCommandCompletions(ctx *Context, command string) {
 // allow using arbitrary functions in template rendering.
 func printHelpCustom(out io.Writer, templ string, data interface{}, customFuncs map[string]interface{}) {
 	funcMap := template.FuncMap{
-		"join":    strings.Join,
-		"indent":  indent,
-		"nindent": nindent,
-		"trim":    strings.TrimSpace,
+		"join":       strings.Join,
+		"indent":     indent,
+		"nindent":    nindent,
+		"trim":       strings.TrimSpace,
+		"replaceAll": strings.ReplaceAll,
 	}
 	for key, value := range customFuncs {
 		funcMap[key] = value

--- a/help_test.go
+++ b/help_test.go
@@ -251,6 +251,29 @@ func TestShowCommandHelp_HelpPrinter(t *testing.T) {
 			wantOutput:   "yo",
 		},
 		{
+			name:         "no-command-full",
+			template:     "",
+			printer:      HelpPrinter,
+			command:      "",
+			wantTemplate: SubcommandHelpTemplate,
+			wantOutput: `NAME:
+   my-app - A new cli application
+
+USAGE:
+   my-app command [command options] [arguments...]
+
+COMMANDS:
+   my-command  lorem ipsum
+     dolor sit
+     amet
+   help, h  Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help (default: false)
+   
+`,
+		},
+		{
 			name:     "standard-command",
 			template: "",
 			printer: func(w io.Writer, templ string, data interface{}) {
@@ -259,6 +282,21 @@ func TestShowCommandHelp_HelpPrinter(t *testing.T) {
 			command:      "my-command",
 			wantTemplate: CommandHelpTemplate,
 			wantOutput:   "yo",
+		},
+		{
+			name:         "standard-command-full",
+			template:     "",
+			printer:      HelpPrinter,
+			command:      "my-command",
+			wantTemplate: CommandHelpTemplate,
+			wantOutput: `NAME:
+   my-app my-command - lorem ipsum
+     dolor sit
+     amet
+
+USAGE:
+   my-app my-command [arguments...]
+`,
 		},
 		{
 			name:     "custom-template-command",
@@ -294,6 +332,7 @@ func TestShowCommandHelp_HelpPrinter(t *testing.T) {
 				Commands: []*Command{
 					{
 						Name:               "my-command",
+						Usage:              "lorem ipsum\ndolor sit\namet",
 						CustomHelpTemplate: tt.template,
 					},
 				},

--- a/template.go
+++ b/template.go
@@ -21,8 +21,8 @@ AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
    {{.Name}}:{{range .VisibleCommands}}
-     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
-   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+     {{join .Names ", "}}{{"\t"}}{{replaceAll .Usage "\n" "\n       "}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{replaceAll .Usage "\n" "\n     "}}{{end}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
 
 GLOBAL OPTIONS:
    {{range $index, $option := .VisibleFlags}}{{if $index}}
@@ -36,7 +36,7 @@ COPYRIGHT:
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
 var CommandHelpTemplate = `NAME:
-   {{.HelpName}} - {{.Usage}}
+   {{.HelpName}} - {{replaceAll .Usage "\n" "\n     "}}
 
 USAGE:
    {{if .UsageText}}{{.UsageText | nindent 3 | trim}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
@@ -66,8 +66,8 @@ DESCRIPTION:
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
    {{.Name}}:{{range .VisibleCommands}}
-     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
-   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+     {{join .Names ", "}}{{"\t"}}{{replaceAll .Usage "\n" "\n       "}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{replaceAll .Usage "\n" "\n     "}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
 
 OPTIONS:
    {{range .VisibleFlags}}{{.}}


### PR DESCRIPTION
Fix issue by adding custom replaceAll function and replacing all newlines by newlines+spaces in command usage description

Some new spaces would align command usage and fulfill user needs

## What type of PR is this?

- bug

## What this PR does / why we need it:

I've added new custom function into the template. I assume this is fine because similar workaround has been introduced for `join` function. I didn't fix indent if user just types in long usage without any newlines and I expect it isn't possible, cause user screen width is unknown

## Which issue(s) this PR fixes:

Fixes #1293

## Testing

Tested by using the test case provided by user, by adding/removing some newlines

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
User may use newlines to correctly align usage section of help.
```
