### PR TITLE
Make test case compatible with Go 1.17

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -476,18 +476,18 @@ func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {
 	a := App{
 		Name: "cmd",
 		Flags: []Flag{
-			&StringFlag{Name: "--foo"},
+			&StringFlag{Name: "foo"},
 		},
 		Writer: bytes.NewBufferString(""),
 	}
 
 	set := flag.NewFlagSet("", flag.ContinueOnError)
-	_ = set.Parse([]string{"", "---foo"})
+	_ = set.Parse([]string{"", "foobar"})
 	c := &Context{flagSet: set}
 
 	err := a.RunAsSubcommand(c)
 
-	expect(t, err, errors.New("bad flag syntax: ---foo"))
+	expect(t, err.Error(), "No help topic for 'foobar'")
 }
 
 func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -482,12 +482,12 @@ func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {
 	}
 
 	set := flag.NewFlagSet("", flag.ContinueOnError)
-	_ = set.Parse([]string{"", "foobar"})
+	_ = set.Parse([]string{"", "-bar"})
 	c := &Context{flagSet: set}
 
 	err := a.RunAsSubcommand(c)
 
-	expect(t, err.Error(), "No help topic for 'foobar'")
+	expect(t, err.Error(), "flag provided but not defined: -bar")
 }
 
 func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {


### PR DESCRIPTION
 As of Go 1.17, the go `flag` package will panic if given a syntactically invalid flag. This causes TestApp_RunAsSubCommandIncorrectUsage to panic and therefore fail. See https://golang.org/doc/go1.17#flag for more information.

## What type of PR is this?

- [x] bug

## What this PR does / why we need it:

*  app_test.go: Rather than using a syntactically invalid flag, use a flag that does not exist. This still tests an incorrect usage, while avoiding the panic() introduced in Go 1.17

## Which issue(s) this PR fixes:

Fixes #1298

## Special notes for your reviewer:

 Ubuntu impish Indri (21.10) will include golang 1.17, and the golang-defaults package will point to Go 1.17. We prefer to remain in sync with upstream, so if you have any suggestions on how to improve this PR we would be happy to hear them.
