### PR TITLE
Support Help Template overrides for Subcommands

### DIFF
--- a/help.go
+++ b/help.go
@@ -189,7 +189,14 @@ func ShowCommandHelpAndExit(c *Context, command string, code int) {
 func ShowCommandHelp(ctx *Context, command string) error {
 	// show the subcommand help for a command with subcommands
 	if command == "" {
-		HelpPrinter(ctx.App.Writer, SubcommandHelpTemplate, ctx.App)
+		// If the command == "", this maybe a subcommand. Check to see if the context
+		// has a non nil *cli.App and if that has a template defined, use it.
+		templ := SubcommandHelpTemplate
+		if ctx.App != nil && ctx.App.CustomAppHelpTemplate != "" {
+			templ = ctx.App.CustomAppHelpTemplate
+		}
+
+		HelpPrinter(ctx.App.Writer, templ, ctx.App)
 		return nil
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

When using the Subcommands, it is currently no possible to override the Subcommand Template that is used due to the Command being overwritten when initializing Context inside of the `RunAsSubcommand` function. I outline everything in #1303. The comment in the code details how I came to the conclusion I came to. Ideally, the Command would not be overridden but set to the Parent Command that houses the Subcommands that are being executed. 

## Which issue(s) this PR fixes:

Fixes #1303

## Special notes for your reviewer:

This is a bandaid at best. I do not expect this PR to be merged. I might update it later with an actual fix, but I just wanted to test my hypothesis, I did that, this works, but ideally, you give Subcommand Context to the `NewContext` Command should the `c.Command` is initialized with the parent command instead of a empty `*cli.Command`

## Release Notes



```release-note
Adds Support for overriding cli.SubcommandHelpTemplate
```
