### PR TITLE
Fix reversed Got/Expected in expectFileContent in docs_test.go

### DIFF
--- a/docs_test.go
+++ b/docs_test.go
@@ -119,13 +119,13 @@ Should be a part of the same code block
 	return app
 }
 
-func expectFileContent(t *testing.T, file, expected string) {
+func expectFileContent(t *testing.T, file, got string) {
 	data, err := ioutil.ReadFile(file)
 	// Ignore windows line endings
 	// TODO: Replace with bytes.ReplaceAll when support for Go 1.11 is dropped
 	data = bytes.Replace(data, []byte("\r\n"), []byte("\n"), -1)
 	expect(t, err, nil)
-	expect(t, string(data), expected)
+	expect(t, got, string(data))
 }
 
 func TestToMarkdownFull(t *testing.T) {


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

To fix reversed Got/Expected in expectFileContent (in docs_test.go).
The bug confused me (as a developer) when bumping github.com/cpuguy83/go-md2man/v2 to v2.0.1 (see PR #1321) and noticed go-md2man generated output ended up in "Expected".

## Which issue(s) this PR fixes:

None

## Testing

I edited testdata/expected-doc-full.man and noticed my change ended up in "Got" instead of "Expected".

I then changed some test cases in app_test.go and convinced myself expect() is OK (Expected/Got not reversed), and eventually confirmed that the bug is in expectFileContent() in docs_test.go.

Finally, after applying this fix, I confirmed that my local change to testdata/expected-doc-full.man would indeed end up in the "Expected" section of TestToMan and TestToManWithSection output.

## Release Notes

```release-note
NONE
```
