### PR TITLE
Bump github.com/cpuguy83/go-md2man/v2 to v2.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.11
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d
+	github.com/cpuguy83/go-md2man/v2 v2.0.1
 	gopkg.in/yaml.v2 v2.2.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,9 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
-github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
-github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.3 h1:fvjTMHxHEw/mxHbtzPi3JCcKXQRAnQTBRo6YCJSVHKI=

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-greet \- Some app
+greet - Some app
 
 
 .SH SYNOPSIS
@@ -14,9 +14,9 @@ greet
 .RS
 
 .nf
-[\-\-another\-flag|\-b]
-[\-\-flag|\-\-fl|\-f]=[value]
-[\-\-socket|\-s]=[value]
+[--another-flag|-b]
+[--flag|--fl|-f]=[value]
+[--socket|-s]=[value]
 
 .fi
 .RE
@@ -33,7 +33,7 @@ Description of the application.
 .RS
 
 .nf
-app [first\_arg] [second\_arg]
+app [first_arg] [second_arg]
 
 .fi
 .RE
@@ -41,13 +41,13 @@ app [first\_arg] [second\_arg]
 
 .SH GLOBAL OPTIONS
 .PP
-\fB\-\-another\-flag, \-b\fP: another usage text
+\fB--another-flag, -b\fP: another usage text
 
 .PP
-\fB\-\-flag, \-\-fl, \-f\fP="":
+\fB--flag, --fl, -f\fP="":
 
 .PP
-\fB\-\-socket, \-s\fP="": some 'usage' text (default: value)
+\fB--socket, -s\fP="": some 'usage' text (default: value)
 
 
 .SH COMMANDS
@@ -56,26 +56,26 @@ app [first\_arg] [second\_arg]
 another usage test
 
 .PP
-\fB\-\-another\-flag, \-b\fP: another usage text
+\fB--another-flag, -b\fP: another usage text
 
 .PP
-\fB\-\-flag, \-\-fl, \-f\fP="":
+\fB--flag, --fl, -f\fP="":
 
-.SS sub\-config, s, ss
+.SS sub-config, s, ss
 .PP
 another usage test
 
 .PP
-\fB\-\-sub\-command\-flag, \-s\fP: some usage text
+\fB--sub-command-flag, -s\fP: some usage text
 
 .PP
-\fB\-\-sub\-flag, \-\-sub\-fl, \-s\fP="":
+\fB--sub-flag, --sub-fl, -s\fP="":
 
 .SH info, i, in
 .PP
 retrieve generic information
 
-.SH some\-command
+.SH some-command
 .SH usage, u
 .PP
 standard usage text
@@ -85,9 +85,9 @@ standard usage text
 
 .nf
 Usage for the usage text
-\- formatted:  Based on the specified ConfigMap and summon secrets.yml
-\- list:       Inspect the environment for a specific process running on a Pod
-\- for\_effect: Compare 'namespace' environment with 'local'
+- formatted:  Based on the specified ConfigMap and summon secrets.yml
+- list:       Inspect the environment for a specific process running on a Pod
+- for_effect: Compare 'namespace' environment with 'local'
 
 ```
 func() { ... }
@@ -99,12 +99,12 @@ Should be a part of the same code block
 .RE
 
 .PP
-\fB\-\-another\-flag, \-b\fP: another usage text
+\fB--another-flag, -b\fP: another usage text
 
 .PP
-\fB\-\-flag, \-\-fl, \-f\fP="":
+\fB--flag, --fl, -f\fP="":
 
-.SS sub\-usage, su
+.SS sub-usage, su
 .PP
 standard usage text
 
@@ -117,4 +117,4 @@ Single line of UsageText
 .RE
 
 .PP
-\fB\-\-sub\-command\-flag, \-s\fP: some usage text
+\fB--sub-command-flag, -s\fP: some usage text


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [x] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

github.com/cpuguy83/go-md2man/v2 v2.0.1 has been released with fixes, especially the following change which affects man page output:

* cpuguy83/go-md2man#74

It is good to bump our dependency on go-md2man to an official release from an old snapshot.  For example, GitHub CLI https://github.com/cli/cl bumped dependency on go-md2man to v2.0.1 back in October 2021.

## Which issue(s) this PR fixes:

None (no filed GitHub issue).

However, this PR fixes build/test error in Debian package golang-github-urfave-cli when built with go-md2man v2.0.1, failing at TestToMan, see:

1. List of recent CI tests (v1): https://ci.debian.net/packages/g/golang-github-urfave-cli/testing/amd64/
    * Failed when rebuilding 1.22.5-2 with go-md2man v2.0.1:
        * https://ci.debian.net/data/autopkgtest/testing/amd64/g/golang-github-urfave-cli/18010703/log.gz
        * (or see the attached [log.gz](https://github.com/urfave/cli/files/7800293/log.gz) if the URL is expired.)
    * Fixed in 1.22.5-3: https://salsa.debian.org/go-team/packages/golang-github-urfave-cli/-/commit/91a12f2d0ea405f1aabc27901dcc1a51333944a9
2. List of recent CI tests (v2): https://ci.debian.net/packages/g/golang-github-urfave-cli-v2/testing/amd64/
    * Failed when rebuilding 2.3.0-1 with go-md2man v2.0.1:
        * https://ci.debian.net/data/autopkgtest/testing/amd64/g/golang-github-urfave-cli-v2/18010704/log.gz
        * (or see the attached [log.gz](https://github.com/urfave/cli/files/7804543/log.gz) if the URL is expired.)
    * Fixed in 2.3.0-2: https://salsa.debian.org/go-team/packages/golang-github-urfave-cli-v2/-/commit/6412d95ff9a24ef5d85802757a8ba6a100b64e7d

## Release Notes

```release-note
Bump github.com/cpuguy83/go-md2man/v2 to v2.0.1
```
