### PR TITLE
Fix strconv.ParseFloat usage

### DIFF
--- a/flag_float64.go
+++ b/flag_float64.go
@@ -67,8 +67,7 @@ func (f *Float64Flag) IsVisible() bool {
 func (f *Float64Flag) Apply(set *flag.FlagSet) error {
 	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
 		if val != "" {
-			valFloat, err := strconv.ParseFloat(val, 10)
-
+			valFloat, err := strconv.ParseFloat(val, 64)
 			if err != nil {
 				return fmt.Errorf("could not parse %q as float64 value for flag %s: %s", val, f.Name, err)
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [x] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

The bitSize argument of ParseFloat should either be 32 or 64, not 10.

Found by staticcheck linter.

## Which issue(s) this PR fixes:

none

## Special notes for your reviewer:

none

## Testing

Should be covered by existing tests, e.g. `TestFloat64Flag*`.

## Release Notes
```release-note
NONE
```
