### PR TITLE
Don't call open("")

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -434,8 +434,10 @@ func flagFromEnvOrFile(envVars []string, filePath string) (val string, ok bool) 
 		}
 	}
 	for _, fileVar := range strings.Split(filePath, ",") {
-		if data, err := ioutil.ReadFile(fileVar); err == nil {
-			return string(data), true
+		if fileVar != "" {
+			if data, err := ioutil.ReadFile(fileVar); err == nil {
+				return string(data), true
+			}
 		}
 	}
 	return "", false


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup  
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

`strings.Split(s, sep)` returns a slice of a single element containing s
if sep is not found in s. This is true even if s is empty.

As a result, every call to flagFromEnvOrFile results in an attempt to
open a file with empty name. This is seen from strace as
```
[pid 3287620] openat(AT_FDCWD, "", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
[pid 3287620] openat(AT_FDCWD, "", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
...
```
To fix, check if the string is empty before calling ReadFile.

This also fixes cases where filePath is non-empty but has extra commas.

## Which issue(s) this PR fixes:

none

## Special notes for your reviewer:

none

## Testing

Due to the obvious nature of the fix, no additional testing is required.

## Release Notes

```release-note
Fix calling open(2) with empty file name.
```
