### PR TITLE
Exclude hidden sub-command flags from docs

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -80,14 +80,14 @@ func prepareCommands(commands []*Command, level int) []string {
 			usageText,
 		)
 
-		flags := prepareArgsWithValues(command.Flags)
+		flags := prepareArgsWithValues(command.VisibleFlags())
 		if len(flags) > 0 {
 			prepared += fmt.Sprintf("\n%s", strings.Join(flags, "\n"))
 		}
 
 		coms = append(coms, prepared)
 
-		// recursevly iterate subcommands
+		// recursively iterate subcommands
 		if len(command.Subcommands) > 0 {
 			coms = append(
 				coms,

--- a/docs_test.go
+++ b/docs_test.go
@@ -103,6 +103,11 @@ Should be a part of the same code block
 					Aliases: []string{"s"},
 					Usage:   "some usage text",
 				},
+				&StringFlag{
+					Name:   "sub-command-hidden-flag",
+					Usage:  "some hidden usage text",
+					Hidden: true,
+				},
 			},
 			Name:      "sub-usage",
 			Usage:     "standard usage text",

--- a/fish.go
+++ b/fish.go
@@ -95,7 +95,7 @@ func (a *App) prepareFishCommands(commands []*Command, allCommands *[]string, pr
 		completions = append(completions, completion.String())
 		completions = append(
 			completions,
-			a.prepareFishFlags(command.Flags, command.Names())...,
+			a.prepareFishFlags(command.VisibleFlags(), command.Names())...,
 		)
 
 		// recursevly iterate subcommands


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Not sure I would hard-classify this as a "bug" per-se, but it expands on #999 by also excluding flags marked as `hidden` in sub-commands for docs generation.

## Which issue(s) this PR fixes:

Expands upon #999 

## Testing

I've changed `docs_test.go` and `go test ./...` passes.

## Release Notes

```release-note
NONE
```
