### PR TITLE
Add Stale bot configuration per docs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 365
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 90
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
## What type of PR is this?

- 🔲  bug
- ❌  cleanup  
- 🔲  documentation
- 🔲  feature

## What this PR does / why we need it:

This PR adds a "Stale" bot configuration per integration docs with (greatly) extended values for `daysUntilStale` and `daysUntilClose` per suggestion elsewhere.

I fully admit that this may not be the right place to codify this decision, but it's the solution that seemed attainable to me after looking around repository settings.

## Which issue(s) this PR fixes:

N/A (?) Fewer issues/PRs closed due to "staleness", which IIUC is desirable.