### PR TITLE
Drop references/usage of GO111MODULE

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Set GOPATH, PATH and ENV
         run: |
           echo "GOPATH=$(dirname $GITHUB_WORKSPACE)" >> $GITHUB_ENV
-          echo "GO111MODULE=on" >> $GITHUB_ENV
           echo "GOPROXY=https://proxy.golang.org" >> $GITHUB_ENV
           echo "$(dirname $GITHUB_WORKSPACE)/bin" >> $GITHUB_PATH
         shell: bash
@@ -74,7 +73,6 @@ jobs:
       - name: Set GOPATH, PATH and ENV
         run: |
           echo "GOPATH=$(dirname $GITHUB_WORKSPACE)" >> $GITHUB_ENV
-          echo "GO111MODULE=on" >> $GITHUB_ENV
           echo "GOPROXY=https://proxy.golang.org" >> $GITHUB_ENV
           echo "$(dirname $GITHUB_WORKSPACE)/bin" >> $GITHUB_PATH
         shell: bash

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Go Modules are required when using this package. [See the go blog guide on using
 ### Using `v2` releases
 
 ```
-$ GO111MODULE=on go get github.com/urfave/cli/v2
+$ go get github.com/urfave/cli/v2
 ```
 
 ```go
@@ -44,7 +44,7 @@ import (
 ### Using `v1` releases
 
 ```
-$ GO111MODULE=on go get github.com/urfave/cli
+$ go get github.com/urfave/cli
 ```
 
 ```go


### PR DESCRIPTION
## What type of PR is this?

- 🔲  bug
- ❌  cleanup  
- 🔲  documentation
- 🔲  feature

## What this PR does / why we need it:

Drop the references to and usage of `GO111MODULE` given currently-targeted Go versions are well past that awkward chapter in Go history.

## Which issue(s) this PR fixes:

N/A 😬 