### PR TITLE
Switch branch references from `master` to `main`

### DIFF
--- a/.github/ISSUE_TEMPLATE/v1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/v1-bug-report.md
@@ -14,7 +14,7 @@ _**( Put the version of urfave/cli that you are using here )**_
 ## Checklist
 
 - [ ] Are you running the latest v1 release? The list of releases is [here](https://github.com/urfave/cli/releases).
-- [ ] Did you check the manual for your release? The v1 manual is [here](https://github.com/urfave/cli/blob/master/docs/v1/manual.md).
+- [ ] Did you check the manual for your release? The v1 manual is [here](https://github.com/urfave/cli/blob/main/docs/v1/manual.md).
 - [ ] Did you perform a search about this problem? Here's the [Github guide](https://help.github.com/en/github/managing-your-work-on-github/using-search-to-filter-issues-and-pull-requests) about searching.
 
 ## Dependency Management

--- a/.github/ISSUE_TEMPLATE/v2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/v2-bug-report.md
@@ -14,7 +14,7 @@ _**( Put the version of urfave/cli that you are using here )**_
 ## Checklist
 
 - [ ] Are you running the latest v2 release? The list of releases is [here](https://github.com/urfave/cli/releases).
-- [ ] Did you check the manual for your release? The v2 manual is [here](https://github.com/urfave/cli/blob/master/docs/v2/manual.md)
+- [ ] Did you check the manual for your release? The v2 manual is [here](https://github.com/urfave/cli/blob/main/docs/v2/manual.md)
 - [ ] Did you perform a search about this problem? Here's the [Github guide](https://help.github.com/en/github/managing-your-work-on-github/using-search-to-filter-issues-and-pull-requests) about searching.
 
 ## Dependency Management

--- a/.github/ISSUE_TEMPLATE/v2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/v2-feature-request.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Checklist
 
 * [ ] Are you running the latest v2 release? The list of releases is [here](https://github.com/urfave/cli/releases).
-* [ ] Did you check the manual for your release? The v2 manual is [here](https://github.com/urfave/cli/blob/master/docs/v2/manual.md).
+* [ ] Did you check the manual for your release? The v2 manual is [here](https://github.com/urfave/cli/blob/main/docs/v2/manual.md).
 * [ ] Did you perform a search about this feature? Here's the [Github guide](https://help.github.com/en/github/managing-your-work-on-github/using-search-to-filter-issues-and-pull-requests) about searching.
 
 ## What problem does this solve?

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -3,12 +3,12 @@ name: Run Tests
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v2.*
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ cli
 [![GoDoc](https://godoc.org/github.com/urfave/cli?status.svg)](https://pkg.go.dev/github.com/urfave/cli/v2)
 [![codebeat](https://codebeat.co/badges/0a8f30aa-f975-404b-b878-5fab3ae1cc5f)](https://codebeat.co/projects/github-com-urfave-cli)
 [![Go Report Card](https://goreportcard.com/badge/urfave/cli)](https://goreportcard.com/report/urfave/cli)
-[![codecov](https://codecov.io/gh/urfave/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/urfave/cli)
+[![codecov](https://codecov.io/gh/urfave/cli/branch/main/graph/badge.svg)](https://codecov.io/gh/urfave/cli)
 
 cli is a simple, fast, and fun package for building command line apps in Go. The
 goal is to enable developers to write fast and distributable command line
@@ -12,7 +12,7 @@ applications in an expressive way.
 
 ## Usage Documentation
 
-Usage documentation exists for each major version. Don't know what version you're on? You're probably using the version from the `master` branch, which is currently `v2`.
+Usage documentation exists for each major version. Don't know what version you're on? You're probably using the version from the `main` branch, which is currently `v2`.
 
 - `v2` - [./docs/v2/manual.md](./docs/v2/manual.md)
 - `v1` - [./docs/v1/manual.md](./docs/v1/manual.md)
@@ -67,4 +67,4 @@ export PATH=$PATH:$GOPATH/bin
 
 cli is tested against multiple versions of Go on Linux, and against the latest
 released version of Go on OS X and Windows. This project uses Github Actions for
-builds. To see our currently supported go versions and platforms, look at the [./.github/workflows/cli.yml](https://github.com/urfave/cli/blob/master/.github/workflows/cli.yml).
+builds. To see our currently supported go versions and platforms, look at the [./.github/workflows/cli.yml](https://github.com/urfave/cli/blob/main/.github/workflows/cli.yml).

--- a/app.go
+++ b/app.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	changeLogURL            = "https://github.com/urfave/cli/blob/master/docs/CHANGELOG.md"
+	changeLogURL            = "https://github.com/urfave/cli/blob/main/docs/CHANGELOG.md"
 	appActionDeprecationURL = fmt.Sprintf("%s#deprecated-cli-app-action-signature", changeLogURL)
 	contactSysadmin         = "This is an error in the application.  Please contact the distributor of this application if this is not you."
 	errInvalidActionType    = NewExitError("ERROR invalid Action type. "+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Feel free to put up a pull request to fix a bug or maybe add a feature. We will
 give it a code review and make sure that it does not break backwards
 compatibility. If collaborators agree that it is in line with
 the vision of the project, we will work with you to get the code into
-a mergeable state and merge it into the master branch.
+a mergeable state and merge it into the main branch.
 
 If you have contributed something significant to the project, we will most
 likely add you as a collaborator. As a collaborator you are given the ability


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Supports switching from `master` to `main` as primary ("trunk") line of development.

## Which issue(s) this PR fixes:

Connected to #1349 but action will also be needed outside of a pull request context to finish the job.

```release-note
NONE
```
