### PR TITLE
Make `ToMarkdown` and `ToMan` optional

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -1,3 +1,6 @@
+//go:build cli_docs
+// +build cli_docs
+
 package cli
 
 import (
@@ -13,6 +16,8 @@ import (
 
 // ToMarkdown creates a markdown string for the `*App`
 // The function errors if either parsing or writing of the string fails.
+//
+// To use this functionality, you need to have cli_docs build flag set.
 func (a *App) ToMarkdown() (string, error) {
 	var w bytes.Buffer
 	if err := a.writeDocTemplate(&w); err != nil {
@@ -23,6 +28,8 @@ func (a *App) ToMarkdown() (string, error) {
 
 // ToMan creates a man page string for the `*App`
 // The function errors if either parsing or writing of the string fails.
+//
+// To use this functionality, you need to have cli_docs build flag set.
 func (a *App) ToMan() (string, error) {
 	var w bytes.Buffer
 	if err := a.writeDocTemplate(&w); err != nil {

--- a/docs_test.go
+++ b/docs_test.go
@@ -1,3 +1,6 @@
+//go:build cli_docs
+// +build cli_docs
+
 package cli
 
 import (


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Their functionality is not always used, and it brings in quite a big
dependency (russross/blackfriday).

Amend the documentation to make it clear that cli_docs build tag is
needed to use these functions.

This reduces runc size by about 318 Kb, or 3.4% (comparing stripped
binaries).

## Which issue(s) this PR fixes:

none

## Special notes for your reviewer:

none

## Testing

## Release Notes

```release-note
Compatibility: if you are using `ToMan` or `ToMarkdown` methods, from now on
you need to add `cli_docs` build tag for your app.
```
