### PR TITLE
Unshadow `context` package

### DIFF
--- a/altsrc/flag.go
+++ b/altsrc/flag.go
@@ -13,18 +13,18 @@ import (
 // allows a value to be set on the existing parsed flags.
 type FlagInputSourceExtension interface {
 	cli.Flag
-	ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error
+	ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
 }
 
 // ApplyInputSourceValues iterates over all provided flags and
 // executes ApplyInputSourceValue on flags implementing the
 // FlagInputSourceExtension interface to initialize these flags
 // to an alternate input source.
-func ApplyInputSourceValues(context *cli.Context, inputSourceContext InputSourceContext, flags []cli.Flag) error {
+func ApplyInputSourceValues(cCtx *cli.Context, inputSourceContext InputSourceContext, flags []cli.Flag) error {
 	for _, f := range flags {
 		inputSourceExtendedFlag, isType := f.(FlagInputSourceExtension)
 		if isType {
-			err := inputSourceExtendedFlag.ApplyInputSourceValue(context, inputSourceContext)
+			err := inputSourceExtendedFlag.ApplyInputSourceValue(cCtx, inputSourceContext)
 			if err != nil {
 				return err
 			}
@@ -38,34 +38,34 @@ func ApplyInputSourceValues(context *cli.Context, inputSourceContext InputSource
 // input source based on the func provided. If there is no error it will then apply the new input source to any flags
 // that are supported by the input source
 func InitInputSource(flags []cli.Flag, createInputSource func() (InputSourceContext, error)) cli.BeforeFunc {
-	return func(context *cli.Context) error {
+	return func(cCtx *cli.Context) error {
 		inputSource, err := createInputSource()
 		if err != nil {
 			return fmt.Errorf("Unable to create input source: inner error: \n'%v'", err.Error())
 		}
 
-		return ApplyInputSourceValues(context, inputSource, flags)
+		return ApplyInputSourceValues(cCtx, inputSource, flags)
 	}
 }
 
 // InitInputSourceWithContext is used to to setup an InputSourceContext on a cli.Command Before method. It will create a new
 // input source based on the func provided with potentially using existing cli.Context values to initialize itself. If there is
 // no error it will then apply the new input source to any flags that are supported by the input source
-func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(context *cli.Context) (InputSourceContext, error)) cli.BeforeFunc {
-	return func(context *cli.Context) error {
-		inputSource, err := createInputSource(context)
+func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(cCtx *cli.Context) (InputSourceContext, error)) cli.BeforeFunc {
+	return func(cCtx *cli.Context) error {
+		inputSource, err := createInputSource(cCtx)
 		if err != nil {
 			return fmt.Errorf("Unable to create input source with context: inner error: \n'%v'", err.Error())
 		}
 
-		return ApplyInputSourceValues(context, inputSource, flags)
+		return ApplyInputSourceValues(cCtx, inputSource, flags)
 	}
 }
 
 // ApplyInputSourceValue applies a generic value to the flagSet if required
-func (f *GenericFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *GenericFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
-		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
+		if !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
 			value, err := isc.Generic(f.GenericFlag.Name)
 			if err != nil {
 				return err
@@ -82,9 +82,9 @@ func (f *GenericFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourc
 }
 
 // ApplyInputSourceValue applies a StringSlice value to the flagSet if required
-func (f *StringSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *StringSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
-		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
+		if !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
 			value, err := isc.StringSlice(f.StringSliceFlag.Name)
 			if err != nil {
 				return err
@@ -104,9 +104,9 @@ func (f *StringSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputS
 }
 
 // ApplyInputSourceValue applies a IntSlice value if required
-func (f *IntSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *IntSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
-		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
+		if !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
 			value, err := isc.IntSlice(f.IntSliceFlag.Name)
 			if err != nil {
 				return err
@@ -126,9 +126,9 @@ func (f *IntSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputSour
 }
 
 // ApplyInputSourceValue applies a Bool value to the flagSet if required
-func (f *BoolFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *BoolFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
-		if !context.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
+		if !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
 			value, err := isc.Bool(f.BoolFlag.Name)
 			if err != nil {
 				return err
@@ -144,9 +144,9 @@ func (f *BoolFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceCo
 }
 
 // ApplyInputSourceValue applies a String value to the flagSet if required
-func (f *StringFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *StringFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
-		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
+		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.String(f.StringFlag.Name)
 			if err != nil {
 				return err
@@ -162,9 +162,9 @@ func (f *StringFlag) ApplyInputSourceValue(context *cli.Context, isc InputSource
 }
 
 // ApplyInputSourceValue applies a Path value to the flagSet if required
-func (f *PathFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *PathFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
-		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
+		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.String(f.PathFlag.Name)
 			if err != nil {
 				return err
@@ -190,9 +190,9 @@ func (f *PathFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceCo
 }
 
 // ApplyInputSourceValue applies a int value to the flagSet if required
-func (f *IntFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *IntFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
-		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
+		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.Int(f.IntFlag.Name)
 			if err != nil {
 				return err
@@ -208,9 +208,9 @@ func (f *IntFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceCon
 }
 
 // ApplyInputSourceValue applies a Duration value to the flagSet if required
-func (f *DurationFlag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *DurationFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
-		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
+		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.Duration(f.DurationFlag.Name)
 			if err != nil {
 				return err
@@ -226,9 +226,9 @@ func (f *DurationFlag) ApplyInputSourceValue(context *cli.Context, isc InputSour
 }
 
 // ApplyInputSourceValue applies a Float64 value to the flagSet if required
-func (f *Float64Flag) ApplyInputSourceValue(context *cli.Context, isc InputSourceContext) error {
+func (f *Float64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
 	if f.set != nil {
-		if !(context.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
+		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
 			value, err := isc.Float64(f.Float64Flag.Name)
 			if err != nil {
 				return err

--- a/altsrc/json_source_context.go
+++ b/altsrc/json_source_context.go
@@ -16,9 +16,9 @@ import (
 // variables from a file containing JSON data with the file name defined
 // by the given flag.
 func NewJSONSourceFromFlagFunc(flag string) func(c *cli.Context) (InputSourceContext, error) {
-	return func(context *cli.Context) (InputSourceContext, error) {
-		if context.IsSet(flag) {
-			return NewJSONSourceFromFile(context.String(flag))
+	return func(cCtx *cli.Context) (InputSourceContext, error) {
+		if cCtx.IsSet(flag) {
+			return NewJSONSourceFromFile(cCtx.String(flag))
 		}
 
 		return defaultInputSource()

--- a/altsrc/toml_file_loader.go
+++ b/altsrc/toml_file_loader.go
@@ -85,10 +85,10 @@ func NewTomlSourceFromFile(file string) (InputSourceContext, error) {
 }
 
 // NewTomlSourceFromFlagFunc creates a new TOML InputSourceContext from a provided flag name and source context.
-func NewTomlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (InputSourceContext, error) {
-	return func(context *cli.Context) (InputSourceContext, error) {
-		if context.IsSet(flagFileName) {
-			filePath := context.String(flagFileName)
+func NewTomlSourceFromFlagFunc(flagFileName string) func(cCtx *cli.Context) (InputSourceContext, error) {
+	return func(cCtx *cli.Context) (InputSourceContext, error) {
+		if cCtx.IsSet(flagFileName) {
+			filePath := cCtx.String(flagFileName)
 			return NewTomlSourceFromFile(filePath)
 		}
 

--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -31,10 +31,10 @@ func NewYamlSourceFromFile(file string) (InputSourceContext, error) {
 }
 
 // NewYamlSourceFromFlagFunc creates a new Yaml InputSourceContext from a provided flag name and source context.
-func NewYamlSourceFromFlagFunc(flagFileName string) func(context *cli.Context) (InputSourceContext, error) {
-	return func(context *cli.Context) (InputSourceContext, error) {
-		if context.IsSet(flagFileName) {
-			filePath := context.String(flagFileName)
+func NewYamlSourceFromFlagFunc(flagFileName string) func(cCtx *cli.Context) (InputSourceContext, error) {
+	return func(cCtx *cli.Context) (InputSourceContext, error) {
+		if cCtx.IsSet(flagFileName) {
+			filePath := cCtx.String(flagFileName)
 			return NewYamlSourceFromFile(filePath)
 		}
 

--- a/app_test.go
+++ b/app_test.go
@@ -445,14 +445,14 @@ func TestApp_Setup_defaultsWriter(t *testing.T) {
 }
 
 func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
-	var context *Context
+	var cCtx *Context
 
 	a := &App{
 		Commands: []*Command{
 			{
 				Name: "foo",
 				Action: func(c *Context) error {
-					context = c
+					cCtx = c
 					return nil
 				},
 				Flags: []Flag{
@@ -468,8 +468,8 @@ func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
 	}
 	_ = a.Run([]string{"", "foo", "--lang", "spanish", "abcd"})
 
-	expect(t, context.Args().Get(0), "abcd")
-	expect(t, context.String("lang"), "spanish")
+	expect(t, cCtx.Args().Get(0), "abcd")
+	expect(t, cCtx.String("lang"), "spanish")
 }
 
 func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {

--- a/command.go
+++ b/command.go
@@ -105,39 +105,39 @@ func (c *Command) Run(ctx *Context) (err error) {
 
 	set, err := c.parseFlags(ctx.Args(), ctx.shellComplete)
 
-	context := NewContext(ctx.App, set, ctx)
-	context.Command = c
-	if checkCommandCompletions(context, c.Name) {
+	cCtx := NewContext(ctx.App, set, ctx)
+	cCtx.Command = c
+	if checkCommandCompletions(cCtx, c.Name) {
 		return nil
 	}
 
 	if err != nil {
 		if c.OnUsageError != nil {
-			err = c.OnUsageError(context, err, false)
-			context.App.handleExitCoder(context, err)
+			err = c.OnUsageError(cCtx, err, false)
+			cCtx.App.handleExitCoder(cCtx, err)
 			return err
 		}
-		_, _ = fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
-		_, _ = fmt.Fprintln(context.App.Writer)
-		_ = ShowCommandHelp(context, c.Name)
+		_, _ = fmt.Fprintln(cCtx.App.Writer, "Incorrect Usage:", err.Error())
+		_, _ = fmt.Fprintln(cCtx.App.Writer)
+		_ = ShowCommandHelp(cCtx, c.Name)
 		return err
 	}
 
-	if checkCommandHelp(context, c.Name) {
+	if checkCommandHelp(cCtx, c.Name) {
 		return nil
 	}
 
-	cerr := context.checkRequiredFlags(c.Flags)
+	cerr := cCtx.checkRequiredFlags(c.Flags)
 	if cerr != nil {
-		_ = ShowCommandHelp(context, c.Name)
+		_ = ShowCommandHelp(cCtx, c.Name)
 		return cerr
 	}
 
 	if c.After != nil {
 		defer func() {
-			afterErr := c.After(context)
+			afterErr := c.After(cCtx)
 			if afterErr != nil {
-				context.App.handleExitCoder(context, err)
+				cCtx.App.handleExitCoder(cCtx, err)
 				if err != nil {
 					err = newMultiError(err, afterErr)
 				} else {
@@ -148,9 +148,9 @@ func (c *Command) Run(ctx *Context) (err error) {
 	}
 
 	if c.Before != nil {
-		err = c.Before(context)
+		err = c.Before(cCtx)
 		if err != nil {
-			context.App.handleExitCoder(context, err)
+			cCtx.App.handleExitCoder(cCtx, err)
 			return err
 		}
 	}
@@ -159,11 +159,11 @@ func (c *Command) Run(ctx *Context) (err error) {
 		c.Action = helpSubcommand.Action
 	}
 
-	context.Command = c
-	err = c.Action(context)
+	cCtx.Command = c
+	err = c.Action(cCtx)
 
 	if err != nil {
-		context.App.handleExitCoder(context, err)
+		cCtx.App.handleExitCoder(cCtx, err)
 	}
 	return err
 }

--- a/command_test.go
+++ b/command_test.go
@@ -30,7 +30,7 @@ func TestCommandFlagParsing(t *testing.T) {
 		set := flag.NewFlagSet("test", 0)
 		_ = set.Parse(c.testArgs)
 
-		context := NewContext(app, set, nil)
+		cCtx := NewContext(app, set, nil)
 
 		command := Command{
 			Name:            "test-cmd",
@@ -41,10 +41,10 @@ func TestCommandFlagParsing(t *testing.T) {
 			SkipFlagParsing: c.skipFlagParsing,
 		}
 
-		err := command.Run(context)
+		err := command.Run(cCtx)
 
 		expect(t, err, c.expectedErr)
-		expect(t, context.Args().Slice(), c.testArgs)
+		expect(t, cCtx.Args().Slice(), c.testArgs)
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -40,18 +40,18 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
 }
 
 // NumFlags returns the number of flags set
-func (c *Context) NumFlags() int {
-	return c.flagSet.NFlag()
+func (cCtx *Context) NumFlags() int {
+	return cCtx.flagSet.NFlag()
 }
 
 // Set sets a context flag to a value.
-func (c *Context) Set(name, value string) error {
-	return c.flagSet.Set(name, value)
+func (cCtx *Context) Set(name, value string) error {
+	return cCtx.flagSet.Set(name, value)
 }
 
 // IsSet determines if the flag was actually set
-func (c *Context) IsSet(name string) bool {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) IsSet(name string) bool {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		isSet := false
 		fs.Visit(func(f *flag.Flag) {
 			if f.Name == name {
@@ -62,7 +62,7 @@ func (c *Context) IsSet(name string) bool {
 			return true
 		}
 
-		f := c.lookupFlag(name)
+		f := cCtx.lookupFlag(name)
 		if f == nil {
 			return false
 		}
@@ -74,28 +74,28 @@ func (c *Context) IsSet(name string) bool {
 }
 
 // LocalFlagNames returns a slice of flag names used in this context.
-func (c *Context) LocalFlagNames() []string {
+func (cCtx *Context) LocalFlagNames() []string {
 	var names []string
-	c.flagSet.Visit(makeFlagNameVisitor(&names))
+	cCtx.flagSet.Visit(makeFlagNameVisitor(&names))
 	return names
 }
 
 // FlagNames returns a slice of flag names used by the this context and all of
 // its parent contexts.
-func (c *Context) FlagNames() []string {
+func (cCtx *Context) FlagNames() []string {
 	var names []string
-	for _, ctx := range c.Lineage() {
-		ctx.flagSet.Visit(makeFlagNameVisitor(&names))
+	for _, pCtx := range cCtx.Lineage() {
+		pCtx.flagSet.Visit(makeFlagNameVisitor(&names))
 	}
 	return names
 }
 
 // Lineage returns *this* context and all of its ancestor contexts in order from
 // child to parent
-func (c *Context) Lineage() []*Context {
+func (cCtx *Context) Lineage() []*Context {
 	var lineage []*Context
 
-	for cur := c; cur != nil; cur = cur.parentContext {
+	for cur := cCtx; cur != nil; cur = cur.parentContext {
 		lineage = append(lineage, cur)
 	}
 
@@ -103,26 +103,26 @@ func (c *Context) Lineage() []*Context {
 }
 
 // Value returns the value of the flag corresponding to `name`
-func (c *Context) Value(name string) interface{} {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Value(name string) interface{} {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return fs.Lookup(name).Value.(flag.Getter).Get()
 	}
 	return nil
 }
 
 // Args returns the command line arguments associated with the context.
-func (c *Context) Args() Args {
-	ret := args(c.flagSet.Args())
+func (cCtx *Context) Args() Args {
+	ret := args(cCtx.flagSet.Args())
 	return &ret
 }
 
 // NArg returns the number of the command line arguments.
-func (c *Context) NArg() int {
-	return c.Args().Len()
+func (cCtx *Context) NArg() int {
+	return cCtx.Args().Len()
 }
 
-func (ctx *Context) lookupFlag(name string) Flag {
-	for _, c := range ctx.Lineage() {
+func (cCtx *Context) lookupFlag(name string) Flag {
+	for _, c := range cCtx.Lineage() {
 		if c.Command == nil {
 			continue
 		}
@@ -136,8 +136,8 @@ func (ctx *Context) lookupFlag(name string) Flag {
 		}
 	}
 
-	if ctx.App != nil {
-		for _, f := range ctx.App.Flags {
+	if cCtx.App != nil {
+		for _, f := range cCtx.App.Flags {
 			for _, n := range f.Names() {
 				if n == name {
 					return f
@@ -149,8 +149,8 @@ func (ctx *Context) lookupFlag(name string) Flag {
 	return nil
 }
 
-func (ctx *Context) lookupFlagSet(name string) *flag.FlagSet {
-	for _, c := range ctx.Lineage() {
+func (cCtx *Context) lookupFlagSet(name string) *flag.FlagSet {
+	for _, c := range cCtx.Lineage() {
 		if c.flagSet == nil {
 			continue
 		}
@@ -162,7 +162,7 @@ func (ctx *Context) lookupFlagSet(name string) *flag.FlagSet {
 	return nil
 }
 
-func (context *Context) checkRequiredFlags(flags []Flag) requiredFlagsErr {
+func (cCtx *Context) checkRequiredFlags(flags []Flag) requiredFlagsErr {
 	var missingFlags []string
 	for _, f := range flags {
 		if rf, ok := f.(RequiredFlag); ok && rf.IsRequired() {
@@ -174,7 +174,7 @@ func (context *Context) checkRequiredFlags(flags []Flag) requiredFlagsErr {
 					flagName = key
 				}
 
-				if context.IsSet(strings.TrimSpace(key)) {
+				if cCtx.IsSet(strings.TrimSpace(key)) {
 					flagPresent = true
 				}
 			}

--- a/flag_bool.go
+++ b/flag_bool.go
@@ -104,8 +104,8 @@ func (f *BoolFlag) Apply(set *flag.FlagSet) error {
 
 // Bool looks up the value of a local BoolFlag, returns
 // false if not found
-func (c *Context) Bool(name string) bool {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Bool(name string) bool {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupBool(name, fs)
 	}
 	return false

--- a/flag_duration.go
+++ b/flag_duration.go
@@ -103,8 +103,8 @@ func (f *DurationFlag) Apply(set *flag.FlagSet) error {
 
 // Duration looks up the value of a local DurationFlag, returns
 // 0 if not found
-func (c *Context) Duration(name string) time.Duration {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Duration(name string) time.Duration {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupDuration(name, fs)
 	}
 	return 0

--- a/flag_float64.go
+++ b/flag_float64.go
@@ -103,8 +103,8 @@ func (f *Float64Flag) Apply(set *flag.FlagSet) error {
 
 // Float64 looks up the value of a local Float64Flag, returns
 // 0 if not found
-func (c *Context) Float64(name string) float64 {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Float64(name string) float64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupFloat64(name, fs)
 	}
 	return 0

--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -177,8 +177,8 @@ func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error {
 
 // Float64Slice looks up the value of a local Float64SliceFlag, returns
 // nil if not found
-func (c *Context) Float64Slice(name string) []float64 {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Float64Slice(name string) []float64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupFloat64Slice(name, fs)
 	}
 	return nil

--- a/flag_generic.go
+++ b/flag_generic.go
@@ -106,8 +106,8 @@ func (f GenericFlag) Apply(set *flag.FlagSet) error {
 
 // Generic looks up the value of a local GenericFlag, returns
 // nil if not found
-func (c *Context) Generic(name string) interface{} {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Generic(name string) interface{} {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupGeneric(name, fs)
 	}
 	return nil

--- a/flag_int.go
+++ b/flag_int.go
@@ -104,8 +104,8 @@ func (f *IntFlag) Apply(set *flag.FlagSet) error {
 
 // Int looks up the value of a local IntFlag, returns
 // 0 if not found
-func (c *Context) Int(name string) int {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Int(name string) int {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupInt(name, fs)
 	}
 	return 0

--- a/flag_int64.go
+++ b/flag_int64.go
@@ -103,8 +103,8 @@ func (f *Int64Flag) Apply(set *flag.FlagSet) error {
 
 // Int64 looks up the value of a local Int64Flag, returns
 // 0 if not found
-func (c *Context) Int64(name string) int64 {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Int64(name string) int64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupInt64(name, fs)
 	}
 	return 0

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -176,8 +176,8 @@ func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error {
 
 // Int64Slice looks up the value of a local Int64SliceFlag, returns
 // nil if not found
-func (c *Context) Int64Slice(name string) []int64 {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Int64Slice(name string) []int64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupInt64Slice(name, fs)
 	}
 	return nil

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -187,8 +187,8 @@ func (f *IntSliceFlag) Apply(set *flag.FlagSet) error {
 
 // IntSlice looks up the value of a local IntSliceFlag, returns
 // nil if not found
-func (c *Context) IntSlice(name string) []int {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) IntSlice(name string) []int {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupIntSlice(name, fs)
 	}
 	return nil

--- a/flag_path.go
+++ b/flag_path.go
@@ -98,8 +98,8 @@ func (f *PathFlag) Apply(set *flag.FlagSet) error {
 
 // Path looks up the value of a local PathFlag, returns
 // "" if not found
-func (c *Context) Path(name string) string {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Path(name string) string {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupPath(name, fs)
 	}
 

--- a/flag_string.go
+++ b/flag_string.go
@@ -99,8 +99,8 @@ func (f *StringFlag) Apply(set *flag.FlagSet) error {
 
 // String looks up the value of a local StringFlag, returns
 // "" if not found
-func (c *Context) String(name string) string {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) String(name string) string {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupString(name, fs)
 	}
 	return ""

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -188,8 +188,8 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 
 // StringSlice looks up the value of a local StringSliceFlag, returns
 // nil if not found
-func (c *Context) StringSlice(name string) []string {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) StringSlice(name string) []string {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupStringSlice(name, fs)
 	}
 	return nil

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -165,8 +165,8 @@ func (f *TimestampFlag) Apply(set *flag.FlagSet) error {
 }
 
 // Timestamp gets the timestamp from a flag name
-func (c *Context) Timestamp(name string) *time.Time {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Timestamp(name string) *time.Time {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupTimestamp(name, fs)
 	}
 	return nil

--- a/flag_uint.go
+++ b/flag_uint.go
@@ -103,8 +103,8 @@ func (f *UintFlag) GetEnvVars() []string {
 
 // Uint looks up the value of a local UintFlag, returns
 // 0 if not found
-func (c *Context) Uint(name string) uint {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Uint(name string) uint {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupUint(name, fs)
 	}
 	return 0

--- a/flag_uint64.go
+++ b/flag_uint64.go
@@ -103,8 +103,8 @@ func (f *Uint64Flag) GetEnvVars() []string {
 
 // Uint64 looks up the value of a local Uint64Flag, returns
 // 0 if not found
-func (c *Context) Uint64(name string) uint64 {
-	if fs := c.lookupFlagSet(name); fs != nil {
+func (cCtx *Context) Uint64(name string) uint64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupUint64(name, fs)
 	}
 	return 0

--- a/funcs.go
+++ b/funcs.go
@@ -21,11 +21,11 @@ type CommandNotFoundFunc func(*Context, string)
 // customized usage error messages.  This function is able to replace the
 // original error messages.  If this function is not set, the "Incorrect usage"
 // is displayed and the execution is interrupted.
-type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
+type OnUsageErrorFunc func(cCtx *Context, err error, isSubcommand bool) error
 
 // ExitErrHandlerFunc is executed if provided in order to handle exitError values
 // returned by Actions and Before/After functions.
-type ExitErrHandlerFunc func(context *Context, err error)
+type ExitErrHandlerFunc func(cCtx *Context, err error)
 
 // FlagStringFunc is used by the help generation to display a flag, which is
 // expected to be a single line.

--- a/help.go
+++ b/help.go
@@ -15,13 +15,13 @@ var helpCommand = &Command{
 	Aliases:   []string{"h"},
 	Usage:     "Shows a list of commands or help for one command",
 	ArgsUsage: "[command]",
-	Action: func(c *Context) error {
-		args := c.Args()
+	Action: func(cCtx *Context) error {
+		args := cCtx.Args()
 		if args.Present() {
-			return ShowCommandHelp(c, args.First())
+			return ShowCommandHelp(cCtx, args.First())
 		}
 
-		_ = ShowAppHelp(c)
+		_ = ShowAppHelp(cCtx)
 		return nil
 	},
 }
@@ -31,13 +31,13 @@ var helpSubcommand = &Command{
 	Aliases:   []string{"h"},
 	Usage:     "Shows a list of commands or help for one command",
 	ArgsUsage: "[command]",
-	Action: func(c *Context) error {
-		args := c.Args()
+	Action: func(cCtx *Context) error {
+		args := cCtx.Args()
 		if args.Present() {
-			return ShowCommandHelp(c, args.First())
+			return ShowCommandHelp(cCtx, args.First())
 		}
 
-		return ShowSubcommandHelp(c)
+		return ShowSubcommandHelp(cCtx)
 	},
 }
 
@@ -71,30 +71,30 @@ func ShowAppHelpAndExit(c *Context, exitCode int) {
 }
 
 // ShowAppHelp is an action that displays the help.
-func ShowAppHelp(c *Context) error {
-	tpl := c.App.CustomAppHelpTemplate
+func ShowAppHelp(cCtx *Context) error {
+	tpl := cCtx.App.CustomAppHelpTemplate
 	if tpl == "" {
 		tpl = AppHelpTemplate
 	}
 
-	if c.App.ExtraInfo == nil {
-		HelpPrinter(c.App.Writer, tpl, c.App)
+	if cCtx.App.ExtraInfo == nil {
+		HelpPrinter(cCtx.App.Writer, tpl, cCtx.App)
 		return nil
 	}
 
 	customAppData := func() map[string]interface{} {
 		return map[string]interface{}{
-			"ExtraInfo": c.App.ExtraInfo,
+			"ExtraInfo": cCtx.App.ExtraInfo,
 		}
 	}
-	HelpPrinterCustom(c.App.Writer, tpl, c.App, customAppData())
+	HelpPrinterCustom(cCtx.App.Writer, tpl, cCtx.App, customAppData())
 
 	return nil
 }
 
 // DefaultAppComplete prints the list of subcommands as the default app completion method
-func DefaultAppComplete(c *Context) {
-	DefaultCompleteWithFlags(nil)(c)
+func DefaultAppComplete(cCtx *Context) {
+	DefaultCompleteWithFlags(nil)(cCtx)
 }
 
 func printCommandSuggestions(commands []*Command, writer io.Writer) {
@@ -159,30 +159,30 @@ func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
 	}
 }
 
-func DefaultCompleteWithFlags(cmd *Command) func(c *Context) {
-	return func(c *Context) {
+func DefaultCompleteWithFlags(cmd *Command) func(cCtx *Context) {
+	return func(cCtx *Context) {
 		if len(os.Args) > 2 {
 			lastArg := os.Args[len(os.Args)-2]
 
 			if strings.HasPrefix(lastArg, "-") {
 				if cmd != nil {
-					printFlagSuggestions(lastArg, cmd.Flags, c.App.Writer)
+					printFlagSuggestions(lastArg, cmd.Flags, cCtx.App.Writer)
 
 					return
 				}
 
-				printFlagSuggestions(lastArg, c.App.Flags, c.App.Writer)
+				printFlagSuggestions(lastArg, cCtx.App.Flags, cCtx.App.Writer)
 
 				return
 			}
 		}
 
 		if cmd != nil {
-			printCommandSuggestions(cmd.Subcommands, c.App.Writer)
+			printCommandSuggestions(cmd.Subcommands, cCtx.App.Writer)
 			return
 		}
 
-		printCommandSuggestions(c.App.Commands, c.App.Writer)
+		printCommandSuggestions(cCtx.App.Commands, cCtx.App.Writer)
 	}
 }
 
@@ -228,32 +228,32 @@ func ShowSubcommandHelpAndExit(c *Context, exitCode int) {
 }
 
 // ShowSubcommandHelp prints help for the given subcommand
-func ShowSubcommandHelp(c *Context) error {
-	if c == nil {
+func ShowSubcommandHelp(cCtx *Context) error {
+	if cCtx == nil {
 		return nil
 	}
 
-	if c.Command != nil {
-		return ShowCommandHelp(c, c.Command.Name)
+	if cCtx.Command != nil {
+		return ShowCommandHelp(cCtx, cCtx.Command.Name)
 	}
 
-	return ShowCommandHelp(c, "")
+	return ShowCommandHelp(cCtx, "")
 }
 
 // ShowVersion prints the version number of the App
-func ShowVersion(c *Context) {
-	VersionPrinter(c)
+func ShowVersion(cCtx *Context) {
+	VersionPrinter(cCtx)
 }
 
-func printVersion(c *Context) {
-	_, _ = fmt.Fprintf(c.App.Writer, "%v version %v\n", c.App.Name, c.App.Version)
+func printVersion(cCtx *Context) {
+	_, _ = fmt.Fprintf(cCtx.App.Writer, "%v version %v\n", cCtx.App.Name, cCtx.App.Version)
 }
 
 // ShowCompletions prints the lists of commands within a given context
-func ShowCompletions(c *Context) {
-	a := c.App
+func ShowCompletions(cCtx *Context) {
+	a := cCtx.App
 	if a != nil && a.BashComplete != nil {
-		a.BashComplete(c)
+		a.BashComplete(cCtx)
 	}
 }
 
@@ -304,20 +304,20 @@ func printHelp(out io.Writer, templ string, data interface{}) {
 	HelpPrinterCustom(out, templ, data, nil)
 }
 
-func checkVersion(c *Context) bool {
+func checkVersion(cCtx *Context) bool {
 	found := false
 	for _, name := range VersionFlag.Names() {
-		if c.Bool(name) {
+		if cCtx.Bool(name) {
 			found = true
 		}
 	}
 	return found
 }
 
-func checkHelp(c *Context) bool {
+func checkHelp(cCtx *Context) bool {
 	found := false
 	for _, name := range HelpFlag.Names() {
-		if c.Bool(name) {
+		if cCtx.Bool(name) {
 			found = true
 		}
 	}
@@ -333,9 +333,9 @@ func checkCommandHelp(c *Context, name string) bool {
 	return false
 }
 
-func checkSubcommandHelp(c *Context) bool {
-	if c.Bool("h") || c.Bool("help") {
-		_ = ShowSubcommandHelp(c)
+func checkSubcommandHelp(cCtx *Context) bool {
+	if cCtx.Bool("h") || cCtx.Bool("help") {
+		_ = ShowSubcommandHelp(cCtx)
 		return true
 	}
 
@@ -357,20 +357,20 @@ func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
 	return true, arguments[:pos]
 }
 
-func checkCompletions(c *Context) bool {
-	if !c.shellComplete {
+func checkCompletions(cCtx *Context) bool {
+	if !cCtx.shellComplete {
 		return false
 	}
 
-	if args := c.Args(); args.Present() {
+	if args := cCtx.Args(); args.Present() {
 		name := args.First()
-		if cmd := c.App.Command(name); cmd != nil {
+		if cmd := cCtx.App.Command(name); cmd != nil {
 			// let the command handle the completion
 			return false
 		}
 	}
 
-	ShowCompletions(c)
+	ShowCompletions(cCtx)
 	return true
 }
 


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

The `context` package was being shadowed by local vars in a few places, which is not something that's currently being checked by a linter but it _should be_ (in the future).

## Which issue(s) this PR fixes:

N/A 😬 

## Special notes for your reviewer:

Also includes changes to consistently name `*cli.Context` vars and method receivers `cCtx`