### PR TITLE
Do not apply altsrc input values that are not set

### DIFF
--- a/altsrc/flag.go
+++ b/altsrc/flag.go
@@ -64,7 +64,7 @@ func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(cCtx *c
 
 // ApplyInputSourceValue applies a generic value to the flagSet if required
 func (f *GenericFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.IsSet(f.GenericFlag.Name) {
+	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.isSet(f.GenericFlag.Name) {
 		value, err := isc.Generic(f.GenericFlag.Name)
 		if err != nil {
 			return err
@@ -81,7 +81,7 @@ func (f *GenericFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceCo
 
 // ApplyInputSourceValue applies a StringSlice value to the flagSet if required
 func (f *StringSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.IsSet(f.StringSliceFlag.Name) {
+	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.isSet(f.StringSliceFlag.Name) {
 		value, err := isc.StringSlice(f.StringSliceFlag.Name)
 		if err != nil {
 			return err
@@ -101,7 +101,7 @@ func (f *StringSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSour
 
 // ApplyInputSourceValue applies a IntSlice value if required
 func (f *IntSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.IsSet(f.IntSliceFlag.Name) {
+	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.isSet(f.IntSliceFlag.Name) {
 		value, err := isc.IntSlice(f.IntSliceFlag.Name)
 		if err != nil {
 			return err
@@ -121,7 +121,7 @@ func (f *IntSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceC
 
 // ApplyInputSourceValue applies a Bool value to the flagSet if required
 func (f *BoolFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.IsSet(f.BoolFlag.Name) {
+	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.isSet(f.BoolFlag.Name) {
 		value, err := isc.Bool(f.BoolFlag.Name)
 		if err != nil {
 			return err
@@ -137,7 +137,7 @@ func (f *BoolFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceConte
 
 // ApplyInputSourceValue applies a String value to the flagSet if required
 func (f *StringFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.StringFlag.Name) {
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.isSet(f.StringFlag.Name) {
 		value, err := isc.String(f.StringFlag.Name)
 		if err != nil {
 			return err
@@ -153,7 +153,7 @@ func (f *StringFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceCon
 
 // ApplyInputSourceValue applies a Path value to the flagSet if required
 func (f *PathFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.PathFlag.Name) {
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.isSet(f.PathFlag.Name) {
 		value, err := isc.String(f.PathFlag.Name)
 		if err != nil {
 			return err
@@ -179,7 +179,7 @@ func (f *PathFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceConte
 
 // ApplyInputSourceValue applies a int value to the flagSet if required
 func (f *IntFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.IntFlag.Name) {
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.isSet(f.IntFlag.Name) {
 		value, err := isc.Int(f.IntFlag.Name)
 		if err != nil {
 			return err
@@ -193,7 +193,7 @@ func (f *IntFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContex
 
 // ApplyInputSourceValue applies a Duration value to the flagSet if required
 func (f *DurationFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.DurationFlag.Name) {
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.isSet(f.DurationFlag.Name) {
 		value, err := isc.Duration(f.DurationFlag.Name)
 		if err != nil {
 			return err
@@ -207,7 +207,7 @@ func (f *DurationFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceC
 
 // ApplyInputSourceValue applies a Float64 value to the flagSet if required
 func (f *Float64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.Float64Flag.Name) {
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.isSet(f.Float64Flag.Name) {
 		value, err := isc.Float64(f.Float64Flag.Name)
 		if err != nil {
 			return err

--- a/altsrc/flag.go
+++ b/altsrc/flag.go
@@ -64,16 +64,14 @@ func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(cCtx *c
 
 // ApplyInputSourceValue applies a generic value to the flagSet if required
 func (f *GenericFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil {
-		if !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
-			value, err := isc.Generic(f.GenericFlag.Name)
-			if err != nil {
-				return err
-			}
-			if value != nil {
-				for _, name := range f.Names() {
-					_ = f.set.Set(name, value.String())
-				}
+	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.IsSet(f.GenericFlag.Name) {
+		value, err := isc.Generic(f.GenericFlag.Name)
+		if err != nil {
+			return err
+		}
+		if value != nil {
+			for _, name := range f.Names() {
+				_ = f.set.Set(name, value.String())
 			}
 		}
 	}
@@ -83,19 +81,17 @@ func (f *GenericFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceCo
 
 // ApplyInputSourceValue applies a StringSlice value to the flagSet if required
 func (f *StringSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil {
-		if !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
-			value, err := isc.StringSlice(f.StringSliceFlag.Name)
-			if err != nil {
-				return err
-			}
-			if value != nil {
-				var sliceValue cli.StringSlice = *(cli.NewStringSlice(value...))
-				for _, name := range f.Names() {
-					underlyingFlag := f.set.Lookup(name)
-					if underlyingFlag != nil {
-						underlyingFlag.Value = &sliceValue
-					}
+	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.IsSet(f.StringSliceFlag.Name) {
+		value, err := isc.StringSlice(f.StringSliceFlag.Name)
+		if err != nil {
+			return err
+		}
+		if value != nil {
+			var sliceValue cli.StringSlice = *(cli.NewStringSlice(value...))
+			for _, name := range f.Names() {
+				underlyingFlag := f.set.Lookup(name)
+				if underlyingFlag != nil {
+					underlyingFlag.Value = &sliceValue
 				}
 			}
 		}
@@ -105,19 +101,17 @@ func (f *StringSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSour
 
 // ApplyInputSourceValue applies a IntSlice value if required
 func (f *IntSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil {
-		if !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
-			value, err := isc.IntSlice(f.IntSliceFlag.Name)
-			if err != nil {
-				return err
-			}
-			if value != nil {
-				var sliceValue cli.IntSlice = *(cli.NewIntSlice(value...))
-				for _, name := range f.Names() {
-					underlyingFlag := f.set.Lookup(name)
-					if underlyingFlag != nil {
-						underlyingFlag.Value = &sliceValue
-					}
+	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.IsSet(f.IntSliceFlag.Name) {
+		value, err := isc.IntSlice(f.IntSliceFlag.Name)
+		if err != nil {
+			return err
+		}
+		if value != nil {
+			var sliceValue cli.IntSlice = *(cli.NewIntSlice(value...))
+			for _, name := range f.Names() {
+				underlyingFlag := f.set.Lookup(name)
+				if underlyingFlag != nil {
+					underlyingFlag.Value = &sliceValue
 				}
 			}
 		}
@@ -127,16 +121,14 @@ func (f *IntSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceC
 
 // ApplyInputSourceValue applies a Bool value to the flagSet if required
 func (f *BoolFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil {
-		if !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) {
-			value, err := isc.Bool(f.BoolFlag.Name)
-			if err != nil {
-				return err
-			}
-			if value {
-				for _, name := range f.Names() {
-					_ = f.set.Set(name, strconv.FormatBool(value))
-				}
+	if f.set != nil && !cCtx.IsSet(f.Name) && !isEnvVarSet(f.EnvVars) && isc.IsSet(f.BoolFlag.Name) {
+		value, err := isc.Bool(f.BoolFlag.Name)
+		if err != nil {
+			return err
+		}
+		if value {
+			for _, name := range f.Names() {
+				_ = f.set.Set(name, strconv.FormatBool(value))
 			}
 		}
 	}
@@ -145,16 +137,14 @@ func (f *BoolFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceConte
 
 // ApplyInputSourceValue applies a String value to the flagSet if required
 func (f *StringFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil {
-		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
-			value, err := isc.String(f.StringFlag.Name)
-			if err != nil {
-				return err
-			}
-			if value != "" {
-				for _, name := range f.Names() {
-					_ = f.set.Set(name, value)
-				}
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.StringFlag.Name) {
+		value, err := isc.String(f.StringFlag.Name)
+		if err != nil {
+			return err
+		}
+		if value != "" {
+			for _, name := range f.Names() {
+				_ = f.set.Set(name, value)
 			}
 		}
 	}
@@ -163,26 +153,24 @@ func (f *StringFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceCon
 
 // ApplyInputSourceValue applies a Path value to the flagSet if required
 func (f *PathFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil {
-		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
-			value, err := isc.String(f.PathFlag.Name)
-			if err != nil {
-				return err
-			}
-			if value != "" {
-				for _, name := range f.Names() {
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.PathFlag.Name) {
+		value, err := isc.String(f.PathFlag.Name)
+		if err != nil {
+			return err
+		}
+		if value != "" {
+			for _, name := range f.Names() {
 
-					if !filepath.IsAbs(value) && isc.Source() != "" {
-						basePathAbs, err := filepath.Abs(isc.Source())
-						if err != nil {
-							return err
-						}
-
-						value = filepath.Join(filepath.Dir(basePathAbs), value)
+				if !filepath.IsAbs(value) && isc.Source() != "" {
+					basePathAbs, err := filepath.Abs(isc.Source())
+					if err != nil {
+						return err
 					}
 
-					_ = f.set.Set(name, value)
+					value = filepath.Join(filepath.Dir(basePathAbs), value)
 				}
+
+				_ = f.set.Set(name, value)
 			}
 		}
 	}
@@ -191,15 +179,13 @@ func (f *PathFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceConte
 
 // ApplyInputSourceValue applies a int value to the flagSet if required
 func (f *IntFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil {
-		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
-			value, err := isc.Int(f.IntFlag.Name)
-			if err != nil {
-				return err
-			}
-			for _, name := range f.Names() {
-				_ = f.set.Set(name, strconv.FormatInt(int64(value), 10))
-			}
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.IntFlag.Name) {
+		value, err := isc.Int(f.IntFlag.Name)
+		if err != nil {
+			return err
+		}
+		for _, name := range f.Names() {
+			_ = f.set.Set(name, strconv.FormatInt(int64(value), 10))
 		}
 	}
 	return nil
@@ -207,15 +193,13 @@ func (f *IntFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContex
 
 // ApplyInputSourceValue applies a Duration value to the flagSet if required
 func (f *DurationFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil {
-		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
-			value, err := isc.Duration(f.DurationFlag.Name)
-			if err != nil {
-				return err
-			}
-			for _, name := range f.Names() {
-				_ = f.set.Set(name, value.String())
-			}
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.DurationFlag.Name) {
+		value, err := isc.Duration(f.DurationFlag.Name)
+		if err != nil {
+			return err
+		}
+		for _, name := range f.Names() {
+			_ = f.set.Set(name, value.String())
 		}
 	}
 	return nil
@@ -223,16 +207,14 @@ func (f *DurationFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceC
 
 // ApplyInputSourceValue applies a Float64 value to the flagSet if required
 func (f *Float64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error {
-	if f.set != nil {
-		if !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) {
-			value, err := isc.Float64(f.Float64Flag.Name)
-			if err != nil {
-				return err
-			}
-			floatStr := float64ToString(value)
-			for _, name := range f.Names() {
-				_ = f.set.Set(name, floatStr)
-			}
+	if f.set != nil && !(cCtx.IsSet(f.Name) || isEnvVarSet(f.EnvVars)) && isc.IsSet(f.Float64Flag.Name) {
+		value, err := isc.Float64(f.Float64Flag.Name)
+		if err != nil {
+			return err
+		}
+		floatStr := float64ToString(value)
+		for _, name := range f.Names() {
+			_ = f.set.Set(name, floatStr)
 		}
 	}
 	return nil

--- a/altsrc/flag_test.go
+++ b/altsrc/flag_test.go
@@ -26,29 +26,48 @@ type testApplyInputSource struct {
 	MapValue           interface{}
 }
 
+type racyInputSource struct {
+	*MapInputSource
+}
+
+func (ris *racyInputSource) isSet(name string) bool {
+	if _, ok := ris.MapInputSource.valueMap[name]; ok {
+		ris.MapInputSource.valueMap[name] = bogus{0}
+	}
+	return true
+}
+
 func TestGenericApplyInputSourceValue(t *testing.T) {
 	v := &Parser{"abc", "def"}
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewGenericFlag(&cli.GenericFlag{Name: "test", Value: &Parser{}}),
 		FlagName: "test",
 		MapValue: v,
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, v, c.Generic("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, v, c.Generic("test"))
 }
 
 func TestGenericApplyInputSourceMethodContextSet(t *testing.T) {
 	p := &Parser{"abc", "def"}
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:               NewGenericFlag(&cli.GenericFlag{Name: "test", Value: &Parser{}}),
 		FlagName:           "test",
 		MapValue:           &Parser{"efg", "hig"},
 		ContextValueString: p.String(),
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, p, c.Generic("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, p, c.Generic("test"))
 }
 
 func TestGenericApplyInputSourceMethodEnvVarSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag: NewGenericFlag(&cli.GenericFlag{
 			Name:    "test",
 			Value:   &Parser{},
@@ -58,17 +77,25 @@ func TestGenericApplyInputSourceMethodEnvVarSet(t *testing.T) {
 		MapValue:    &Parser{"efg", "hij"},
 		EnvVarName:  "TEST",
 		EnvVarValue: "abc,def",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, &Parser{"abc", "def"}, c.Generic("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, &Parser{"abc", "def"}, c.Generic("test"))
 }
 
 func TestStringSliceApplyInputSourceValue(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewStringSliceFlag(&cli.StringSliceFlag{Name: "test"}),
 		FlagName: "test",
 		MapValue: []interface{}{"hello", "world"},
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, c.StringSlice("test"), []string{"hello", "world"})
+
+	c = runRacyTest(t, tis)
+	refute(t, c.StringSlice("test"), []string{"hello", "world"})
 }
 
 func TestStringSliceApplyInputSourceMethodContextSet(t *testing.T) {
@@ -82,112 +109,154 @@ func TestStringSliceApplyInputSourceMethodContextSet(t *testing.T) {
 }
 
 func TestStringSliceApplyInputSourceMethodEnvVarSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:        NewStringSliceFlag(&cli.StringSliceFlag{Name: "test", EnvVars: []string{"TEST"}}),
 		FlagName:    "test",
 		MapValue:    []interface{}{"hello", "world"},
 		EnvVarName:  "TEST",
 		EnvVarValue: "oh,no",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, c.StringSlice("test"), []string{"oh", "no"})
+
+	c = runRacyTest(t, tis)
+	refute(t, c.StringSlice("test"), []string{"oh", "no"})
 }
 
 func TestIntSliceApplyInputSourceValue(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewIntSliceFlag(&cli.IntSliceFlag{Name: "test"}),
 		FlagName: "test",
 		MapValue: []interface{}{1, 2},
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, c.IntSlice("test"), []int{1, 2})
+
+	c = runRacyTest(t, tis)
+	refute(t, c.IntSlice("test"), []int{1, 2})
 }
 
 func TestIntSliceApplyInputSourceMethodContextSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:               NewIntSliceFlag(&cli.IntSliceFlag{Name: "test"}),
 		FlagName:           "test",
 		MapValue:           []interface{}{1, 2},
 		ContextValueString: "3",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, c.IntSlice("test"), []int{3})
+
+	c = runRacyTest(t, tis)
+	refute(t, c.IntSlice("test"), []int{3})
 }
 
 func TestIntSliceApplyInputSourceMethodEnvVarSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:        NewIntSliceFlag(&cli.IntSliceFlag{Name: "test", EnvVars: []string{"TEST"}}),
 		FlagName:    "test",
 		MapValue:    []interface{}{1, 2},
 		EnvVarName:  "TEST",
 		EnvVarValue: "3,4",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, c.IntSlice("test"), []int{3, 4})
+
+	c = runRacyTest(t, tis)
+	refute(t, c.IntSlice("test"), []int{3, 4})
 }
 
 func TestBoolApplyInputSourceMethodSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewBoolFlag(&cli.BoolFlag{Name: "test"}),
 		FlagName: "test",
 		MapValue: true,
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, true, c.Bool("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, true, c.Bool("test"))
 }
 
 func TestBoolApplyInputSourceMethodContextSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:               NewBoolFlag(&cli.BoolFlag{Name: "test"}),
 		FlagName:           "test",
 		MapValue:           false,
 		ContextValueString: "true",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, true, c.Bool("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, true, c.Bool("test"))
 }
 
 func TestBoolApplyInputSourceMethodEnvVarSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:        NewBoolFlag(&cli.BoolFlag{Name: "test", EnvVars: []string{"TEST"}}),
 		FlagName:    "test",
 		MapValue:    false,
 		EnvVarName:  "TEST",
 		EnvVarValue: "true",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, true, c.Bool("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, true, c.Bool("test"))
 }
 
 func TestStringApplyInputSourceMethodSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewStringFlag(&cli.StringFlag{Name: "test"}),
 		FlagName: "test",
 		MapValue: "hello",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, "hello", c.String("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, "hello", c.String("test"))
 }
 
 func TestStringApplyInputSourceMethodContextSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:               NewStringFlag(&cli.StringFlag{Name: "test"}),
 		FlagName:           "test",
 		MapValue:           "hello",
 		ContextValueString: "goodbye",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, "goodbye", c.String("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, "goodbye", c.String("test"))
 }
 
 func TestStringApplyInputSourceMethodEnvVarSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:        NewStringFlag(&cli.StringFlag{Name: "test", EnvVars: []string{"TEST"}}),
 		FlagName:    "test",
 		MapValue:    "hello",
 		EnvVarName:  "TEST",
 		EnvVarValue: "goodbye",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, "goodbye", c.String("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, "goodbye", c.String("test"))
 }
+
 func TestPathApplyInputSourceMethodSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:       NewPathFlag(&cli.PathFlag{Name: "test"}),
 		FlagName:   "test",
 		MapValue:   "hello",
 		SourcePath: "/path/to/source/file",
-	})
+	}
+	c := runTest(t, tis)
 
 	expected := "/path/to/source/hello"
 	if runtime.GOOS == "windows" {
@@ -200,125 +269,176 @@ func TestPathApplyInputSourceMethodSet(t *testing.T) {
 		}
 	}
 	expect(t, expected, c.String("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, expected, c.String("test"))
 }
 
 func TestPathApplyInputSourceMethodContextSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:               NewPathFlag(&cli.PathFlag{Name: "test"}),
 		FlagName:           "test",
 		MapValue:           "hello",
 		ContextValueString: "goodbye",
 		SourcePath:         "/path/to/source/file",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, "goodbye", c.String("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, "goodbye", c.String("test"))
 }
 
 func TestPathApplyInputSourceMethodEnvVarSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:        NewPathFlag(&cli.PathFlag{Name: "test", EnvVars: []string{"TEST"}}),
 		FlagName:    "test",
 		MapValue:    "hello",
 		EnvVarName:  "TEST",
 		EnvVarValue: "goodbye",
 		SourcePath:  "/path/to/source/file",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, "goodbye", c.String("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, "goodbye", c.String("test"))
 }
 
 func TestIntApplyInputSourceMethodSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewIntFlag(&cli.IntFlag{Name: "test"}),
 		FlagName: "test",
 		MapValue: 15,
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, 15, c.Int("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, 15, c.Int("test"))
 }
 
 func TestIntApplyInputSourceMethodSetNegativeValue(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewIntFlag(&cli.IntFlag{Name: "test"}),
 		FlagName: "test",
 		MapValue: -1,
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, -1, c.Int("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, -1, c.Int("test"))
 }
 
 func TestIntApplyInputSourceMethodContextSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:               NewIntFlag(&cli.IntFlag{Name: "test"}),
 		FlagName:           "test",
 		MapValue:           15,
 		ContextValueString: "7",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, 7, c.Int("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, 7, c.Int("test"))
 }
 
 func TestIntApplyInputSourceMethodEnvVarSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:        NewIntFlag(&cli.IntFlag{Name: "test", EnvVars: []string{"TEST"}}),
 		FlagName:    "test",
 		MapValue:    15,
 		EnvVarName:  "TEST",
 		EnvVarValue: "12",
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, 12, c.Int("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, 12, c.Int("test"))
 }
 
 func TestDurationApplyInputSourceMethodSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewDurationFlag(&cli.DurationFlag{Name: "test"}),
 		FlagName: "test",
 		MapValue: 30 * time.Second,
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, 30*time.Second, c.Duration("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, 30*time.Second, c.Duration("test"))
 }
 
 func TestDurationApplyInputSourceMethodSetNegativeValue(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewDurationFlag(&cli.DurationFlag{Name: "test"}),
 		FlagName: "test",
 		MapValue: -30 * time.Second,
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, -30*time.Second, c.Duration("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, -30*time.Second, c.Duration("test"))
 }
 
 func TestDurationApplyInputSourceMethodContextSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:               NewDurationFlag(&cli.DurationFlag{Name: "test"}),
 		FlagName:           "test",
 		MapValue:           30 * time.Second,
 		ContextValueString: (15 * time.Second).String(),
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, 15*time.Second, c.Duration("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, 15*time.Second, c.Duration("test"))
 }
 
 func TestDurationApplyInputSourceMethodEnvVarSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:        NewDurationFlag(&cli.DurationFlag{Name: "test", EnvVars: []string{"TEST"}}),
 		FlagName:    "test",
 		MapValue:    30 * time.Second,
 		EnvVarName:  "TEST",
 		EnvVarValue: (15 * time.Second).String(),
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, 15*time.Second, c.Duration("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, 15*time.Second, c.Duration("test"))
 }
 
 func TestFloat64ApplyInputSourceMethodSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewFloat64Flag(&cli.Float64Flag{Name: "test"}),
 		FlagName: "test",
 		MapValue: 1.3,
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, 1.3, c.Float64("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, 1.3, c.Float64("test"))
 }
 
 func TestFloat64ApplyInputSourceMethodSetNegativeValue(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:     NewFloat64Flag(&cli.Float64Flag{Name: "test"}),
 		FlagName: "test",
 		MapValue: -1.3,
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, -1.3, c.Float64("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, -1.3, c.Float64("test"))
 }
 
 func TestFloat64ApplyInputSourceMethodSetNegativeValueNotSet(t *testing.T) {
@@ -331,24 +451,32 @@ func TestFloat64ApplyInputSourceMethodSetNegativeValueNotSet(t *testing.T) {
 }
 
 func TestFloat64ApplyInputSourceMethodContextSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:               NewFloat64Flag(&cli.Float64Flag{Name: "test"}),
 		FlagName:           "test",
 		MapValue:           1.3,
 		ContextValueString: fmt.Sprintf("%v", 1.4),
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, 1.4, c.Float64("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, 1.4, c.Float64("test"))
 }
 
 func TestFloat64ApplyInputSourceMethodEnvVarSet(t *testing.T) {
-	c := runTest(t, testApplyInputSource{
+	tis := testApplyInputSource{
 		Flag:        NewFloat64Flag(&cli.Float64Flag{Name: "test", EnvVars: []string{"TEST"}}),
 		FlagName:    "test",
 		MapValue:    1.3,
 		EnvVarName:  "TEST",
 		EnvVarValue: fmt.Sprintf("%v", 1.4),
-	})
+	}
+	c := runTest(t, tis)
 	expect(t, 1.4, c.Float64("test"))
+
+	c = runRacyTest(t, tis)
+	refute(t, 1.4, c.Float64("test"))
 }
 
 func runTest(t *testing.T, test testApplyInputSource) *cli.Context {
@@ -376,6 +504,19 @@ func runTest(t *testing.T, test testApplyInputSource) *cli.Context {
 	return c
 }
 
+func runRacyTest(t *testing.T, test testApplyInputSource) *cli.Context {
+	set := flag.NewFlagSet(test.FlagSetName, flag.ContinueOnError)
+	c := cli.NewContext(nil, set, nil)
+	_ = test.Flag.ApplyInputSourceValue(c, &racyInputSource{
+		MapInputSource: &MapInputSource{
+			file:     test.SourcePath,
+			valueMap: map[interface{}]interface{}{test.FlagName: test.MapValue},
+		},
+	})
+
+	return c
+}
+
 type Parser [2]string
 
 func (p *Parser) Set(value string) error {
@@ -393,3 +534,5 @@ func (p *Parser) Set(value string) error {
 func (p *Parser) String() string {
 	return fmt.Sprintf("%s,%s", p[0], p[1])
 }
+
+type bogus [1]uint

--- a/altsrc/helpers_test.go
+++ b/altsrc/helpers_test.go
@@ -22,7 +22,10 @@ func expect(t *testing.T, a interface{}, b interface{}) {
 }
 
 func refute(t *testing.T, a interface{}, b interface{}) {
-	if a == b {
-		t.Errorf("Did not expect %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	_, fn, line, _ := runtime.Caller(1)
+	fn = strings.Replace(fn, wd+"/", "", -1)
+
+	if reflect.DeepEqual(a, b) {
+		t.Errorf("(%s:%d) Did not expect %v (type %v) - Got %v (type %v)", fn, line, b, reflect.TypeOf(b), a, reflect.TypeOf(a))
 	}
 }

--- a/altsrc/input_source_context.go
+++ b/altsrc/input_source_context.go
@@ -14,6 +14,7 @@ import (
 type InputSourceContext interface {
 	Source() string
 
+	IsSet(name string) bool
 	Int(name string) (int, error)
 	Duration(name string) (time.Duration, error)
 	Float64(name string) (float64, error)

--- a/altsrc/input_source_context.go
+++ b/altsrc/input_source_context.go
@@ -14,7 +14,6 @@ import (
 type InputSourceContext interface {
 	Source() string
 
-	IsSet(name string) bool
 	Int(name string) (int, error)
 	Duration(name string) (time.Duration, error)
 	Float64(name string) (float64, error)
@@ -23,4 +22,6 @@ type InputSourceContext interface {
 	IntSlice(name string) ([]int, error)
 	Generic(name string) (cli.Generic, error)
 	Bool(name string) (bool, error)
+
+	isSet(name string) bool
 }

--- a/altsrc/json_source_context.go
+++ b/altsrc/json_source_context.go
@@ -184,7 +184,7 @@ func (x *jsonSource) Bool(name string) (bool, error) {
 	return v, nil
 }
 
-func (x *jsonSource) IsSet(name string) bool {
+func (x *jsonSource) isSet(name string) bool {
 	_, err := x.getValue(name)
 	return err == nil
 }

--- a/altsrc/json_source_context.go
+++ b/altsrc/json_source_context.go
@@ -184,6 +184,11 @@ func (x *jsonSource) Bool(name string) (bool, error) {
 	return v, nil
 }
 
+func (x *jsonSource) IsSet(name string) bool {
+	_, err := x.getValue(name)
+	return err == nil
+}
+
 func (x *jsonSource) getValue(key string) (interface{}, error) {
 	return jsonGetValue(key, x.deserialized)
 }

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -249,11 +249,8 @@ func (fsm *MapInputSource) isSet(name string) bool {
 		return exists
 	}
 
-	if _, exists := nestedVal(name, fsm.valueMap); exists {
-		return exists
-	}
-
-	return false
+	_, exists := nestedVal(name, fsm.valueMap)
+	return exists
 }
 
 func incorrectTypeForFlagError(name, expectedTypeName string, value interface{}) error {

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -244,6 +244,19 @@ func (fsm *MapInputSource) Bool(name string) (bool, error) {
 	return false, nil
 }
 
+// IsSet returns the truth of the key's existence in the map
+func (fsm *MapInputSource) IsSet(name string) bool {
+	if _, exists := fsm.valueMap[name]; exists {
+		return exists
+	}
+
+	if _, exists := nestedVal(name, fsm.valueMap); exists {
+		return exists
+	}
+
+	return false
+}
+
 func incorrectTypeForFlagError(name, expectedTypeName string, value interface{}) error {
 	valueType := reflect.TypeOf(value)
 	valueTypeName := ""

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -244,8 +244,7 @@ func (fsm *MapInputSource) Bool(name string) (bool, error) {
 	return false, nil
 }
 
-// IsSet returns the truth of the key's existence in the map
-func (fsm *MapInputSource) IsSet(name string) bool {
+func (fsm *MapInputSource) isSet(name string) bool {
 	if _, exists := fsm.valueMap[name]; exists {
 		return exists
 	}

--- a/altsrc/yaml_file_loader_test.go
+++ b/altsrc/yaml_file_loader_test.go
@@ -1,0 +1,87 @@
+package altsrc_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
+)
+
+func ExampleApp_Run_yamlFileLoaderDuration() {
+	execServe := func(c *cli.Context) error {
+		keepaliveInterval := c.Duration("keepalive-interval")
+		fmt.Printf("keepalive %s\n", keepaliveInterval)
+		return nil
+	}
+
+	fileExists := func(filename string) bool {
+		stat, _ := os.Stat(filename)
+		return stat != nil
+	}
+
+	// initConfigFileInputSource is like altsrc.InitInputSourceWithContext and altsrc.NewYamlSourceFromFlagFunc, but checks
+	// if the config flag is exists and only loads it if it does. If the flag is set and the file exists, it fails.
+	initConfigFileInputSource := func(configFlag string, flags []cli.Flag) cli.BeforeFunc {
+		return func(context *cli.Context) error {
+			configFile := context.String(configFlag)
+			if context.IsSet(configFlag) && !fileExists(configFile) {
+				return fmt.Errorf("config file %s does not exist", configFile)
+			} else if !context.IsSet(configFlag) && !fileExists(configFile) {
+				return nil
+			}
+			inputSource, err := altsrc.NewYamlSourceFromFile(configFile)
+			if err != nil {
+				return err
+			}
+			return altsrc.ApplyInputSourceValues(context, inputSource, flags)
+		}
+	}
+
+	flagsServe := []cli.Flag{
+		&cli.StringFlag{
+			Name:        "config",
+			Aliases:     []string{"c"},
+			EnvVars:     []string{"CONFIG_FILE"},
+			Value:       "../testdata/empty.yml",
+			DefaultText: "../testdata/empty.yml",
+			Usage:       "config file",
+		},
+		altsrc.NewDurationFlag(
+			&cli.DurationFlag{
+				Name:    "keepalive-interval",
+				Aliases: []string{"k"},
+				EnvVars: []string{"KEEPALIVE_INTERVAL"},
+				Value:   45 * time.Second,
+				Usage:   "interval of keepalive messages",
+			},
+		),
+	}
+
+	cmdServe := &cli.Command{
+		Name:      "serve",
+		Usage:     "Run the server",
+		UsageText: "serve [OPTIONS..]",
+		Action:    execServe,
+		Flags:     flagsServe,
+		Before:    initConfigFileInputSource("config", flagsServe),
+	}
+
+	c := &cli.App{
+		Name:                   "cmd",
+		HideVersion:            true,
+		UseShortOptionHandling: true,
+		Commands: []*cli.Command{
+			cmdServe,
+		},
+	}
+
+	if err := c.Run([]string{"cmd", "serve", "--config", "../testdata/empty.yml"}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// keepalive 45s
+}

--- a/testdata/empty.yml
+++ b/testdata/empty.yml
@@ -1,0 +1,1 @@
+# empty file


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

This fixes the behavior of applied altsrc inputs so that they are only applied if the matching key exists in the input.

## Which issue(s) this PR fixes:

Fixes #1373