### PR TITLE
[v1] fix CI, add Go 1.17.x and 1.18.x

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -15,13 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go:
-          - 1.16.x
-          # NOTE: tests fail with panic at
-          # TestApp_RunAsSubCommandIncorrectUsage on these
-          # versions:
-          # - 1.17.x
-          # - 1.18.x
+        go: [1.16.x, 1.17.x, 1.18.x]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -38,6 +32,6 @@ jobs:
 
       - name: Run Tests
         run:
-          go run build.go vet &&
-          go run build.go test &&
+          go run build.go vet
+          go run build.go test
           go run build.go toc docs/v1/manual.md

--- a/app_test.go
+++ b/app_test.go
@@ -508,6 +508,14 @@ func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
 }
 
 func TestApp_RunAsSubCommandIncorrectUsage(t *testing.T) {
+	// Go 1.17+ panics when invalid flag is given.
+	// Catch it here and consider the test passed.
+	defer func() {
+		if err := recover(); err == nil {
+			t.Fatal("expected error, got nothing")
+		}
+	}()
+
 	a := App{
 		Flags: []Flag{
 			StringFlag{Name: "--foo"},


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

One test is failing with Go 1.17+ since it now panics instead of
returning an error. Catch the panic and consider the test passed.

With that out of the door, add Go 1.17.x and 1.18.x to the testing
matrix.

While at it, do not use && in run since it is executed by a shell with
set -e, thus making && redundant.

## Which issue(s) this PR fixes:

None (AFAICS)

## Special notes for your reviewer:

None 

## Testing

That's what we have CI for!

## Release Notes

```release-note
NONE
```
