### PR TITLE
[v1] Add urfave_cli_no_docs build tag

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -34,4 +34,5 @@ jobs:
         run: |
           go run build.go vet
           go run build.go test
+          go run build.go -tags urfave_cli_no_docs test
           go run build.go toc docs/v1/manual.md

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ cli is tested against multiple versions of Go on Linux, and against the latest
 released version of Go on OS X and Windows.  For full details, see
 [`./.travis.yml`](./.travis.yml) and [`./appveyor.yml`](./appveyor.yml).
 
+### Build tags
+
+You can use the following build tags:
+
+#### `urfave_cli_no_docs`
+
+When set, this removes `ToMarkdown` and `ToMan` methods, so your application
+won't be able to call those. This reduces the resulting binary size by about
+300-400 KB (measured using Go 1.18.1 on Linux/amd64), due to less dependencies.
+
 ### Using `v1` releases
 
 ```

--- a/build.go
+++ b/build.go
@@ -41,6 +41,12 @@ func main() {
 			Action: TocActionFunc,
 		},
 	}
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:  "tags",
+			Usage: "set build tags",
+		},
+	}
 
 	err := app.Run(os.Args)
 	if err != nil {
@@ -63,6 +69,8 @@ func VetActionFunc(_ *cli.Context) error {
 }
 
 func TestActionFunc(c *cli.Context) error {
+	tags := c.String("tags")
+
 	for _, pkg := range packages {
 		var packageName string
 
@@ -74,7 +82,7 @@ func TestActionFunc(c *cli.Context) error {
 
 		coverProfile := fmt.Sprintf("--coverprofile=%s.coverprofile", pkg)
 
-		err := runCmd("go", "test", "-v", coverProfile, packageName)
+		err := runCmd("go", "test", "-tags", tags, "-v", coverProfile, packageName)
 		if err != nil {
 			return err
 		}

--- a/docs.go
+++ b/docs.go
@@ -1,3 +1,6 @@
+//go:build !urfave_cli_no_docs
+// +build !urfave_cli_no_docs
+
 package cli
 
 import (

--- a/docs_test.go
+++ b/docs_test.go
@@ -1,3 +1,6 @@
+//go:build !urfave_cli_no_docs
+// +build !urfave_cli_no_docs
+
 package cli
 
 import (

--- a/docs_test.go
+++ b/docs_test.go
@@ -1,75 +1,8 @@
 package cli
 
 import (
-	"io/ioutil"
 	"testing"
 )
-
-func testApp() *App {
-	app := NewApp()
-	app.Name = "greet"
-	app.Flags = []Flag{
-		StringFlag{
-			Name:      "socket, s",
-			Usage:     "some 'usage' text",
-			Value:     "value",
-			TakesFile: true,
-		},
-		StringFlag{Name: "flag, fl, f"},
-		BoolFlag{
-			Name:  "another-flag, b",
-			Usage: "another usage text",
-		},
-	}
-	app.Commands = []Command{{
-		Aliases: []string{"c"},
-		Flags: []Flag{
-			StringFlag{
-				Name:      "flag, fl, f",
-				TakesFile: true,
-			},
-			BoolFlag{
-				Name:  "another-flag, b",
-				Usage: "another usage text",
-			},
-		},
-		Name:  "config",
-		Usage: "another usage test",
-		Subcommands: []Command{{
-			Aliases: []string{"s", "ss"},
-			Flags: []Flag{
-				StringFlag{Name: "sub-flag, sub-fl, s"},
-				BoolFlag{
-					Name:  "sub-command-flag, s",
-					Usage: "some usage text",
-				},
-			},
-			Name:  "sub-config",
-			Usage: "another usage test",
-		}},
-	}, {
-		Aliases: []string{"i", "in"},
-		Name:    "info",
-		Usage:   "retrieve generic information",
-	}, {
-		Name: "some-command",
-	}, {
-		Name:   "hidden-command",
-		Hidden: true,
-	}}
-	app.UsageText = "app [first_arg] [second_arg]"
-	app.Usage = "Some app"
-	app.Author = "Harrison"
-	app.Email = "harrison@lolwut.com"
-	app.Authors = []Author{{Name: "Oliver Allen", Email: "oliver@toyshop.com"}}
-	return app
-}
-
-func expectFileContent(t *testing.T, file, expected string) {
-	data, err := ioutil.ReadFile(file)
-	expect(t, err, nil)
-	expect(t, string(data), expected)
-}
 
 func TestToMarkdownFull(t *testing.T) {
 	// Given

--- a/fish_test.go
+++ b/fish_test.go
@@ -1,8 +1,75 @@
 package cli
 
 import (
+	"io/ioutil"
 	"testing"
 )
+
+func testApp() *App {
+	app := NewApp()
+	app.Name = "greet"
+	app.Flags = []Flag{
+		StringFlag{
+			Name:      "socket, s",
+			Usage:     "some 'usage' text",
+			Value:     "value",
+			TakesFile: true,
+		},
+		StringFlag{Name: "flag, fl, f"},
+		BoolFlag{
+			Name:  "another-flag, b",
+			Usage: "another usage text",
+		},
+	}
+	app.Commands = []Command{{
+		Aliases: []string{"c"},
+		Flags: []Flag{
+			StringFlag{
+				Name:      "flag, fl, f",
+				TakesFile: true,
+			},
+			BoolFlag{
+				Name:  "another-flag, b",
+				Usage: "another usage text",
+			},
+		},
+		Name:  "config",
+		Usage: "another usage test",
+		Subcommands: []Command{{
+			Aliases: []string{"s", "ss"},
+			Flags: []Flag{
+				StringFlag{Name: "sub-flag, sub-fl, s"},
+				BoolFlag{
+					Name:  "sub-command-flag, s",
+					Usage: "some usage text",
+				},
+			},
+			Name:  "sub-config",
+			Usage: "another usage test",
+		}},
+	}, {
+		Aliases: []string{"i", "in"},
+		Name:    "info",
+		Usage:   "retrieve generic information",
+	}, {
+		Name: "some-command",
+	}, {
+		Name:   "hidden-command",
+		Hidden: true,
+	}}
+	app.UsageText = "app [first_arg] [second_arg]"
+	app.Usage = "Some app"
+	app.Author = "Harrison"
+	app.Email = "harrison@lolwut.com"
+	app.Authors = []Author{{Name: "Oliver Allen", Email: "oliver@toyshop.com"}}
+	return app
+}
+
+func expectFileContent(t *testing.T, file, expected string) {
+	data, err := ioutil.ReadFile(file)
+	expect(t, err, nil)
+	expect(t, string(data), expected)
+}
 
 func TestFishCompletion(t *testing.T) {
 	// Given


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Add urfave_cli_no_docs build tag

This removes the resulting binary dependency on cpuguy83/md2man and
russross/blackfriday (and a few more packages imported by those),
which saves more than 400 KB (more than 300 KB
once stripped) from the resulting binary.

## Which issue(s) this PR fixes:

none (although see some discussions in e.g. #1055)

## Special notes for your reviewer:

This is a backport of https://github.com/urfave/cli/pull/1375 to v1 branch.

## Testing

Unit tests with this tag set are added to GHA CI (see last commit).

## Release Notes

```release-note
Added support for `urfave_cli_no_docs` tag to reduce the binary size by 300+ KB
in case your application is not using `ToMarkdown` and `ToMan` methods.
```
