### PR TITLE
feature: add DefaultCommand field to App

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -469,6 +469,42 @@ func TestApp_Command(t *testing.T) {
 	}
 }
 
+var defaultCommandAppTests = []struct {
+	cmdName    string
+	defaultCmd string
+	expected   bool
+}{
+	{"foobar", "foobar", true},
+	{"batbaz", "foobar", true},
+	{"b", "", true},
+	{"f", "", true},
+	{"", "foobar", true},
+	{"", "", true},
+	{" ", "", false},
+	{"bat", "batbaz", false},
+	{"nothing", "batbaz", false},
+	{"nothing", "", false},
+}
+
+func TestApp_RunDefaultCommand(t *testing.T) {
+	for _, test := range defaultCommandAppTests {
+		testTitle := fmt.Sprintf("command=%[1]s-default=%[2]s", test.cmdName, test.defaultCmd)
+		t.Run(testTitle, func(t *testing.T) {
+			app := &App{
+				DefaultCommand: test.defaultCmd,
+				Commands: []*Command{
+					{Name: "foobar", Aliases: []string{"f"}},
+					{Name: "batbaz", Aliases: []string{"b"}},
+				},
+			}
+
+			err := app.Run([]string{"c", test.cmdName})
+			expect(t, err == nil, test.expected)
+		})
+	}
+
+}
+
 func TestApp_Setup_defaultsReader(t *testing.T) {
 	app := &App{}
 	app.Setup()

--- a/app_test.go
+++ b/app_test.go
@@ -502,7 +502,60 @@ func TestApp_RunDefaultCommand(t *testing.T) {
 			expect(t, err == nil, test.expected)
 		})
 	}
+}
 
+var defaultCommandSubCmdAppTests = []struct {
+	cmdName    string
+	subCmd     string
+	defaultCmd string
+	expected   bool
+}{
+	{"foobar", "", "foobar", true},
+	{"foobar", "carly", "foobar", true},
+	{"batbaz", "", "foobar", true},
+	{"b", "", "", true},
+	{"f", "", "", true},
+	{"", "", "foobar", true},
+	{"", "", "", true},
+	{"", "jimbob", "foobar", true},
+	{"", "j", "foobar", true},
+	{"", "carly", "foobar", true},
+	{"", "jimmers", "foobar", true},
+	{"", "jimmers", "", true},
+	{" ", "jimmers", "foobar", false},
+	{"", "", "", true},
+	{" ", "", "", false},
+	{" ", "j", "", false},
+	{"bat", "", "batbaz", false},
+	{"nothing", "", "batbaz", false},
+	{"nothing", "", "", false},
+	{"nothing", "j", "batbaz", false},
+	{"nothing", "carly", "", false},
+}
+
+func TestApp_RunDefaultCommandWithSubCommand(t *testing.T) {
+	for _, test := range defaultCommandSubCmdAppTests {
+		testTitle := fmt.Sprintf("command=%[1]s-subcmd=%[2]s-default=%[3]s", test.cmdName, test.subCmd, test.defaultCmd)
+		t.Run(testTitle, func(t *testing.T) {
+			app := &App{
+				DefaultCommand: test.defaultCmd,
+				Commands: []*Command{
+					{
+						Name:    "foobar",
+						Aliases: []string{"f"},
+						Subcommands: []*Command{
+							{Name: "jimbob", Aliases: []string{"j"}},
+							{Name: "carly"},
+						},
+					},
+					{Name: "batbaz", Aliases: []string{"b"}},
+				},
+			}
+			
+			err := app.Run([]string{"c", test.cmdName, test.subCmd})
+			expect(t, err == nil, test.expected)
+		})
+	}
 }
 
 func TestApp_Setup_defaultsReader(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -558,6 +558,86 @@ func TestApp_RunDefaultCommandWithSubCommand(t *testing.T) {
 	}
 }
 
+var defaultCommandFlagAppTests = []struct {
+	cmdName    string
+	flag       string
+	defaultCmd string
+	expected   bool
+}{
+	{"foobar", "", "foobar", true},
+	{"foobar", "-c derp", "foobar", true},
+	{"batbaz", "", "foobar", true},
+	{"b", "", "", true},
+	{"f", "", "", true},
+	{"", "", "foobar", true},
+	{"", "", "", true},
+	{"", "-j", "foobar", true},
+	{"", "-j", "foobar", true},
+	{"", "-c derp", "foobar", true},
+	{"", "--carly=derp", "foobar", true},
+	{"", "-j", "foobar", true},
+	{"", "-j", "", true},
+	{" ", "-j", "foobar", false},
+	{"", "", "", true},
+	{" ", "", "", false},
+	{" ", "-j", "", false},
+	{"bat", "", "batbaz", false},
+	{"nothing", "", "batbaz", false},
+	{"nothing", "", "", false},
+	{"nothing", "--jimbob", "batbaz", false},
+	{"nothing", "--carly", "", false},
+}
+
+func TestApp_RunDefaultCommandWithFlags(t *testing.T) {
+	for _, test := range defaultCommandFlagAppTests {
+		testTitle := fmt.Sprintf("command=%[1]s-flag=%[2]s-default=%[3]s", test.cmdName, test.flag, test.defaultCmd)
+		t.Run(testTitle, func(t *testing.T) {
+			app := &App{
+				DefaultCommand: test.defaultCmd,
+				Flags: []Flag{
+					&StringFlag{
+						Name:     "carly",
+						Aliases:  []string{"c"},
+						Required: false,
+					},
+					&BoolFlag{
+						Name:     "jimbob",
+						Aliases:  []string{"j"},
+						Required: false,
+						Value:    true,
+					},
+				},
+				Commands: []*Command{
+					{
+						Name:    "foobar",
+						Aliases: []string{"f"},
+					},
+					{Name: "batbaz", Aliases: []string{"b"}},
+				},
+			}
+
+			appArgs := []string{"c"}
+
+			if test.flag != "" {
+				flags := strings.Split(test.flag, " ")
+				if len(flags) > 1 {
+					appArgs = append(appArgs, flags...)
+				}
+
+				flags = strings.Split(test.flag, "=")
+				if len(flags) > 1 {
+					appArgs = append(appArgs, flags...)
+				}
+			}
+
+			appArgs = append(appArgs, test.cmdName)
+
+			err := app.Run(appArgs)
+			expect(t, err == nil, test.expected)
+		})
+	}
+}
+
 func TestApp_Setup_defaultsReader(t *testing.T) {
 	app := &App{}
 	app.Setup()

--- a/app_test.go
+++ b/app_test.go
@@ -551,7 +551,7 @@ func TestApp_RunDefaultCommandWithSubCommand(t *testing.T) {
 					{Name: "batbaz", Aliases: []string{"b"}},
 				},
 			}
-			
+
 			err := app.Run([]string{"c", test.cmdName, test.subCmd})
 			expect(t, err == nil, test.expected)
 		})


### PR DESCRIPTION
See issue #1307 for context.

## What type of PR is this?

- feature

## What this PR does / why we need it:

Enables a CLI application to run a default `Command` (by name) if no command name is passed as a cli argument.

## Which issue(s) this PR fixes:

Fixes #1307 

## Special notes for your reviewer:

Genuinely unsure if I implemented this correctly, but the test cases look sane on my end and they pass. 

## Release Notes

```release-note
cli.App now has a `DefaultCommand` field, which, if set, enables a cli.App to run a specific command if no command is otherwise passed as an argument. 
```
