### PR TITLE
Add JSON wrapping generic capability

### DIFF
--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -205,18 +205,18 @@ func (fsm *MapInputSource) Generic(name string) (cli.Generic, error) {
 	otherGenericValue, exists := fsm.valueMap[name]
 	if exists {
 		otherValue, isType := otherGenericValue.(cli.Generic)
-		if !isType {
-			return nil, incorrectTypeForFlagError(name, "cli.Generic", otherGenericValue)
+		if isType {
+			return otherValue, nil
 		}
-		return otherValue, nil
+		return cli.JSONWrapGeneric(otherGenericValue), nil
 	}
 	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
 	if exists {
 		otherValue, isType := nestedGenericValue.(cli.Generic)
-		if !isType {
-			return nil, incorrectTypeForFlagError(name, "cli.Generic", nestedGenericValue)
+		if isType {
+			return otherValue, nil
 		}
-		return otherValue, nil
+		return cli.JSONWrapGeneric(nestedGenericValue), nil
 	}
 
 	return nil, nil

--- a/flag_generic.go
+++ b/flag_generic.go
@@ -20,15 +20,11 @@ type jsonGenericWrapper struct {
 }
 
 func (gw *jsonGenericWrapper) Set(value string) error {
-	fromJSONStr := ""
-
-	if err := json.Unmarshal([]byte(value), &fromJSONStr); err == nil {
-		value = fromJSONStr
-	}
-
 	return json.Unmarshal([]byte(value), &gw.v)
 }
 
+// String makes a best effort to JSON marshal the wrapped type and
+// falls back to returning the fmt "%v" representation.
 func (gw *jsonGenericWrapper) String() string {
 	vBytes, err := json.Marshal(gw.v)
 	if err != nil {

--- a/flag_test.go
+++ b/flag_test.go
@@ -1253,6 +1253,28 @@ func TestGenericFlagValueFromContext(t *testing.T) {
 	expect(t, f.Get(ctx), &Parser{"abc", "def"})
 }
 
+func TestJSONWrapGeneric(t *testing.T) {
+	type unknowable []uint8
+
+	unk := unknowable([]uint8{4, 8, 15, 16, 23, 42})
+
+	app := &App{
+		Flags: []Flag{
+			&GenericFlag{Name: "unk", Value: JSONWrapGeneric(&unk)},
+		},
+		Action: func(cCtx *Context) error {
+			unkValue := *cCtx.Generic("unk").(*unknowable)
+			expect(t, unkValue, unknowable([]uint8{6, 1, 0}))
+
+			return nil
+		},
+	}
+
+	if err := app.Run([]string{"cmd", "--unk", "[6,1,0]"}); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestParseMultiString(t *testing.T) {
 	_ = (&App{
 		Flags: []Flag{


### PR DESCRIPTION
## What type of PR is this?

- bug
- feature

## What this PR does / why we need it:

This change adds JSON wrapping generic capability to allow for wrapping of any type with JSON marshal/unmarshal so that it may provide the `Generic` interface. This is also useful when reading values from `altsrc` providers where the type information is likely at a more primitive level than what a given `Generic` type may allow.

## Which issue(s) this PR fixes:

Fixes #1072 

## Special notes for your reviewer:

I'm labeling this both `kind/feature` and `kind/bug` given that I'm addressing a bug fix (#1072) with a feature.