### PR TITLE
Generate RequiredFlag and VisibleFlag implementations

### DIFF
--- a/flag_bool.go
+++ b/flag_bool.go
@@ -6,11 +6,6 @@ import (
 	"strconv"
 )
 
-// IsRequired returns whether or not the flag is required
-func (f *BoolFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *BoolFlag) TakesValue() bool {
 	return false
@@ -25,11 +20,6 @@ func (f *BoolFlag) GetUsage() string {
 // string if the flag takes no value at all.
 func (f *BoolFlag) GetValue() string {
 	return ""
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *BoolFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_duration.go
+++ b/flag_duration.go
@@ -6,11 +6,6 @@ import (
 	"time"
 )
 
-// IsRequired returns whether or not the flag is required
-func (f *DurationFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *DurationFlag) TakesValue() bool {
 	return true
@@ -25,11 +20,6 @@ func (f *DurationFlag) GetUsage() string {
 // string if the flag takes no value at all.
 func (f *DurationFlag) GetValue() string {
 	return f.Value.String()
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *DurationFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_float64.go
+++ b/flag_float64.go
@@ -6,11 +6,6 @@ import (
 	"strconv"
 )
 
-// IsRequired returns whether or not the flag is required
-func (f *Float64Flag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *Float64Flag) TakesValue() bool {
 	return true
@@ -38,11 +33,6 @@ func (f *Float64Flag) GetDefaultText() string {
 // GetEnvVars returns the env vars for this flag
 func (f *Float64Flag) GetEnvVars() []string {
 	return f.EnvVars
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *Float64Flag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // Apply populates the flag given the flag set and environment

--- a/flag_float64_slice.go
+++ b/flag_float64_slice.go
@@ -81,11 +81,6 @@ func (f *Float64SliceFlag) String() string {
 	return withEnvHint(f.GetEnvVars(), stringifyFloat64SliceFlag(f))
 }
 
-// IsRequired returns whether or not the flag is required
-func (f *Float64SliceFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true if the flag takes a value, otherwise false
 func (f *Float64SliceFlag) TakesValue() bool {
 	return true
@@ -103,11 +98,6 @@ func (f *Float64SliceFlag) GetValue() string {
 		return f.Value.String()
 	}
 	return ""
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *Float64SliceFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_generic.go
+++ b/flag_generic.go
@@ -11,11 +11,6 @@ type Generic interface {
 	String() string
 }
 
-// IsRequired returns whether or not the flag is required
-func (f *GenericFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *GenericFlag) TakesValue() bool {
 	return true
@@ -33,11 +28,6 @@ func (f *GenericFlag) GetValue() string {
 		return f.Value.String()
 	}
 	return ""
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *GenericFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_int.go
+++ b/flag_int.go
@@ -6,11 +6,6 @@ import (
 	"strconv"
 )
 
-// IsRequired returns whether or not the flag is required
-func (f *IntFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *IntFlag) TakesValue() bool {
 	return true
@@ -25,11 +20,6 @@ func (f *IntFlag) GetUsage() string {
 // string if the flag takes no value at all.
 func (f *IntFlag) GetValue() string {
 	return fmt.Sprintf("%d", f.Value)
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *IntFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_int64.go
+++ b/flag_int64.go
@@ -6,11 +6,6 @@ import (
 	"strconv"
 )
 
-// IsRequired returns whether or not the flag is required
-func (f *Int64Flag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *Int64Flag) TakesValue() bool {
 	return true
@@ -25,11 +20,6 @@ func (f *Int64Flag) GetUsage() string {
 // string if the flag takes no value at all.
 func (f *Int64Flag) GetValue() string {
 	return fmt.Sprintf("%d", f.Value)
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *Int64Flag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_int64_slice.go
+++ b/flag_int64_slice.go
@@ -82,11 +82,6 @@ func (f *Int64SliceFlag) String() string {
 	return withEnvHint(f.GetEnvVars(), stringifyInt64SliceFlag(f))
 }
 
-// IsRequired returns whether or not the flag is required
-func (f *Int64SliceFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *Int64SliceFlag) TakesValue() bool {
 	return true
@@ -104,11 +99,6 @@ func (f *Int64SliceFlag) GetValue() string {
 		return f.Value.String()
 	}
 	return ""
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *Int64SliceFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -93,11 +93,6 @@ func (f *IntSliceFlag) String() string {
 	return withEnvHint(f.GetEnvVars(), stringifyIntSliceFlag(f))
 }
 
-// IsRequired returns whether or not the flag is required
-func (f *IntSliceFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *IntSliceFlag) TakesValue() bool {
 	return true
@@ -115,11 +110,6 @@ func (f *IntSliceFlag) GetValue() string {
 		return f.Value.String()
 	}
 	return ""
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *IntSliceFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_path.go
+++ b/flag_path.go
@@ -7,11 +7,6 @@ import (
 
 type Path = string
 
-// IsRequired returns whether or not the flag is required
-func (f *PathFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *PathFlag) TakesValue() bool {
 	return true
@@ -26,11 +21,6 @@ func (f *PathFlag) GetUsage() string {
 // string if the flag takes no value at all.
 func (f *PathFlag) GetValue() string {
 	return f.Value
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *PathFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_string.go
+++ b/flag_string.go
@@ -5,11 +5,6 @@ import (
 	"fmt"
 )
 
-// IsRequired returns whether or not the flag is required
-func (f *StringFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *StringFlag) TakesValue() bool {
 	return true
@@ -24,11 +19,6 @@ func (f *StringFlag) GetUsage() string {
 // string if the flag takes no value at all.
 func (f *StringFlag) GetValue() string {
 	return f.Value
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *StringFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -76,11 +76,6 @@ func (f *StringSliceFlag) String() string {
 	return withEnvHint(f.GetEnvVars(), stringifyStringSliceFlag(f))
 }
 
-// IsRequired returns whether or not the flag is required
-func (f *StringSliceFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *StringSliceFlag) TakesValue() bool {
 	return true
@@ -98,11 +93,6 @@ func (f *StringSliceFlag) GetValue() string {
 		return f.Value.String()
 	}
 	return ""
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *StringSliceFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -58,11 +58,6 @@ func (t *Timestamp) Get() interface{} {
 	return *t
 }
 
-// IsRequired returns whether or not the flag is required
-func (f *TimestampFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *TimestampFlag) TakesValue() bool {
 	return true
@@ -80,11 +75,6 @@ func (f *TimestampFlag) GetValue() string {
 		return f.Value.timestamp.String()
 	}
 	return ""
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *TimestampFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // GetDefaultText returns the default text for this flag

--- a/flag_uint.go
+++ b/flag_uint.go
@@ -6,11 +6,6 @@ import (
 	"strconv"
 )
 
-// IsRequired returns whether or not the flag is required
-func (f *UintFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *UintFlag) TakesValue() bool {
 	return true
@@ -19,11 +14,6 @@ func (f *UintFlag) TakesValue() bool {
 // GetUsage returns the usage string for the flag
 func (f *UintFlag) GetUsage() string {
 	return f.Usage
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *UintFlag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // Apply populates the flag given the flag set and environment

--- a/flag_uint64.go
+++ b/flag_uint64.go
@@ -6,11 +6,6 @@ import (
 	"strconv"
 )
 
-// IsRequired returns whether or not the flag is required
-func (f *Uint64Flag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *Uint64Flag) TakesValue() bool {
 	return true
@@ -19,11 +14,6 @@ func (f *Uint64Flag) TakesValue() bool {
 // GetUsage returns the usage string for the flag
 func (f *Uint64Flag) GetUsage() string {
 	return f.Usage
-}
-
-// IsVisible returns true if the flag is not hidden, otherwise false
-func (f *Uint64Flag) IsVisible() bool {
-	return !f.Hidden
 }
 
 // Apply populates the flag given the flag set and environment

--- a/internal/genflags/generated.gotmpl
+++ b/internal/genflags/generated.gotmpl
@@ -31,7 +31,7 @@ type {{.TypeName}} struct {
 func (f *{{.TypeName}}) String() string {
   return {{$.UrfaveCLINamespace}}FlagStringer(f)
 }
-{{end}}
+{{end}}{{/* /if .GenerateFmtStringerInterface */}}
 
 {{if .GenerateFlagInterface}}
 // IsSet returns whether or not the flag has been set through env or file
@@ -45,6 +45,20 @@ func (f *{{.TypeName}}) Names() []string {
 }
 
 {{end}}{{/* /if .GenerateFlagInterface */}}
+
+{{if .GenerateRequiredFlagInterface}}
+// IsRequired returns whether or not the flag is required
+func (f *{{.TypeName}}) IsRequired() bool {
+  return f.Required
+}
+{{end}}{{/* /if .GenerateRequiredFlagInterface */}}
+
+{{if .GenerateVisibleFlagInterface}}
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *{{.TypeName}}) IsVisible() bool {
+	return !f.Hidden
+}
+{{end}}{{/* /if .GenerateVisibleFlagInterface */}}
 {{end}}{{/* /range .SortedFlagTypes */}}
 
 // vim{{/* 👻 */}}:ro

--- a/internal/genflags/generated_test.gotmpl
+++ b/internal/genflags/generated_test.gotmpl
@@ -19,6 +19,22 @@ func Test{{.TypeName}}_SatisfiesFmtStringerInterface(t *testing.T) {
   _ = f.String()
 }
 {{end}}
+
+{{if .GenerateRequiredFlagInterface}}
+func Test{{.TypeName}}_SatisfiesRequiredFlagInterface(t *testing.T) {
+  var f {{$.UrfaveCLITestNamespace}}RequiredFlag = &{{$.UrfaveCLITestNamespace}}{{.TypeName}}{}
+
+  _ = f.IsRequired()
+}
+{{end}}
+
+{{if .GenerateVisibleFlagInterface}}
+func Test{{.TypeName}}_SatisfiesVisibleFlagInterface(t *testing.T) {
+  var f {{$.UrfaveCLITestNamespace}}VisibleFlag = &{{$.UrfaveCLITestNamespace}}{{.TypeName}}{}
+
+  _ = f.IsVisible()
+}
+{{end}}
 {{end}}
 
 // vim{{/* 👻 */}}:ro

--- a/internal/genflags/spec.go
+++ b/internal/genflags/spec.go
@@ -83,6 +83,14 @@ func (ft *FlagType) GenerateFlagInterface() bool {
 	return ft.skipInterfaceNamed("Flag")
 }
 
+func (ft *FlagType) GenerateRequiredFlagInterface() bool {
+	return ft.skipInterfaceNamed("RequiredFlag")
+}
+
+func (ft *FlagType) GenerateVisibleFlagInterface() bool {
+	return ft.skipInterfaceNamed("VisibleFlag")
+}
+
 func (ft *FlagType) skipInterfaceNamed(name string) bool {
 	if ft.Config == nil {
 		return true

--- a/zz_generated.flags.go
+++ b/zz_generated.flags.go
@@ -33,6 +33,16 @@ func (f *Float64SliceFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+// IsRequired returns whether or not the flag is required
+func (f *Float64SliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Float64SliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
 // GenericFlag is a flag with type Generic
 type GenericFlag struct {
 	Name string
@@ -69,6 +79,16 @@ func (f *GenericFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+// IsRequired returns whether or not the flag is required
+func (f *GenericFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *GenericFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
 // Int64SliceFlag is a flag with type *Int64Slice
 type Int64SliceFlag struct {
 	Name string
@@ -98,6 +118,16 @@ func (f *Int64SliceFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+// IsRequired returns whether or not the flag is required
+func (f *Int64SliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Int64SliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
 // IntSliceFlag is a flag with type *IntSlice
 type IntSliceFlag struct {
 	Name string
@@ -125,6 +155,16 @@ func (f *IntSliceFlag) IsSet() bool {
 // Names returns the names of the flag
 func (f *IntSliceFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *IntSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *IntSliceFlag) IsVisible() bool {
+	return !f.Hidden
 }
 
 // PathFlag is a flag with type Path
@@ -163,6 +203,16 @@ func (f *PathFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+// IsRequired returns whether or not the flag is required
+func (f *PathFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *PathFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
 // StringSliceFlag is a flag with type *StringSlice
 type StringSliceFlag struct {
 	Name string
@@ -192,6 +242,16 @@ func (f *StringSliceFlag) IsSet() bool {
 // Names returns the names of the flag
 func (f *StringSliceFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *StringSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *StringSliceFlag) IsVisible() bool {
+	return !f.Hidden
 }
 
 // TimestampFlag is a flag with type *Timestamp
@@ -230,6 +290,16 @@ func (f *TimestampFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+// IsRequired returns whether or not the flag is required
+func (f *TimestampFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *TimestampFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
 // BoolFlag is a flag with type bool
 type BoolFlag struct {
 	Name string
@@ -262,6 +332,16 @@ func (f *BoolFlag) IsSet() bool {
 // Names returns the names of the flag
 func (f *BoolFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *BoolFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *BoolFlag) IsVisible() bool {
+	return !f.Hidden
 }
 
 // Float64Flag is a flag with type float64
@@ -298,6 +378,16 @@ func (f *Float64Flag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+// IsRequired returns whether or not the flag is required
+func (f *Float64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Float64Flag) IsVisible() bool {
+	return !f.Hidden
+}
+
 // IntFlag is a flag with type int
 type IntFlag struct {
 	Name string
@@ -332,6 +422,16 @@ func (f *IntFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+// IsRequired returns whether or not the flag is required
+func (f *IntFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *IntFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
 // Int64Flag is a flag with type int64
 type Int64Flag struct {
 	Name string
@@ -364,6 +464,16 @@ func (f *Int64Flag) IsSet() bool {
 // Names returns the names of the flag
 func (f *Int64Flag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Int64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Int64Flag) IsVisible() bool {
+	return !f.Hidden
 }
 
 // StringFlag is a flag with type string
@@ -402,6 +512,16 @@ func (f *StringFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+// IsRequired returns whether or not the flag is required
+func (f *StringFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *StringFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
 // DurationFlag is a flag with type time.Duration
 type DurationFlag struct {
 	Name string
@@ -434,6 +554,16 @@ func (f *DurationFlag) IsSet() bool {
 // Names returns the names of the flag
 func (f *DurationFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *DurationFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *DurationFlag) IsVisible() bool {
+	return !f.Hidden
 }
 
 // UintFlag is a flag with type uint
@@ -470,6 +600,16 @@ func (f *UintFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+// IsRequired returns whether or not the flag is required
+func (f *UintFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *UintFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
 // Uint64Flag is a flag with type uint64
 type Uint64Flag struct {
 	Name string
@@ -502,6 +642,16 @@ func (f *Uint64Flag) IsSet() bool {
 // Names returns the names of the flag
 func (f *Uint64Flag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Uint64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Uint64Flag) IsVisible() bool {
+	return !f.Hidden
 }
 
 // vim:ro

--- a/zz_generated.flags_test.go
+++ b/zz_generated.flags_test.go
@@ -16,6 +16,18 @@ func TestFloat64SliceFlag_SatisfiesFlagInterface(t *testing.T) {
 	_ = f.Names()
 }
 
+func TestFloat64SliceFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.Float64SliceFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestFloat64SliceFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.Float64SliceFlag{}
+
+	_ = f.IsVisible()
+}
+
 func TestGenericFlag_SatisfiesFlagInterface(t *testing.T) {
 	var f cli.Flag = &cli.GenericFlag{}
 
@@ -29,6 +41,18 @@ func TestGenericFlag_SatisfiesFmtStringerInterface(t *testing.T) {
 	_ = f.String()
 }
 
+func TestGenericFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.GenericFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestGenericFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.GenericFlag{}
+
+	_ = f.IsVisible()
+}
+
 func TestInt64SliceFlag_SatisfiesFlagInterface(t *testing.T) {
 	var f cli.Flag = &cli.Int64SliceFlag{}
 
@@ -36,11 +60,35 @@ func TestInt64SliceFlag_SatisfiesFlagInterface(t *testing.T) {
 	_ = f.Names()
 }
 
+func TestInt64SliceFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.Int64SliceFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestInt64SliceFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.Int64SliceFlag{}
+
+	_ = f.IsVisible()
+}
+
 func TestIntSliceFlag_SatisfiesFlagInterface(t *testing.T) {
 	var f cli.Flag = &cli.IntSliceFlag{}
 
 	_ = f.IsSet()
 	_ = f.Names()
+}
+
+func TestIntSliceFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.IntSliceFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestIntSliceFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.IntSliceFlag{}
+
+	_ = f.IsVisible()
 }
 
 func TestPathFlag_SatisfiesFlagInterface(t *testing.T) {
@@ -56,11 +104,35 @@ func TestPathFlag_SatisfiesFmtStringerInterface(t *testing.T) {
 	_ = f.String()
 }
 
+func TestPathFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.PathFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestPathFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.PathFlag{}
+
+	_ = f.IsVisible()
+}
+
 func TestStringSliceFlag_SatisfiesFlagInterface(t *testing.T) {
 	var f cli.Flag = &cli.StringSliceFlag{}
 
 	_ = f.IsSet()
 	_ = f.Names()
+}
+
+func TestStringSliceFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.StringSliceFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestStringSliceFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.StringSliceFlag{}
+
+	_ = f.IsVisible()
 }
 
 func TestTimestampFlag_SatisfiesFlagInterface(t *testing.T) {
@@ -76,6 +148,18 @@ func TestTimestampFlag_SatisfiesFmtStringerInterface(t *testing.T) {
 	_ = f.String()
 }
 
+func TestTimestampFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.TimestampFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestTimestampFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.TimestampFlag{}
+
+	_ = f.IsVisible()
+}
+
 func TestBoolFlag_SatisfiesFlagInterface(t *testing.T) {
 	var f cli.Flag = &cli.BoolFlag{}
 
@@ -87,6 +171,18 @@ func TestBoolFlag_SatisfiesFmtStringerInterface(t *testing.T) {
 	var f fmt.Stringer = &cli.BoolFlag{}
 
 	_ = f.String()
+}
+
+func TestBoolFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.BoolFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestBoolFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.BoolFlag{}
+
+	_ = f.IsVisible()
 }
 
 func TestFloat64Flag_SatisfiesFlagInterface(t *testing.T) {
@@ -102,6 +198,18 @@ func TestFloat64Flag_SatisfiesFmtStringerInterface(t *testing.T) {
 	_ = f.String()
 }
 
+func TestFloat64Flag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.Float64Flag{}
+
+	_ = f.IsRequired()
+}
+
+func TestFloat64Flag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.Float64Flag{}
+
+	_ = f.IsVisible()
+}
+
 func TestIntFlag_SatisfiesFlagInterface(t *testing.T) {
 	var f cli.Flag = &cli.IntFlag{}
 
@@ -113,6 +221,18 @@ func TestIntFlag_SatisfiesFmtStringerInterface(t *testing.T) {
 	var f fmt.Stringer = &cli.IntFlag{}
 
 	_ = f.String()
+}
+
+func TestIntFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.IntFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestIntFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.IntFlag{}
+
+	_ = f.IsVisible()
 }
 
 func TestInt64Flag_SatisfiesFlagInterface(t *testing.T) {
@@ -128,6 +248,18 @@ func TestInt64Flag_SatisfiesFmtStringerInterface(t *testing.T) {
 	_ = f.String()
 }
 
+func TestInt64Flag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.Int64Flag{}
+
+	_ = f.IsRequired()
+}
+
+func TestInt64Flag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.Int64Flag{}
+
+	_ = f.IsVisible()
+}
+
 func TestStringFlag_SatisfiesFlagInterface(t *testing.T) {
 	var f cli.Flag = &cli.StringFlag{}
 
@@ -139,6 +271,18 @@ func TestStringFlag_SatisfiesFmtStringerInterface(t *testing.T) {
 	var f fmt.Stringer = &cli.StringFlag{}
 
 	_ = f.String()
+}
+
+func TestStringFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.StringFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestStringFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.StringFlag{}
+
+	_ = f.IsVisible()
 }
 
 func TestDurationFlag_SatisfiesFlagInterface(t *testing.T) {
@@ -154,6 +298,18 @@ func TestDurationFlag_SatisfiesFmtStringerInterface(t *testing.T) {
 	_ = f.String()
 }
 
+func TestDurationFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.DurationFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestDurationFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.DurationFlag{}
+
+	_ = f.IsVisible()
+}
+
 func TestUintFlag_SatisfiesFlagInterface(t *testing.T) {
 	var f cli.Flag = &cli.UintFlag{}
 
@@ -167,6 +323,18 @@ func TestUintFlag_SatisfiesFmtStringerInterface(t *testing.T) {
 	_ = f.String()
 }
 
+func TestUintFlag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.UintFlag{}
+
+	_ = f.IsRequired()
+}
+
+func TestUintFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.UintFlag{}
+
+	_ = f.IsVisible()
+}
+
 func TestUint64Flag_SatisfiesFlagInterface(t *testing.T) {
 	var f cli.Flag = &cli.Uint64Flag{}
 
@@ -178,6 +346,18 @@ func TestUint64Flag_SatisfiesFmtStringerInterface(t *testing.T) {
 	var f fmt.Stringer = &cli.Uint64Flag{}
 
 	_ = f.String()
+}
+
+func TestUint64Flag_SatisfiesRequiredFlagInterface(t *testing.T) {
+	var f cli.RequiredFlag = &cli.Uint64Flag{}
+
+	_ = f.IsRequired()
+}
+
+func TestUint64Flag_SatisfiesVisibleFlagInterface(t *testing.T) {
+	var f cli.VisibleFlag = &cli.Uint64Flag{}
+
+	_ = f.IsVisible()
 }
 
 // vim:ro


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Generate each flag type's implementations of the `RequiredFlag` and `VisibleFlag` interfaces so that they do not need to be maintained separately/manually.

## Which issue(s) this PR fixes:

N/A 😬 