### PR TITLE
Fix 'repetetive' typo

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -85,7 +85,7 @@ step.
 #### generated code
 
 A significant portion of the project's source code is generated, with the goal being to
-eliminate repetetive maintenance where other type-safe abstraction is impractical or
+eliminate repetitive maintenance where other type-safe abstraction is impractical or
 impossible with Go versions `< 1.18`. In a future where the eldest Go version supported is
 `1.18.x`, there will likely be efforts to take advantage of
 [generics](https://go.dev/doc/tutorial/generics).


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

This is a documentation typo fix, also created so I can test that CI is green on the tip of main.

## Which issue(s) this PR fixes:

(none)

## Release Notes

```release-note
NONE
```
