### PR TITLE
Run docs tests against current work tree

### DIFF
--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -363,7 +363,7 @@ For example this:
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": "add a task to the list\n.*complete a task on the list\n.*\n\n.*\n.*Load configuration from FILE\n.*Language for the greeting.*"
+  "output": ".*Language for the greeting.*"
 } -->
 ``` go
 package main

--- a/docs/v2/manual.md
+++ b/docs/v2/manual.md
@@ -363,7 +363,7 @@ For example this:
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": ".*Language for the greeting.*"
+  "output": ".*Load configuration from FILE\n.*\n.*Language for the greeting.*"
 } -->
 ``` go
 package main

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -182,6 +182,13 @@ func testCleanup(packages []string) error {
 func GfmrunActionFunc(cCtx *cli.Context) error {
 	top := cCtx.Path("top")
 
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		return err
+	}
+
+	os.Setenv("SHELL", bash)
+
 	tmpDir, err := os.MkdirTemp("", "urfave-cli*")
 	if err != nil {
 		return err
@@ -203,7 +210,6 @@ func GfmrunActionFunc(cCtx *cli.Context) error {
 	}
 
 	os.Setenv("TMPDIR", tmpDir)
-	os.Setenv("SHELL", "bash")
 
 	if err := os.Chdir(wd); err != nil {
 		return err

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -179,8 +179,37 @@ func testCleanup(packages []string) error {
 	return os.WriteFile("coverage.txt", out.Bytes(), 0644)
 }
 
-func GfmrunActionFunc(c *cli.Context) error {
-	filename := c.Args().Get(0)
+func GfmrunActionFunc(cCtx *cli.Context) error {
+	top := cCtx.Path("top")
+
+	tmpDir, err := os.MkdirTemp("", "urfave-cli*")
+	if err != nil {
+		return err
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Chdir(tmpDir); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cCtx.App.ErrWriter, "# ---> workspace/TMPDIR is %q\n", tmpDir)
+
+	if err := runCmd("go", "work", "init", top); err != nil {
+		return err
+	}
+
+	os.Setenv("TMPDIR", tmpDir)
+	os.Setenv("SHELL", "bash")
+
+	if err := os.Chdir(wd); err != nil {
+		return err
+	}
+
+	filename := cCtx.Args().Get(0)
 	if filename == "" {
 		filename = "README.md"
 	}
@@ -209,7 +238,11 @@ func GfmrunActionFunc(c *cli.Context) error {
 		return err
 	}
 
-	return runCmd("gfmrun", "-c", fmt.Sprint(counter), "-s", filename)
+	if err := runCmd("gfmrun", "-c", fmt.Sprint(counter), "-s", filename); err != nil {
+		return err
+	}
+
+	return os.RemoveAll(tmpDir)
 }
 
 // checkBinarySizeActionFunc checks the size of an example binary to ensure that we are keeping size down


### PR DESCRIPTION
## What type of PR is this?

- bug
- documentation

## What this PR does / why we need it:

This change ensures the docs tests are run against the current work tree by creating a temporary go workspace to be used by gfmrun via `TMPDIR`.

## Which issue(s) this PR fixes:

N/A 😬 