### PR TITLE
Remove temporary go mod workaround

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -34,10 +34,6 @@ jobs:
         if: matrix.go == '1.18.x' && matrix.os == 'ubuntu-latest'
         run: test -z $(gofmt -l .)
 
-      # https://github.com/urfave/cli/pull/1405#issuecomment-1135458582
-      - name: workaround for golang.org/x/tools error
-        run: go mod download golang.org/x/tools
-
       - name: vet
         run: go run internal/build/build.go vet
 


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Remove a temporary workaround for cross-version go.mod compatibility.

## Which issue(s) this PR fixes:

Loosely related to a comment in #1405 