### PR TITLE
Add SetRequired method to Flag interface

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -2083,6 +2083,8 @@ func (c *customBoolFlag) IsSet() bool {
 	return false
 }
 
+func (c *customBoolFlag) SetRequired(bool) {}
+
 func TestCustomFlagsUnused(t *testing.T) {
 	app := &App{
 		Flags:  []Flag{&customBoolFlag{"custom"}},

--- a/flag.go
+++ b/flag.go
@@ -93,6 +93,7 @@ type Flag interface {
 	Apply(*flag.FlagSet) error
 	Names() []string
 	IsSet() bool
+	SetRequired(bool)
 }
 
 // RequiredFlag is an interface that allows us to mark flags as required

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -484,6 +484,8 @@ func (f *BoolFlag) IsVisible() bool
 func (f *BoolFlag) Names() []string
     Names returns the names of the flag
 
+func (f *BoolFlag) SetRequired(required bool)
+
 func (f *BoolFlag) String() string
     String returns a readable representation of this value (for usage defaults)
 
@@ -774,6 +776,8 @@ func (f *DurationFlag) IsVisible() bool
 func (f *DurationFlag) Names() []string
     Names returns the names of the flag
 
+func (f *DurationFlag) SetRequired(required bool)
+
 func (f *DurationFlag) String() string
     String returns a readable representation of this value (for usage defaults)
 
@@ -817,6 +821,7 @@ type Flag interface {
 	Apply(*flag.FlagSet) error
 	Names() []string
 	IsSet() bool
+	SetRequired(bool)
 }
     Flag is a common interface related to parsing flags in cli. For more
     advanced flag parsing techniques, it is recommended that this interface be
@@ -947,6 +952,8 @@ func (f *Float64Flag) IsVisible() bool
 func (f *Float64Flag) Names() []string
     Names returns the names of the flag
 
+func (f *Float64Flag) SetRequired(required bool)
+
 func (f *Float64Flag) String() string
     String returns a readable representation of this value (for usage defaults)
 
@@ -1034,6 +1041,8 @@ func (f *Float64SliceFlag) Names() []string
 
 func (f *Float64SliceFlag) SetDestination(slice []float64)
 
+func (f *Float64SliceFlag) SetRequired(required bool)
+
 func (f *Float64SliceFlag) SetValue(slice []float64)
 
 func (f *Float64SliceFlag) String() string
@@ -1105,6 +1114,8 @@ func (f *GenericFlag) IsVisible() bool
 func (f *GenericFlag) Names() []string
     Names returns the names of the flag
 
+func (f *GenericFlag) SetRequired(required bool)
+
 func (f *GenericFlag) String() string
     String returns a readable representation of this value (for usage defaults)
 
@@ -1164,6 +1175,8 @@ func (f *Int64Flag) IsVisible() bool
 
 func (f *Int64Flag) Names() []string
     Names returns the names of the flag
+
+func (f *Int64Flag) SetRequired(required bool)
 
 func (f *Int64Flag) String() string
     String returns a readable representation of this value (for usage defaults)
@@ -1252,6 +1265,8 @@ func (f *Int64SliceFlag) Names() []string
 
 func (f *Int64SliceFlag) SetDestination(slice []int64)
 
+func (f *Int64SliceFlag) SetRequired(required bool)
+
 func (f *Int64SliceFlag) SetValue(slice []int64)
 
 func (f *Int64SliceFlag) String() string
@@ -1313,6 +1328,8 @@ func (f *IntFlag) IsVisible() bool
 
 func (f *IntFlag) Names() []string
     Names returns the names of the flag
+
+func (f *IntFlag) SetRequired(required bool)
 
 func (f *IntFlag) String() string
     String returns a readable representation of this value (for usage defaults)
@@ -1404,6 +1421,8 @@ func (f *IntSliceFlag) Names() []string
     Names returns the names of the flag
 
 func (f *IntSliceFlag) SetDestination(slice []int)
+
+func (f *IntSliceFlag) SetRequired(required bool)
 
 func (f *IntSliceFlag) SetValue(slice []int)
 
@@ -1499,6 +1518,8 @@ func (f *PathFlag) IsVisible() bool
 func (f *PathFlag) Names() []string
     Names returns the names of the flag
 
+func (f *PathFlag) SetRequired(required bool)
+
 func (f *PathFlag) String() string
     String returns a readable representation of this value (for usage defaults)
 
@@ -1552,6 +1573,8 @@ func (x *SliceFlag[T, S, E]) IsVisible() bool
 func (x *SliceFlag[T, S, E]) Names() []string
 
 func (x *SliceFlag[T, S, E]) SetDestination(slice S)
+
+func (x *SliceFlag[T, S, E]) SetRequired(bool)
 
 func (x *SliceFlag[T, S, E]) SetValue(slice S)
 
@@ -1635,6 +1658,8 @@ func (f *StringFlag) IsVisible() bool
 
 func (f *StringFlag) Names() []string
     Names returns the names of the flag
+
+func (f *StringFlag) SetRequired(required bool)
 
 func (f *StringFlag) String() string
     String returns a readable representation of this value (for usage defaults)
@@ -1724,6 +1749,8 @@ func (f *StringSliceFlag) Names() []string
     Names returns the names of the flag
 
 func (f *StringSliceFlag) SetDestination(slice []string)
+
+func (f *StringSliceFlag) SetRequired(required bool)
 
 func (f *StringSliceFlag) SetValue(slice []string)
 
@@ -1819,6 +1846,8 @@ func (f *TimestampFlag) IsVisible() bool
 func (f *TimestampFlag) Names() []string
     Names returns the names of the flag
 
+func (f *TimestampFlag) SetRequired(required bool)
+
 func (f *TimestampFlag) String() string
     String returns a readable representation of this value (for usage defaults)
 
@@ -1879,6 +1908,8 @@ func (f *Uint64Flag) IsVisible() bool
 func (f *Uint64Flag) Names() []string
     Names returns the names of the flag
 
+func (f *Uint64Flag) SetRequired(required bool)
+
 func (f *Uint64Flag) String() string
     String returns a readable representation of this value (for usage defaults)
 
@@ -1938,6 +1969,8 @@ func (f *UintFlag) IsVisible() bool
 
 func (f *UintFlag) Names() []string
     Names returns the names of the flag
+
+func (f *UintFlag) SetRequired(required bool)
 
 func (f *UintFlag) String() string
     String returns a readable representation of this value (for usage defaults)

--- a/internal/genflags/generated.gotmpl
+++ b/internal/genflags/generated.gotmpl
@@ -45,6 +45,10 @@ func (f *{{.TypeName}}) Names() []string {
   return {{$.UrfaveCLINamespace}}FlagNames(f.Name, f.Aliases)
 }
 
+func (f *{{.TypeName}}) SetRequired(required bool) {
+    f.Required = required
+}
+
 {{end}}{{/* /if .GenerateFlagInterface */}}
 
 {{if .GenerateRequiredFlagInterface}}

--- a/sliceflag.go
+++ b/sliceflag.go
@@ -128,6 +128,7 @@ func (x *SliceFlag[T, S, E]) GetDefaultText() string { return x.Target.GetDefaul
 func (x *SliceFlag[T, S, E]) GetEnvVars() []string   { return x.Target.GetEnvVars() }
 func (x *SliceFlag[T, S, E]) IsVisible() bool        { return x.Target.IsVisible() }
 func (x *SliceFlag[T, S, E]) GetCategory() string    { return x.Target.GetCategory() }
+func (x *SliceFlag[T, S, E]) SetRequired(bool)       {}
 
 func (x *flagValueHook) Set(value string) error {
 	if err := x.value.Set(value); err != nil {

--- a/zz_generated.flags.go
+++ b/zz_generated.flags.go
@@ -34,6 +34,10 @@ func (f *Float64SliceFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+func (f *Float64SliceFlag) SetRequired(required bool) {
+	f.Required = required
+}
+
 // IsRequired returns whether or not the flag is required
 func (f *Float64SliceFlag) IsRequired() bool {
 	return f.Required
@@ -81,6 +85,10 @@ func (f *GenericFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+func (f *GenericFlag) SetRequired(required bool) {
+	f.Required = required
+}
+
 // IsRequired returns whether or not the flag is required
 func (f *GenericFlag) IsRequired() bool {
 	return f.Required
@@ -121,6 +129,10 @@ func (f *Int64SliceFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+func (f *Int64SliceFlag) SetRequired(required bool) {
+	f.Required = required
+}
+
 // IsRequired returns whether or not the flag is required
 func (f *Int64SliceFlag) IsRequired() bool {
 	return f.Required
@@ -159,6 +171,10 @@ func (f *IntSliceFlag) IsSet() bool {
 // Names returns the names of the flag
 func (f *IntSliceFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+func (f *IntSliceFlag) SetRequired(required bool) {
+	f.Required = required
 }
 
 // IsRequired returns whether or not the flag is required
@@ -208,6 +224,10 @@ func (f *PathFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+func (f *PathFlag) SetRequired(required bool) {
+	f.Required = required
+}
+
 // IsRequired returns whether or not the flag is required
 func (f *PathFlag) IsRequired() bool {
 	return f.Required
@@ -248,6 +268,10 @@ func (f *StringSliceFlag) IsSet() bool {
 // Names returns the names of the flag
 func (f *StringSliceFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+func (f *StringSliceFlag) SetRequired(required bool) {
+	f.Required = required
 }
 
 // IsRequired returns whether or not the flag is required
@@ -297,6 +321,10 @@ func (f *TimestampFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+func (f *TimestampFlag) SetRequired(required bool) {
+	f.Required = required
+}
+
 // IsRequired returns whether or not the flag is required
 func (f *TimestampFlag) IsRequired() bool {
 	return f.Required
@@ -340,6 +368,10 @@ func (f *BoolFlag) IsSet() bool {
 // Names returns the names of the flag
 func (f *BoolFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+func (f *BoolFlag) SetRequired(required bool) {
+	f.Required = required
 }
 
 // IsRequired returns whether or not the flag is required
@@ -387,6 +419,10 @@ func (f *Float64Flag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+func (f *Float64Flag) SetRequired(required bool) {
+	f.Required = required
+}
+
 // IsRequired returns whether or not the flag is required
 func (f *Float64Flag) IsRequired() bool {
 	return f.Required
@@ -432,6 +468,10 @@ func (f *IntFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+func (f *IntFlag) SetRequired(required bool) {
+	f.Required = required
+}
+
 // IsRequired returns whether or not the flag is required
 func (f *IntFlag) IsRequired() bool {
 	return f.Required
@@ -475,6 +515,10 @@ func (f *Int64Flag) IsSet() bool {
 // Names returns the names of the flag
 func (f *Int64Flag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+func (f *Int64Flag) SetRequired(required bool) {
+	f.Required = required
 }
 
 // IsRequired returns whether or not the flag is required
@@ -524,6 +568,10 @@ func (f *StringFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+func (f *StringFlag) SetRequired(required bool) {
+	f.Required = required
+}
+
 // IsRequired returns whether or not the flag is required
 func (f *StringFlag) IsRequired() bool {
 	return f.Required
@@ -567,6 +615,10 @@ func (f *DurationFlag) IsSet() bool {
 // Names returns the names of the flag
 func (f *DurationFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+func (f *DurationFlag) SetRequired(required bool) {
+	f.Required = required
 }
 
 // IsRequired returns whether or not the flag is required
@@ -614,6 +666,10 @@ func (f *UintFlag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
 }
 
+func (f *UintFlag) SetRequired(required bool) {
+	f.Required = required
+}
+
 // IsRequired returns whether or not the flag is required
 func (f *UintFlag) IsRequired() bool {
 	return f.Required
@@ -657,6 +713,10 @@ func (f *Uint64Flag) IsSet() bool {
 // Names returns the names of the flag
 func (f *Uint64Flag) Names() []string {
 	return FlagNames(f.Name, f.Aliases)
+}
+
+func (f *Uint64Flag) SetRequired(required bool) {
+	f.Required = required
 }
 
 // IsRequired returns whether or not the flag is required


### PR DESCRIPTION
Flags can now have their "Required" field set at the interface level.

## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_


## Which issue(s) this PR fixes:

Fixes #1329 

## Release Notes

```release-note
Flags can now have their "Required" field set at the interface level with `SetRequired(bool)`.
```
