### PR TITLE
Add App.EnableStrictLookup option

### DIFF
--- a/app.go
+++ b/app.go
@@ -53,6 +53,8 @@ type App struct {
 	Flags []Flag
 	// Boolean to enable bash completion commands
 	EnableBashCompletion bool
+	// Boolean to enable strict flag lookup
+	EnableStrictLookup bool
 	// Boolean to hide built-in help command and help flag
 	HideHelp bool
 	// Boolean to hide built-in help command but keep help flag.

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"flag"
+	"fmt"
 	"strings"
 )
 
@@ -46,6 +47,9 @@ func (cCtx *Context) NumFlags() int {
 
 // Set sets a context flag to a value.
 func (cCtx *Context) Set(name, value string) error {
+	if cCtx.isStrictLookup() && cCtx.flagSet.Lookup(name) == nil {
+		panic(fmt.Sprintf("flag not found: %q", name))
+	}
 	return cCtx.flagSet.Set(name, value)
 }
 
@@ -158,7 +162,9 @@ func (cCtx *Context) lookupFlagSet(name string) *flag.FlagSet {
 			return c.flagSet
 		}
 	}
-
+	if cCtx.isStrictLookup() {
+		panic(fmt.Sprintf("flag not found: %q", name))
+	}
 	return nil
 }
 
@@ -190,6 +196,10 @@ func (cCtx *Context) checkRequiredFlags(flags []Flag) requiredFlagsErr {
 	}
 
 	return nil
+}
+
+func (cCtx *Context) isStrictLookup() bool {
+	return cCtx.App != nil && cCtx.App.EnableStrictLookup
 }
 
 func makeFlagNameVisitor(names *[]string) func(*flag.Flag) {

--- a/context_test.go
+++ b/context_test.go
@@ -150,6 +150,17 @@ func TestContext_Value(t *testing.T) {
 	expect(t, c.Value("unknown-flag"), nil)
 }
 
+func TestContext_Value_StrictLookup(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	app := &App{EnableStrictLookup: true}
+	c := NewContext(app, set, nil)
+	defer func() {
+		err := recover()
+		expect(t, err, `flag not found: "missing"`)
+	}()
+	c.Value("missing")
+}
+
 func TestContext_Args(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("myflag", false, "doc")
@@ -256,6 +267,17 @@ func TestContext_Set(t *testing.T) {
 	_ = c.Set("int", "1")
 	expect(t, c.Int("int"), 1)
 	expect(t, c.IsSet("int"), true)
+}
+
+func TestContext_Set_StrictLookup(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	app := &App{EnableStrictLookup: true}
+	c := NewContext(app, set, nil)
+	defer func() {
+		err := recover()
+		expect(t, err, `flag not found: "missing"`)
+	}()
+	c.Set("missing", "")
 }
 
 func TestContext_LocalFlagNames(t *testing.T) {


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- feature

## What this PR does / why we need it:

The current behaviour returns a zero value when accessing an undefined flag. This hides programmer errors and has resulted in several bugs on my end.

## Which issue(s) this PR fixes:

https://github.com/urfave/cli/issues/1408

## Testing

I added tests which make sure `Context.Set` and `Context.Value` panic when accessing an undefined flag.

## Release Notes

```release-note
A new `App.EnableStrictLookup` option which causes undefined flag lookups to panic
```
