### PR TITLE
Fix timestamp flag error when using help

### DIFF
--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -90,7 +90,7 @@ func (f *TimestampFlag) GetCategory() string {
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *TimestampFlag) GetValue() string {
-	if f.Value != nil {
+	if f.Value != nil && f.Value.timestamp != nil {
 		return f.Value.timestamp.String()
 	}
 	return ""


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

TimestampFlag causes error when using `help` or `-h`.

<img width="725" alt="image" src="https://user-images.githubusercontent.com/10195648/179466441-ce308b8c-56fd-4c94-9a88-634fdc4f0512.png">

The code reproduce this problem is [here](https://github.com/hmiyado/cli-timestamp-help).
It is same to example in https://cli.urfave.org/v2/#timestamp-flag .

This PR fix this error.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

no issue.

## Testing

manual testing.

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Fix timestamp flag error when using help.
```
