### PR TITLE
fix: allow required flag with one character

### DIFF
--- a/context.go
+++ b/context.go
@@ -170,9 +170,7 @@ func (cCtx *Context) checkRequiredFlags(flags []Flag) requiredFlagsErr {
 			var flagName string
 
 			for _, key := range f.Names() {
-				if len(key) > 1 {
-					flagName = key
-				}
+				flagName = key
 
 				if cCtx.IsSet(strings.TrimSpace(key)) {
 					flagPresent = true

--- a/context_test.go
+++ b/context_test.go
@@ -556,6 +556,13 @@ func TestCheckRequiredFlags(t *testing.T) {
 				&StringSliceFlag{Name: "names, n", Required: true},
 			},
 		},
+		{
+			testCase: "required_flag_with_one_character",
+			flags: []Flag{
+				&StringFlag{Name: "n", Required: true},
+			},
+			parseInput: []string{"--n", "asd"},
+		},
 	}
 
 	for _, test := range tdata {

--- a/context_test.go
+++ b/context_test.go
@@ -557,11 +557,12 @@ func TestCheckRequiredFlags(t *testing.T) {
 			},
 		},
 		{
-			testCase: "required_flag_with_one_character",
+			testCase:              "required_flag_with_one_character",
+			expectedAnError:       true,
+			expectedErrorContents: []string{"Required flag \"n\" not set"},
 			flags: []Flag{
 				&StringFlag{Name: "n", Required: true},
 			},
-			parseInput: []string{"--n", "asd"},
 		},
 	}
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?


<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:
Currently, flags only use one character with required option was ignored by [checkRequiredFlags](https://github.com/urfave/cli/blob/main/context.go#L173) and silently take the default value with no hints.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Fixes #1253 


<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

<!--
  Describe how you tested this change.
-->

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
required flags with only one character can be checked correctly now
```
