### PR TITLE
Update version of codecov action

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -63,6 +63,7 @@ jobs:
         if: success() && matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   test-docs:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: success() && matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
 


### PR DESCRIPTION
## What type of PR is this?

- maintenance

## What this PR does / why we need it:

Updates the version of the codecov action to `v3` given errors seen in other PRs using `v2`, e.g: https://github.com/urfave/cli/runs/8193564475?check_suite_focus=true

## Which issue(s) this PR fixes:

Connected to #1479 

**update:**

## Notes

Updating the action alone didn't fix the problem. I also set a `CODECOV_TOKEN` secret out of band, which I'm fairly sure won't play nicely with PRs from forks 😐 . IIUC using `CODECOV_TOKEN` isn't supposed to be required for public repos on GitHub, so I'd like to find a way to _not_ use it (again).