### PR TITLE
Set codecov status thresholds to 5%

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,3 +1,0 @@
-comment: false
-coverage:
-  threshold: 5%

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,9 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        threshold: 5%
+    patch:
+      default:
+        threshold: 5%


### PR DESCRIPTION
## What type of PR is this?

- maintenance

## What this PR does / why we need it:

Sets the relevant codecov config thresholds so that coverage drops within 5% are still considered a success. This is a fairly permissive configuration that has the potential to allow overall coverage to drop significantly over time, so it will still be up to humans to keep an eye on coverage and quality in general. The goal here is to ensure the codecov checks catch any _extreme coverage drops_.

## Which issue(s) this PR fixes:

NA 😬 