### PR TITLE
Ensure "generate" step runs in CI prior to diff check

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -40,6 +40,7 @@ jobs:
           GFLAGS: -tags urfave_cli_no_docs
       - run: make check-binary-size
       - run: make yamlfmt
+      - run: make generate
       - run: make diffcheck
       - if: matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
         run: make v2diff

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -40,7 +40,8 @@ jobs:
           GFLAGS: -tags urfave_cli_no_docs
       - run: make check-binary-size
       - run: make yamlfmt
-      - run: make generate
+      - if: matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
+        run: make generate
       - run: make diffcheck
       - if: matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
         run: make v2diff

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -458,6 +458,8 @@ type BoolFlag struct {
 	EnvVars []string
 
 	Count *int
+
+	Action func(*Context, bool) error
 }
     BoolFlag is a flag with type bool
 
@@ -565,7 +567,6 @@ type Command struct {
 	// cli.go uses text/template to render templates. You can
 	// render custom help text by setting this variable.
 	CustomHelpTemplate string
-
 	// Has unexported fields.
 }
     Command is a subcommand for a cli.App.
@@ -583,13 +584,6 @@ func (c *Command) Names() []string
 func (c *Command) Run(ctx *Context) (err error)
     Run invokes the command given the context, parses ctx.Args() to generate
     command-specific flags
-
-func (c *Command) VisibleCategories() []CommandCategory
-    VisibleCategories returns a slice of categories and commands that are
-    Hidden=false
-
-func (c *Command) VisibleCommands() []*Command
-    VisibleCommands returns a slice of the Commands with Hidden=false
 
 func (c *Command) VisibleFlagCategories() []VisibleFlagCategory
     VisibleFlagCategories returns a slice containing all the visible flag
@@ -776,6 +770,8 @@ type DurationFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, time.Duration) error
 }
     DurationFlag is a flag with type time.Duration
 
@@ -952,6 +948,8 @@ type Float64Flag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, float64) error
 }
     Float64Flag is a flag with type float64
 
@@ -1038,6 +1036,8 @@ type Float64SliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []float64) error
 }
     Float64SliceFlag is a flag with type *Float64Slice
 
@@ -1115,6 +1115,8 @@ type GenericFlag struct {
 	EnvVars []string
 
 	TakesFile bool
+
+	Action func(*Context, interface{}) error
 }
     GenericFlag is a flag with type Generic
 
@@ -1181,6 +1183,8 @@ type Int64Flag struct {
 	EnvVars []string
 
 	Base int
+
+	Action func(*Context, int64) error
 }
     Int64Flag is a flag with type int64
 
@@ -1267,6 +1271,8 @@ type Int64SliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []int64) error
 }
     Int64SliceFlag is a flag with type *Int64Slice
 
@@ -1338,6 +1344,8 @@ type IntFlag struct {
 	EnvVars []string
 
 	Base int
+
+	Action func(*Context, int) error
 }
     IntFlag is a flag with type int
 
@@ -1428,6 +1436,8 @@ type IntSliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []int) error
 }
     IntSliceFlag is a flag with type *IntSlice
 
@@ -1533,6 +1543,8 @@ type PathFlag struct {
 	EnvVars []string
 
 	TakesFile bool
+
+	Action func(*Context, Path) error
 }
     PathFlag is a flag with type Path
 
@@ -1673,6 +1685,8 @@ type StringFlag struct {
 	EnvVars []string
 
 	TakesFile bool
+
+	Action func(*Context, string) error
 }
     StringFlag is a flag with type string
 
@@ -1761,6 +1775,8 @@ type StringSliceFlag struct {
 	EnvVars []string
 
 	TakesFile bool
+
+	Action func(*Context, []string) error
 }
     StringSliceFlag is a flag with type *StringSlice
 
@@ -1867,6 +1883,8 @@ type TimestampFlag struct {
 	Layout string
 
 	Timezone *time.Location
+
+	Action func(*Context, *time.Time) error
 }
     TimestampFlag is a flag with type *Timestamp
 
@@ -1932,6 +1950,8 @@ type Uint64Flag struct {
 	EnvVars []string
 
 	Base int
+
+	Action func(*Context, uint64) error
 }
     Uint64Flag is a flag with type uint64
 
@@ -2018,6 +2038,8 @@ type Uint64SliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []uint64) error
 }
     Uint64SliceFlag is a flag with type *Uint64Slice
 
@@ -2080,6 +2102,8 @@ type UintFlag struct {
 	EnvVars []string
 
 	Base int
+
+	Action func(*Context, uint) error
 }
     UintFlag is a flag with type uint
 
@@ -2170,6 +2194,8 @@ type UintSliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []uint) error
 }
     UintSliceFlag is a flag with type *UintSlice
 

--- a/testdata/godoc-v2.x.txt
+++ b/testdata/godoc-v2.x.txt
@@ -458,6 +458,8 @@ type BoolFlag struct {
 	EnvVars []string
 
 	Count *int
+
+	Action func(*Context, bool) error
 }
     BoolFlag is a flag with type bool
 
@@ -565,7 +567,6 @@ type Command struct {
 	// cli.go uses text/template to render templates. You can
 	// render custom help text by setting this variable.
 	CustomHelpTemplate string
-
 	// Has unexported fields.
 }
     Command is a subcommand for a cli.App.
@@ -583,13 +584,6 @@ func (c *Command) Names() []string
 func (c *Command) Run(ctx *Context) (err error)
     Run invokes the command given the context, parses ctx.Args() to generate
     command-specific flags
-
-func (c *Command) VisibleCategories() []CommandCategory
-    VisibleCategories returns a slice of categories and commands that are
-    Hidden=false
-
-func (c *Command) VisibleCommands() []*Command
-    VisibleCommands returns a slice of the Commands with Hidden=false
 
 func (c *Command) VisibleFlagCategories() []VisibleFlagCategory
     VisibleFlagCategories returns a slice containing all the visible flag
@@ -776,6 +770,8 @@ type DurationFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, time.Duration) error
 }
     DurationFlag is a flag with type time.Duration
 
@@ -952,6 +948,8 @@ type Float64Flag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, float64) error
 }
     Float64Flag is a flag with type float64
 
@@ -1038,6 +1036,8 @@ type Float64SliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []float64) error
 }
     Float64SliceFlag is a flag with type *Float64Slice
 
@@ -1115,6 +1115,8 @@ type GenericFlag struct {
 	EnvVars []string
 
 	TakesFile bool
+
+	Action func(*Context, interface{}) error
 }
     GenericFlag is a flag with type Generic
 
@@ -1181,6 +1183,8 @@ type Int64Flag struct {
 	EnvVars []string
 
 	Base int
+
+	Action func(*Context, int64) error
 }
     Int64Flag is a flag with type int64
 
@@ -1267,6 +1271,8 @@ type Int64SliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []int64) error
 }
     Int64SliceFlag is a flag with type *Int64Slice
 
@@ -1338,6 +1344,8 @@ type IntFlag struct {
 	EnvVars []string
 
 	Base int
+
+	Action func(*Context, int) error
 }
     IntFlag is a flag with type int
 
@@ -1428,6 +1436,8 @@ type IntSliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []int) error
 }
     IntSliceFlag is a flag with type *IntSlice
 
@@ -1533,6 +1543,8 @@ type PathFlag struct {
 	EnvVars []string
 
 	TakesFile bool
+
+	Action func(*Context, Path) error
 }
     PathFlag is a flag with type Path
 
@@ -1673,6 +1685,8 @@ type StringFlag struct {
 	EnvVars []string
 
 	TakesFile bool
+
+	Action func(*Context, string) error
 }
     StringFlag is a flag with type string
 
@@ -1761,6 +1775,8 @@ type StringSliceFlag struct {
 	EnvVars []string
 
 	TakesFile bool
+
+	Action func(*Context, []string) error
 }
     StringSliceFlag is a flag with type *StringSlice
 
@@ -1867,6 +1883,8 @@ type TimestampFlag struct {
 	Layout string
 
 	Timezone *time.Location
+
+	Action func(*Context, *time.Time) error
 }
     TimestampFlag is a flag with type *Timestamp
 
@@ -1932,6 +1950,8 @@ type Uint64Flag struct {
 	EnvVars []string
 
 	Base int
+
+	Action func(*Context, uint64) error
 }
     Uint64Flag is a flag with type uint64
 
@@ -2018,6 +2038,8 @@ type Uint64SliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []uint64) error
 }
     Uint64SliceFlag is a flag with type *Uint64Slice
 
@@ -2080,6 +2102,8 @@ type UintFlag struct {
 	EnvVars []string
 
 	Base int
+
+	Action func(*Context, uint) error
 }
     UintFlag is a flag with type uint
 
@@ -2170,6 +2194,8 @@ type UintSliceFlag struct {
 
 	Aliases []string
 	EnvVars []string
+
+	Action func(*Context, []uint) error
 }
     UintSliceFlag is a flag with type *UintSlice
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

I thought this was already happening 😬 Maybe it used to, and I accidentally dropped it while mucking with the `Makefile`.

**NOTE** this change includes the result of `make v2approve`, which notably includes the *removal* of `Command.VisibleCategories` and `Command.VisibleCommands`. I would interpret this as a regression given that those have been part of the v2 API and I don't recall seeing discussion about their intentional removal. I don't read everything, though!

## Which issue(s) this PR fixes:

N/A