### PR TITLE
Turn off docs publishing from v3 series

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -93,7 +93,10 @@ jobs:
           git diff --cached --exit-code
 
   publish:
-    if: startswith(github.ref, 'refs/tags/')
+    # TODO: switch once v3 is released {{
+    # if: startswith(github.ref, 'refs/tags/')
+    if: 'false'
+    # }}
     name: publish
     needs: [test-docs]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

Turn off the automatic publishing of documentation from tags so that v3 pre-releases don't overwrite v2 series docs.

## Which issue(s) this PR fixes:

Connected to #1507 