### PR TITLE
wrap: Avoid trailing whitespace for empty lines

### DIFF
--- a/help.go
+++ b/help.go
@@ -476,7 +476,9 @@ func wrap(input string, offset int, wrapAt int) string {
 
 	for i, line := range lines {
 		if i != 0 {
-			sb.WriteString(padding)
+			if len(line) > 0 {
+				sb.WriteString(padding)
+			}
 		}
 
 		sb.WriteString(wrapLine(line, offset, wrapAt, padding))


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Linter tools are picky about trailing whitespace, which creates problems when `--help` output is used in documentation and tests.

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note

```
