### PR TITLE
Add newline after flags

### DIFF
--- a/template.go
+++ b/template.go
@@ -54,11 +54,11 @@ DESCRIPTION:
 
 OPTIONS:{{range .VisibleFlagCategories}}
    {{if .Name}}{{.Name}}
-   {{end}}{{range .Flags}}{{.}}{{end}}{{end}}{{else}}{{if .VisibleFlags}}
+   {{end}}{{range .Flags}}{{.}}
+   {{end}}{{end}}{{else}}{{if .VisibleFlags}}
 
 OPTIONS:
-   {{range .VisibleFlags}}{{.}}
-   {{end}}{{end}}{{end}}
+   {{range .VisibleFlags}}{{.}}{{end}}{{end}}{{end}}
 `
 
 // SubcommandHelpTemplate is the text template for the subcommand help topic.

--- a/template.go
+++ b/template.go
@@ -57,7 +57,8 @@ OPTIONS:{{range .VisibleFlagCategories}}
    {{end}}{{range .Flags}}{{.}}{{end}}{{end}}{{else}}{{if .VisibleFlags}}
 
 OPTIONS:
-   {{range .VisibleFlags}}{{.}}{{end}}{{end}}{{end}}
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}{{end}}
 `
 
 // SubcommandHelpTemplate is the text template for the subcommand help topic.


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Adds missing newlines after flags in help output.

## Which issue(s) this PR fixes:

Fixes https://github.com/urfave/cli/issues/1514

## Testing

I made the change locally and recompiled my app and saw the help output has newlines after each flag.

## Release Notes

```release-note
Newlines are added after each flag in help output.
```
