### PR TITLE
Build and run `urfave-cli-genflags` via its `Makefile`

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -22,4 +22,4 @@
 //	}
 package cli
 
-//go:generate go run cmd/urfave-cli-genflags/main.go
+//go:generate make -C cmd/urfave-cli-genflags run

--- a/cmd/urfave-cli-genflags/Makefile
+++ b/cmd/urfave-cli-genflags/Makefile
@@ -19,3 +19,7 @@ smoke-test: build
 .PHONY: show-cover
 show-cover:
 	go tool cover -func main.coverprofile
+
+.PHONY: run
+run: build
+	./urfave-cli-genflags

--- a/cmd/urfave-cli-genflags/Makefile
+++ b/cmd/urfave-cli-genflags/Makefile
@@ -1,5 +1,8 @@
+GOIMPORTS_BIN ?= $(shell which goimports || true)
 GOTEST_FLAGS ?= -v --coverprofile main.coverprofile --covermode count --cover github.com/urfave/cli/v2/cmd/urfave-cli-genflags
 GOBUILD_FLAGS ?= -x
+
+export GOIMPORTS_BIN
 
 .PHONY: all
 all: test build smoke-test

--- a/cmd/urfave-cli-genflags/main.go
+++ b/cmd/urfave-cli-genflags/main.go
@@ -94,8 +94,9 @@ func main() {
 				Value:   "cli.",
 			},
 			&cli.PathFlag{
-				Name:  "goimports",
-				Value: filepath.Join(top, ".local/bin/goimports"),
+				Name:    "goimports",
+				EnvVars: []string{"GOIMPORTS_BIN"},
+				Value:   filepath.Join(top, ".local/bin/goimports"),
 			},
 		},
 		Action: runGenFlags,

--- a/cmd/urfave-cli-genflags/main.go
+++ b/cmd/urfave-cli-genflags/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -37,6 +38,9 @@ var (
 func sh(ctx context.Context, exe string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, exe, args...)
 	cmd.Stderr = os.Stderr
+
+	fmt.Fprintf(os.Stderr, "# ---> %s\n", cmd)
+
 	outBytes, err := cmd.Output()
 	return string(outBytes), err
 }
@@ -89,8 +93,16 @@ func main() {
 				Aliases: []string{"N"},
 				Value:   "cli.",
 			},
+			&cli.PathFlag{
+				Name:  "goimports",
+				Value: filepath.Join(top, ".local/bin/goimports"),
+			},
 		},
 		Action: runGenFlags,
+	}
+
+	if err := os.Chdir(top); err != nil {
+		log.Fatal(err)
 	}
 
 	if err := app.RunContext(ctx, os.Args); err != nil {
@@ -163,11 +175,11 @@ func runGenFlags(cCtx *cli.Context) error {
 		return err
 	}
 
-	if _, err := sh(cCtx.Context, "goimports", "-w", cCtx.Path("generated-output")); err != nil {
+	if _, err := sh(cCtx.Context, cCtx.Path("goimports"), "-w", cCtx.Path("generated-output")); err != nil {
 		return err
 	}
 
-	if _, err := sh(cCtx.Context, "goimports", "-w", cCtx.Path("generated-test-output")); err != nil {
+	if _, err := sh(cCtx.Context, cCtx.Path("goimports"), "-w", cCtx.Path("generated-test-output")); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- bug
- cleanup

## What this PR does / why we need it:

Without this, running `make generate` can result in errors about missing `github.com/urfave/cli/v2` because the top-level `go.mod` context is in use rather than the `cmd/urfave-cli-genflags/go.mod`.

For example, this failure in the `v3-porting` branch: https://github.com/urfave/cli/actions/runs/3214832631/jobs/5255497140

## Which issue(s) this PR fixes:

NA 😬 