### PR TITLE
Fix:(issue_1548) Check root before run default cmd

### DIFF
--- a/command.go
+++ b/command.go
@@ -252,7 +252,7 @@ func (c *Command) Run(cCtx *Context, arguments ...string) (err error) {
 				}
 			}
 		}
-	} else if cCtx.App.DefaultCommand != "" {
+	} else if c.isRoot && cCtx.App.DefaultCommand != "" {
 		if dc := cCtx.App.Command(cCtx.App.DefaultCommand); dc != c {
 			cmd = dc
 		}

--- a/command_test.go
+++ b/command_test.go
@@ -485,3 +485,33 @@ func TestCommand_VisibleFlagCategories(t *testing.T) {
 		t.Errorf("unexpected flag %+v", fl.Names())
 	}
 }
+
+func TestCommand_RunSubcommandWithDefault(t *testing.T) {
+	app := &App{
+		Version:        "some version",
+		Name:           "app",
+		DefaultCommand: "foo",
+		Commands: []*Command{
+			{
+				Name: "foo",
+				Action: func(ctx *Context) error {
+					return errors.New("should not run this subcommand")
+				},
+			},
+			{
+				Name:        "bar",
+				Usage:       "this is for testing",
+				Subcommands: []*Command{{}}, // some subcommand
+				Action: func(*Context) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	err := app.Run([]string{"app", "bar"})
+	expect(t, err, nil)
+
+	err = app.Run([]string{"app"})
+	expect(t, err, errors.New("should not run this subcommand"))
+}


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Check command is root before run app default command.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #1548 
