### PR TITLE
Feature: Add support for persistent flags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -172,6 +172,12 @@ type CategorizableFlag interface {
 	GetCategory() string
 }
 
+// PersistentFlag is an interface to enable detection of flags which are persistent
+// through subcommands
+type PersistentFlag interface {
+	IsPersistent() bool
+}
+
 func flagSet(name string, flags []Flag) (*flag.FlagSet, error) {
 	set := flag.NewFlagSet(name, flag.ContinueOnError)
 

--- a/flag_impl.go
+++ b/flag_impl.go
@@ -75,10 +75,13 @@ func (f *FlagBase[T, C, V]) GetValue() string {
 
 // Apply populates the flag given the flag set and environment
 func (f *FlagBase[T, C, V]) Apply(set *flag.FlagSet) error {
-	// if flag has been applied then it wouldnt have been set from
-	// env or file as well.
 	// TODO move this phase into a separate flag initialization function
-	if !f.applied {
+	// if flag has been applied previously then it would have already been set
+	// from env or file. So no need to apply the env set again. However
+	// lots of units tests prior to persistent flags assumed that the
+	// flag can be applied to different flag sets multiple times while still
+	// keeping the env set.
+	if !f.applied || !f.Persistent {
 		newVal := f.Value
 
 		if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -780,8 +780,9 @@ type FlagBase[T any, C any, VC ValueCreator[T, C]] struct {
 	FilePath    string // file path to load value from
 	Usage       string // usage string for help output
 
-	Required bool // whether the flag is required or not
-	Hidden   bool // whether to hide the flag in help output
+	Required   bool // whether the flag is required or not
+	Hidden     bool // whether to hide the flag in help output
+	Persistent bool // whether the flag needs to be applied to subcommands as well
 
 	Value       T  // default value for this flag if not set by from any source
 	Destination *T // destination pointer for value when set
@@ -826,6 +827,9 @@ func (f *FlagBase[T, C, V]) GetValue() string
     GetValue returns the flags value as string representation and an empty
     string if the flag takes no value at all.
 
+func (f *FlagBase[T, C, VC]) IsPersistent() bool
+    IsPersistent returns true if flag needs to be persistent across subcommands
+
 func (f *FlagBase[T, C, V]) IsRequired() bool
     IsRequired returns whether or not the flag is required
 
@@ -833,6 +837,7 @@ func (f *FlagBase[T, C, V]) IsSet() bool
     IsSet returns whether or not the flag has been set through env or file
 
 func (f *FlagBase[T, C, VC]) IsSliceFlag() bool
+    IsSliceFlag returns true if the value type T is of kind slice
 
 func (f *FlagBase[T, C, V]) IsVisible() bool
     IsVisible returns true if the flag is not hidden, otherwise false
@@ -939,6 +944,12 @@ type OnUsageErrorFunc func(cCtx *Context, err error, isSubcommand bool) error
     displaying customized usage error messages. This function is able to replace
     the original error messages. If this function is not set, the "Incorrect
     usage" is displayed and the execution is interrupted.
+
+type PersistentFlag interface {
+	IsPersistent() bool
+}
+    PersistentFlag is an interface to enable detection of flags which are
+    persistent through subcommands
 
 type RequiredFlag interface {
 	Flag

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -780,8 +780,9 @@ type FlagBase[T any, C any, VC ValueCreator[T, C]] struct {
 	FilePath    string // file path to load value from
 	Usage       string // usage string for help output
 
-	Required bool // whether the flag is required or not
-	Hidden   bool // whether to hide the flag in help output
+	Required   bool // whether the flag is required or not
+	Hidden     bool // whether to hide the flag in help output
+	Persistent bool // whether the flag needs to be applied to subcommands as well
 
 	Value       T  // default value for this flag if not set by from any source
 	Destination *T // destination pointer for value when set
@@ -826,6 +827,9 @@ func (f *FlagBase[T, C, V]) GetValue() string
     GetValue returns the flags value as string representation and an empty
     string if the flag takes no value at all.
 
+func (f *FlagBase[T, C, VC]) IsPersistent() bool
+    IsPersistent returns true if flag needs to be persistent across subcommands
+
 func (f *FlagBase[T, C, V]) IsRequired() bool
     IsRequired returns whether or not the flag is required
 
@@ -833,6 +837,7 @@ func (f *FlagBase[T, C, V]) IsSet() bool
     IsSet returns whether or not the flag has been set through env or file
 
 func (f *FlagBase[T, C, VC]) IsSliceFlag() bool
+    IsSliceFlag returns true if the value type T is of kind slice
 
 func (f *FlagBase[T, C, V]) IsVisible() bool
     IsVisible returns true if the flag is not hidden, otherwise false
@@ -939,6 +944,12 @@ type OnUsageErrorFunc func(cCtx *Context, err error, isSubcommand bool) error
     displaying customized usage error messages. This function is able to replace
     the original error messages. If this function is not set, the "Incorrect
     usage" is displayed and the execution is interrupted.
+
+type PersistentFlag interface {
+	IsPersistent() bool
+}
+    PersistentFlag is an interface to enable detection of flags which are
+    persistent through subcommands
 
 type RequiredFlag interface {
 	Flag


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
Long asked for feature to have flags in flexible order

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->
Fixes #427 
Fixes #1113 

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

go test -run=TestPersistentFlag

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->
Flags can be marked as persistent in which case they can appear in subcommands. Flags with the same name in subcommand take precedence over commands defined higher in the hierarchy. Since a flag can have multiple names/aliases it is upto the user to ensure that none of the aliases of persistent flags are defined in subcommands. Even if one of the names is matched in a subcommand none of the aliases are applied to subcommand flag parsing

