### PR TITLE
Fix: Nested help command has a incorrect HelpName

### DIFF
--- a/app.go
+++ b/app.go
@@ -230,6 +230,7 @@ func (a *App) Setup() {
 
 	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
 		if !a.HideHelpCommand {
+			helpCommand.HelpName = fmt.Sprintf("%s %s", a.HelpName, helpName)
 			a.appendCommand(helpCommand)
 		}
 

--- a/command.go
+++ b/command.go
@@ -109,6 +109,7 @@ func (cmd *Command) Command(name string) *Command {
 func (c *Command) setup(ctx *Context) {
 	if c.Command(helpCommand.Name) == nil && !c.HideHelp {
 		if !c.HideHelpCommand {
+			helpCommand.HelpName = fmt.Sprintf("%s %s", c.HelpName, helpName)
 			c.Subcommands = append(c.Subcommands, helpCommand)
 		}
 	}

--- a/help.go
+++ b/help.go
@@ -22,6 +22,7 @@ var helpCommandDontUse = &Command{
 	Aliases:   []string{helpAlias},
 	Usage:     "Shows a list of commands or help for one command",
 	ArgsUsage: "[command]",
+	HideHelp:  true,
 }
 
 var helpCommand = &Command{
@@ -29,6 +30,7 @@ var helpCommand = &Command{
 	Aliases:   []string{helpAlias},
 	Usage:     "Shows a list of commands or help for one command",
 	ArgsUsage: "[command]",
+	HideHelp:  true,
 	Action: func(cCtx *Context) error {
 		args := cCtx.Args()
 		argsPresent := args.First() != ""
@@ -246,11 +248,13 @@ func ShowCommandHelp(ctx *Context, command string) error {
 	}
 	for _, c := range commands {
 		if c.HasName(command) {
-			if !ctx.App.HideHelpCommand && !c.HasName(helpName) && len(c.Subcommands) != 0 && c.Command(helpName) == nil {
-				c.Subcommands = append(c.Subcommands, helpCommandDontUse)
-			}
-			if !ctx.App.HideHelp && HelpFlag != nil {
-				c.appendFlag(HelpFlag)
+			if !c.HideHelp {
+				if !c.HideHelpCommand && len(c.Subcommands) != 0 && c.Command(helpName) == nil {
+					c.Subcommands = append(c.Subcommands, helpCommandDontUse)
+				}
+				if HelpFlag != nil {
+					c.appendFlag(HelpFlag)
+				}
 			}
 			templ := c.CustomHelpTemplate
 			if templ == "" {

--- a/help_test.go
+++ b/help_test.go
@@ -178,6 +178,73 @@ func Test_helpCommand_InHelpOutput(t *testing.T) {
 	}
 }
 
+func Test_helpCommand_HelpName(t *testing.T) {
+	var tests = []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "app help's helpName",
+			args: []string{"app", "help", "help"},
+			want: "app help -",
+		},
+		{
+			name: "cmd help's helpName",
+			args: []string{"app", "cmd", "help", "help"},
+			want: "app cmd help -",
+		},
+		{
+			name: "subcmd help's helpName",
+			args: []string{"app", "cmd", "subcmd", "help", "help"},
+			want: "app cmd subcmd help -",
+		},
+	}
+	for _, tt := range tests {
+		buf := &bytes.Buffer{}
+		t.Run(tt.name, func(t *testing.T) {
+			app := &App{
+				Name: "app",
+				Commands: []*Command{
+					{
+						Name:        "cmd",
+						Subcommands: []*Command{{Name: "subcmd"}},
+					},
+				},
+				Writer: buf,
+			}
+			err := app.Run(tt.args)
+			expect(t, err, nil)
+			got := buf.String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("Expected %q contained - Got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_helpCommand_HideHelpCommand(t *testing.T) {
+	buf := &bytes.Buffer{}
+	app := &App{
+		Name:   "app",
+		Writer: buf,
+	}
+	err := app.Run([]string{"app", "help", "help"})
+	expect(t, err, nil)
+	got := buf.String()
+	notWant := "COMMANDS:"
+	if strings.Contains(got, notWant) {
+		t.Errorf("Not expected %q - Got %q", notWant, got)
+	}
+}
+
+func Test_helpCommand_HideHelpFlag(t *testing.T) {
+	app := newTestApp()
+	if err := app.Run([]string{"app", "help", "-h"}); err == nil {
+		t.Errorf("Expected flag error - Got nil")
+	}
+}
+
 func Test_helpSubcommand_Action_ErrorIfNoTopic(t *testing.T) {
 	app := &App{}
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

- Fixed incorrect HelpName of helpCommand
- Changed HideHelp of helpCommand to avoid nested helpCommand
- Added related tests
  - Fixed `ShowCommandHelp` to pass tests

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

Fixes #1570

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

In `ShowCommandHelp`, `len(c.Subcommands) != 0` is used as the condition.. What does it mean? 
Even if a command has no subcommand, I think helpCommand should be added. 
In fact, helpCommand can be invoked although it does not appear in help msg.

I didn't change it this time, because some of the existing test cases asserting entire help msg failed.

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

- `Test_helpCommand_HelpName` tests HelpName of helpCommand
- `Test_helpCommand_HideHelpCommand` and `Test_helpCommand_HideHelpFlag` test nested helpCommand call

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note

```
