### PR TITLE
Disable slice flag separator

### DIFF
--- a/app.go
+++ b/app.go
@@ -107,6 +107,8 @@ type App struct {
 	CustomAppHelpTemplate string
 	// SliceFlagSeparator is used to customize the separator for SliceFlag, the default is ","
 	SliceFlagSeparator string
+	// DisableSliceFlagSeparator is used to disable SliceFlagSeparator, the default is false
+	DisableSliceFlagSeparator bool
 	// Boolean to enable short-option handling so user can combine several
 	// single-character bool arguments into one
 	// i.e. foobar -o -v -> foobar -ov
@@ -264,6 +266,8 @@ func (a *App) Setup() {
 	if len(a.SliceFlagSeparator) != 0 {
 		defaultSliceFlagSeparator = a.SliceFlagSeparator
 	}
+
+	disableSliceFlagSeparator = a.DisableSliceFlagSeparator
 }
 
 func (a *App) newRootCommand() *Command {

--- a/flag.go
+++ b/flag.go
@@ -15,7 +15,10 @@ import (
 
 const defaultPlaceholder = "value"
 
-var defaultSliceFlagSeparator = ","
+var (
+	defaultSliceFlagSeparator = ","
+	disableSliceFlagSeparator = false
+)
 
 var (
 	slPfx = fmt.Sprintf("sl:::%d:::", time.Now().UTC().UnixNano())
@@ -380,5 +383,9 @@ func flagFromEnvOrFile(envVars []string, filePath string) (value string, fromWhe
 }
 
 func flagSplitMultiValues(val string) []string {
+	if disableSliceFlagSeparator {
+		return []string{val}
+	}
+
 	return strings.Split(val, defaultSliceFlagSeparator)
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -3402,3 +3402,19 @@ func TestCustomizedSliceFlagSeparator(t *testing.T) {
 		}
 	}
 }
+
+func TestFlagSplitMultiValues_Disabled(t *testing.T) {
+	disableSliceFlagSeparator = true
+	defer func() {
+		disableSliceFlagSeparator = false
+	}()
+	opts := []string{"opt1", "opt2", "opt3,op", "opt4"}
+	ret := flagSplitMultiValues(strings.Join(opts, ","))
+	if len(ret) != 1 {
+		t.Fatalf("failed to disable split slice flag, want: 1, but got: %d", len(ret))
+	}
+
+	if ret[0] != strings.Join(opts, ",") {
+		t.Fatalf("failed to disable split slice flag, want: %s, but got: %s", strings.Join(opts, ","), ret[0])
+	}
+}

--- a/flag_test.go
+++ b/flag_test.go
@@ -3408,13 +3408,14 @@ func TestFlagSplitMultiValues_Disabled(t *testing.T) {
 	defer func() {
 		disableSliceFlagSeparator = false
 	}()
+
 	opts := []string{"opt1", "opt2", "opt3,op", "opt4"}
-	ret := flagSplitMultiValues(strings.Join(opts, ","))
+	ret := flagSplitMultiValues(strings.Join(opts, defaultSliceFlagSeparator))
 	if len(ret) != 1 {
 		t.Fatalf("failed to disable split slice flag, want: 1, but got: %d", len(ret))
 	}
 
-	if ret[0] != strings.Join(opts, ",") {
-		t.Fatalf("failed to disable split slice flag, want: %s, but got: %s", strings.Join(opts, ","), ret[0])
+	if ret[0] != strings.Join(opts, defaultSliceFlagSeparator) {
+		t.Fatalf("failed to disable split slice flag, want: %s, but got: %s", strings.Join(opts, defaultSliceFlagSeparator), ret[0])
 	}
 }

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -318,6 +318,8 @@ type App struct {
 	CustomAppHelpTemplate string
 	// SliceFlagSeparator is used to customize the separator for SliceFlag, the default is ","
 	SliceFlagSeparator string
+	// DisableSliceFlagSeparator is used to disable SliceFlagSeparator, the default is false
+	DisableSliceFlagSeparator bool
 	// Boolean to enable short-option handling so user can combine several
 	// single-character bool arguments into one
 	// i.e. foobar -o -v -> foobar -ov

--- a/testdata/godoc-v2.x.txt
+++ b/testdata/godoc-v2.x.txt
@@ -318,7 +318,7 @@ type App struct {
 	CustomAppHelpTemplate string
 	// SliceFlagSeparator is used to customize the separator for SliceFlag, the default is ","
 	SliceFlagSeparator string
-    // DisableSliceFlagSeparator is used to disable SliceFlagSeparator, the default is false
+	// DisableSliceFlagSeparator is used to disable SliceFlagSeparator, the default is false
 	DisableSliceFlagSeparator bool
 	// Boolean to enable short-option handling so user can combine several
 	// single-character bool arguments into one

--- a/testdata/godoc-v2.x.txt
+++ b/testdata/godoc-v2.x.txt
@@ -318,6 +318,8 @@ type App struct {
 	CustomAppHelpTemplate string
 	// SliceFlagSeparator is used to customize the separator for SliceFlag, the default is ","
 	SliceFlagSeparator string
+    // DisableSliceFlagSeparator is used to disable SliceFlagSeparator, the default is false
+	DisableSliceFlagSeparator bool
 	// Boolean to enable short-option handling so user can combine several
 	// single-character bool arguments into one
 	// i.e. foobar -o -v -> foobar -ov


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- feature

## What this PR does / why we need it:

Copy of https://github.com/urfave/cli/pull/1582 for consuming with the stable v2

Allows to disable SliceFlagSeparator by setting `DisableSliceFlagSeparator = true`
Useful when processing JSON values as described here https://github.com/urfave/cli/issues/1134#issuecomment-1272105669 and here https://github.com/urfave/cli/issues/1134#issuecomment-1293471975 

## Which issue(s) this PR fixes:

Fixes #1134 and specifically https://github.com/urfave/cli/issues/1134#issuecomment-1272105669

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

New unit test `TestFlagSplitMultiValues_Disabled`

## Release Notes

```release-note
Added support for disabling comma `,` based SliceFlag separator 
```
