### PR TITLE
Run linter fixes + go mod tidy

### DIFF
--- a/app.go
+++ b/app.go
@@ -432,30 +432,6 @@ func (a *App) handleExitCoder(cCtx *Context, err error) {
 	}
 }
 
-func (a *App) commandNames() []string {
-	var cmdNames []string
-
-	for _, cmd := range a.Commands {
-		cmdNames = append(cmdNames, cmd.Names()...)
-	}
-
-	return cmdNames
-}
-
-func (a *App) validCommandName(checkCmdName string) bool {
-	valid := false
-	allCommandNames := a.commandNames()
-
-	for _, cmdName := range allCommandNames {
-		if checkCmdName == cmdName {
-			valid = true
-			break
-		}
-	}
-
-	return valid
-}
-
 func (a *App) argsWithDefaultCommand(oldArgs Args) Args {
 	if a.DefaultCommand != "" {
 		rawArgs := append([]string{a.DefaultCommand}, oldArgs.Slice()...)

--- a/app_test.go
+++ b/app_test.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -114,7 +113,7 @@ func ExampleApp_Run_appHelp() {
 				Aliases:     []string{"d"},
 				Usage:       "use it to see a description",
 				Description: "This is how we describe describeit the function",
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					fmt.Printf("i like to describe things")
 					return nil
 				},
@@ -164,7 +163,7 @@ func ExampleApp_Run_commandHelp() {
 				Aliases:     []string{"d"},
 				Usage:       "use it to see a description",
 				Description: "This is how we describe describeit the function",
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					fmt.Printf("i like to describe things")
 					return nil
 				},
@@ -229,7 +228,6 @@ func ExampleApp_Run_subcommandNoAction() {
 	//
 	// OPTIONS:
 	//    --help, -h  show help (default: false)
-
 }
 
 func ExampleApp_Run_bashComplete_withShortFlag() {
@@ -289,6 +287,7 @@ func ExampleApp_Run_bashComplete_withLongFlag() {
 	// --some-flag
 	// --similar-flag
 }
+
 func ExampleApp_Run_bashComplete_withMultipleLongFlag() {
 	os.Setenv("SHELL", "bash")
 	os.Args = []string{"greet", "--st", "--generate-bash-completion"}
@@ -335,7 +334,7 @@ func ExampleApp_Run_bashComplete() {
 				Aliases:     []string{"d"},
 				Usage:       "use it to see a description",
 				Description: "This is how we describe describeit the function",
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					fmt.Printf("i like to describe things")
 					return nil
 				},
@@ -343,7 +342,7 @@ func ExampleApp_Run_bashComplete() {
 				Name:        "next",
 				Usage:       "next example",
 				Description: "more stuff to see when generating shell completion",
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					fmt.Printf("the next example")
 					return nil
 				},
@@ -374,7 +373,7 @@ func ExampleApp_Run_zshComplete() {
 			Aliases:     []string{"d"},
 			Usage:       "use it to see a description",
 			Description: "This is how we describe describeit the function",
-			Action: func(c *Context) error {
+			Action: func(*Context) error {
 				fmt.Printf("i like to describe things")
 				return nil
 			},
@@ -382,7 +381,7 @@ func ExampleApp_Run_zshComplete() {
 			Name:        "next",
 			Usage:       "next example",
 			Description: "more stuff to see when generating bash completion",
-			Action: func(c *Context) error {
+			Action: func(*Context) error {
 				fmt.Printf("the next example")
 				return nil
 			},
@@ -400,7 +399,8 @@ func ExampleApp_Run_zshComplete() {
 
 func ExampleApp_Run_sliceValues() {
 	// set args for examples sake
-	os.Args = []string{"multi_values",
+	os.Args = []string{
+		"multi_values",
 		"--stringSclice", "parsed1,parsed2", "--stringSclice", "parsed3,parsed4",
 		"--float64Sclice", "13.3,14.4", "--float64Sclice", "15.5,16.6",
 		"--int64Sclice", "13,14", "--int64Sclice", "15,16",
@@ -644,7 +644,6 @@ func TestApp_RunDefaultCommandWithFlags(t *testing.T) {
 }
 
 func TestApp_FlagsFromExtPackage(t *testing.T) {
-
 	var someint int
 	flag.IntVar(&someint, "epflag", 2, "ext package flag usage")
 
@@ -1109,8 +1108,8 @@ func TestApp_ParseSliceFlags(t *testing.T) {
 		}
 		return true
 	}
-	var expectedIntSlice = []int{22, 80}
-	var expectedStringSlice = []string{"8.8.8.8", "8.8.4.4"}
+	expectedIntSlice := []int{22, 80}
+	expectedStringSlice := []string{"8.8.8.8", "8.8.4.4"}
 
 	if !IntsEquals(parsedIntSlice, expectedIntSlice) {
 		t.Errorf("%v does not match %v", parsedIntSlice, expectedIntSlice)
@@ -1144,8 +1143,8 @@ func TestApp_ParseSliceFlagsWithMissingValue(t *testing.T) {
 
 	_ = app.Run([]string{"", "cmd", "-a", "2", "-str", "A"})
 
-	var expectedIntSlice = []int{2}
-	var expectedStringSlice = []string{"A"}
+	expectedIntSlice := []int{2}
+	expectedStringSlice := []string{"A"}
 
 	if parsedIntSlice[0] != expectedIntSlice[0] {
 		t.Errorf("%v does not match %v", parsedIntSlice[0], expectedIntSlice[0])
@@ -1187,7 +1186,6 @@ func TestApp_SetStdin(t *testing.T) {
 	}
 
 	err := app.Run([]string{"help"})
-
 	if err != nil {
 		t.Fatalf("Run error: %s", err)
 	}
@@ -1220,7 +1218,6 @@ func TestApp_SetStdin_Subcommand(t *testing.T) {
 	}
 
 	err := app.Run([]string{"test", "command", "subcommand"})
-
 	if err != nil {
 		t.Fatalf("Run error: %s", err)
 	}
@@ -1239,7 +1236,6 @@ func TestApp_SetStdout(t *testing.T) {
 	}
 
 	err := app.Run([]string{"help"})
-
 	if err != nil {
 		t.Fatalf("Run error: %s", err)
 	}
@@ -1268,7 +1264,7 @@ func TestApp_BeforeFunc(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "sub",
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					counts.Total++
 					counts.SubCommand = counts.Total
 					return nil
@@ -1278,7 +1274,7 @@ func TestApp_BeforeFunc(t *testing.T) {
 		Flags: []Flag{
 			&StringFlag{Name: "opt"},
 		},
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
 	// run with the Before() func succeeding
@@ -1346,12 +1342,12 @@ func TestApp_BeforeAfterFuncShellCompletion(t *testing.T) {
 
 	app := &App{
 		EnableBashCompletion: true,
-		Before: func(c *Context) error {
+		Before: func(*Context) error {
 			counts.Total++
 			counts.Before = counts.Total
 			return nil
 		},
-		After: func(c *Context) error {
+		After: func(*Context) error {
 			counts.Total++
 			counts.After = counts.Total
 			return nil
@@ -1359,7 +1355,7 @@ func TestApp_BeforeAfterFuncShellCompletion(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "sub",
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					counts.Total++
 					counts.SubCommand = counts.Total
 					return nil
@@ -1369,7 +1365,7 @@ func TestApp_BeforeAfterFuncShellCompletion(t *testing.T) {
 		Flags: []Flag{
 			&StringFlag{Name: "opt"},
 		},
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
 	// run with the Before() func succeeding
@@ -1411,7 +1407,7 @@ func TestApp_AfterFunc(t *testing.T) {
 		Commands: []*Command{
 			{
 				Name: "sub",
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					counts.Total++
 					counts.SubCommand = counts.Total
 					return nil
@@ -1487,7 +1483,7 @@ func TestAppNoHelpFlag(t *testing.T) {
 
 	HelpFlag = nil
 
-	app := &App{Writer: ioutil.Discard}
+	app := &App{Writer: io.Discard}
 	err := app.Run([]string{"test", "-h"})
 
 	if err != flag.ErrHelp {
@@ -1643,8 +1639,8 @@ func TestAppHelpPrinter(t *testing.T) {
 		HelpPrinter = oldPrinter
 	}()
 
-	var wasCalled = false
-	HelpPrinter = func(w io.Writer, template string, data interface{}) {
+	wasCalled := false
+	HelpPrinter = func(io.Writer, string, interface{}) {
 		wasCalled = true
 	}
 
@@ -1662,8 +1658,8 @@ func TestApp_VersionPrinter(t *testing.T) {
 		VersionPrinter = oldPrinter
 	}()
 
-	var wasCalled = false
-	VersionPrinter = func(c *Context) {
+	wasCalled := false
+	VersionPrinter = func(*Context) {
 		wasCalled = true
 	}
 
@@ -1679,14 +1675,14 @@ func TestApp_VersionPrinter(t *testing.T) {
 func TestApp_CommandNotFound(t *testing.T) {
 	counts := &opCounts{}
 	app := &App{
-		CommandNotFound: func(c *Context, command string) {
+		CommandNotFound: func(*Context, string) {
 			counts.Total++
 			counts.CommandNotFound = counts.Total
 		},
 		Commands: []*Command{
 			{
 				Name: "bar",
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					counts.Total++
 					counts.SubCommand = counts.Total
 					return nil
@@ -1709,43 +1705,43 @@ func TestApp_OrderOfOperations(t *testing.T) {
 
 	app := &App{
 		EnableBashCompletion: true,
-		BashComplete: func(c *Context) {
+		BashComplete: func(*Context) {
 			counts.Total++
 			counts.ShellComplete = counts.Total
 		},
-		OnUsageError: func(c *Context, err error, isSubcommand bool) error {
+		OnUsageError: func(*Context, error, bool) error {
 			counts.Total++
 			counts.OnUsageError = counts.Total
 			return errors.New("hay OnUsageError")
 		},
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
-	beforeNoError := func(c *Context) error {
+	beforeNoError := func(*Context) error {
 		counts.Total++
 		counts.Before = counts.Total
 		return nil
 	}
 
-	beforeError := func(c *Context) error {
+	beforeError := func(*Context) error {
 		counts.Total++
 		counts.Before = counts.Total
 		return errors.New("hay Before")
 	}
 
 	app.Before = beforeNoError
-	app.CommandNotFound = func(c *Context, command string) {
+	app.CommandNotFound = func(*Context, string) {
 		counts.Total++
 		counts.CommandNotFound = counts.Total
 	}
 
-	afterNoError := func(c *Context) error {
+	afterNoError := func(*Context) error {
 		counts.Total++
 		counts.After = counts.Total
 		return nil
 	}
 
-	afterError := func(c *Context) error {
+	afterError := func(*Context) error {
 		counts.Total++
 		counts.After = counts.Total
 		return errors.New("hay After")
@@ -1755,7 +1751,7 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	app.Commands = []*Command{
 		{
 			Name: "bar",
-			Action: func(c *Context) error {
+			Action: func(*Context) error {
 				counts.Total++
 				counts.SubCommand = counts.Total
 				return nil
@@ -1763,7 +1759,7 @@ func TestApp_OrderOfOperations(t *testing.T) {
 		},
 	}
 
-	app.Action = func(c *Context) error {
+	app.Action = func(*Context) error {
 		counts.Total++
 		counts.Action = counts.Total
 		return nil
@@ -1845,7 +1841,7 @@ func TestApp_OrderOfOperations(t *testing.T) {
 }
 
 func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
-	var subcommandHelpTopics = [][]string{
+	subcommandHelpTopics := [][]string{
 		{"command", "foo", "--help"},
 		{"command", "foo", "-h"},
 		{"command", "foo", "help"},
@@ -1853,7 +1849,6 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 
 	for _, flagSet := range subcommandHelpTopics {
 		t.Run(fmt.Sprintf("checking with flags %v", flagSet), func(t *testing.T) {
-
 			app := &App{}
 			buf := new(bytes.Buffer)
 			app.Writer = buf
@@ -1875,7 +1870,6 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 
 			app.Commands = []*Command{cmd}
 			err := app.Run(flagSet)
-
 			if err != nil {
 				t.Error(err)
 			}
@@ -2044,7 +2038,7 @@ func TestApp_Run_CommandSubcommandHelpName(t *testing.T) {
 }
 
 func TestApp_Run_Help(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		helpArguments []string
 		hideHelp      bool
 		wantContains  string
@@ -2091,7 +2085,7 @@ func TestApp_Run_Help(t *testing.T) {
 				Usage:    "make an explosive entrance",
 				Writer:   buf,
 				HideHelp: tt.hideHelp,
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					buf.WriteString("boom I say!")
 					return nil
 				},
@@ -2112,11 +2106,10 @@ func TestApp_Run_Help(t *testing.T) {
 }
 
 func TestApp_Run_Version(t *testing.T) {
-	var versionArguments = [][]string{{"boom", "--version"}, {"boom", "-v"}}
+	versionArguments := [][]string{{"boom", "--version"}, {"boom", "-v"}}
 
 	for _, args := range versionArguments {
 		t.Run(fmt.Sprintf("checking with arguments %v", args), func(t *testing.T) {
-
 			buf := new(bytes.Buffer)
 
 			app := &App{
@@ -2124,7 +2117,7 @@ func TestApp_Run_Version(t *testing.T) {
 				Usage:   "make an explosive entrance",
 				Version: "0.1.0",
 				Writer:  buf,
-				Action: func(c *Context) error {
+				Action: func(*Context) error {
 					buf.WriteString("boom I say!")
 					return nil
 				},
@@ -2339,7 +2332,7 @@ func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 		Action: func(c *Context) error { return nil },
 		Before: func(c *Context) error { return fmt.Errorf("before error") },
 		After:  func(c *Context) error { return fmt.Errorf("after error") },
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
 	err := app.Run([]string{"foo"})
@@ -2389,7 +2382,7 @@ func TestApp_OnUsageError_WithWrongFlagValue(t *testing.T) {
 		Flags: []Flag{
 			&IntFlag{Name: "flag"},
 		},
-		OnUsageError: func(c *Context, err error, isSubcommand bool) error {
+		OnUsageError: func(_ *Context, err error, isSubcommand bool) error {
 			if isSubcommand {
 				t.Errorf("Expect no subcommand")
 			}
@@ -2420,7 +2413,7 @@ func TestApp_OnUsageError_WithWrongFlagValue_ForSubcommand(t *testing.T) {
 		Flags: []Flag{
 			&IntFlag{Name: "flag"},
 		},
-		OnUsageError: func(c *Context, err error, isSubcommand bool) error {
+		OnUsageError: func(_ *Context, err error, isSubcommand bool) error {
 			if isSubcommand {
 				t.Errorf("Expect subcommand")
 			}
@@ -2509,7 +2502,7 @@ func (c *customBoolFlag) GetDefaultText() string {
 func TestCustomFlagsUnused(t *testing.T) {
 	app := &App{
 		Flags:  []Flag{&customBoolFlag{"custom"}},
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
 	err := app.Run([]string{"foo"})
@@ -2521,7 +2514,7 @@ func TestCustomFlagsUnused(t *testing.T) {
 func TestCustomFlagsUsed(t *testing.T) {
 	app := &App{
 		Flags:  []Flag{&customBoolFlag{"custom"}},
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
 	err := app.Run([]string{"foo", "--custom=bar"})
@@ -2532,7 +2525,7 @@ func TestCustomFlagsUsed(t *testing.T) {
 
 func TestCustomHelpVersionFlags(t *testing.T) {
 	app := &App{
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
 	// Be sure to reset the global flags
@@ -2624,7 +2617,7 @@ func TestShellCompletionForIncompleteFlags(t *testing.T) {
 		Action: func(ctx *Context) error {
 			return fmt.Errorf("should not get here")
 		},
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 	err := app.Run([]string{"", "--test-completion", "--" + "generate-bash-completion"})
 	if err != nil {
@@ -2652,7 +2645,7 @@ func TestWhenExitSubCommandWithCodeThenAppQuitUnexpectedly(t *testing.T) {
 
 	// set user function as ExitErrHandler
 	var exitCodeFromExitErrHandler int
-	app.ExitErrHandler = func(c *Context, err error) {
+	app.ExitErrHandler = func(_ *Context, err error) {
 		if exitErr, ok := err.(ExitCoder); ok {
 			exitCodeFromExitErrHandler = exitErr.ExitCode()
 		}
@@ -2687,7 +2680,7 @@ func TestWhenExitSubCommandWithCodeThenAppQuitUnexpectedly(t *testing.T) {
 
 func newTestApp() *App {
 	a := NewApp()
-	a.Writer = ioutil.Discard
+	a.Writer = io.Discard
 	return a
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -27,7 +27,7 @@ func TestCommandFlagParsing(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		app := &App{Writer: ioutil.Discard}
+		app := &App{Writer: io.Discard}
 		set := flag.NewFlagSet("test", 0)
 		_ = set.Parse(c.testArgs)
 
@@ -46,7 +46,7 @@ func TestCommandFlagParsing(t *testing.T) {
 		err := command.Run(cCtx, c.testArgs...)
 
 		expect(t, err, c.expectedErr)
-		//expect(t, cCtx.Args().Slice(), c.testArgs)
+		// expect(t, cCtx.Args().Slice(), c.testArgs)
 	}
 }
 
@@ -118,7 +118,7 @@ func TestCommand_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 				},
 			},
 		},
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
 	err := app.Run([]string{"foo", "bar"})
@@ -216,7 +216,7 @@ func TestCommand_OnUsageError_WithWrongFlagValue(t *testing.T) {
 				Flags: []Flag{
 					&IntFlag{Name: "flag"},
 				},
-				OnUsageError: func(c *Context, err error, _ bool) error {
+				OnUsageError: func(_ *Context, err error, _ bool) error {
 					if !strings.HasPrefix(err.Error(), "invalid value \"wrong\"") {
 						t.Errorf("Expect an invalid value error, but got \"%v\"", err)
 					}
@@ -249,7 +249,7 @@ func TestCommand_OnUsageError_WithSubcommand(t *testing.T) {
 				Flags: []Flag{
 					&IntFlag{Name: "flag"},
 				},
-				OnUsageError: func(c *Context, err error, _ bool) error {
+				OnUsageError: func(_ *Context, err error, _ bool) error {
 					if !strings.HasPrefix(err.Error(), "invalid value \"wrong\"") {
 						t.Errorf("Expect an invalid value error, but got \"%v\"", err)
 					}
@@ -271,7 +271,7 @@ func TestCommand_OnUsageError_WithSubcommand(t *testing.T) {
 
 func TestCommand_Run_SubcommandsCanUseErrWriter(t *testing.T) {
 	app := &App{
-		ErrWriter: ioutil.Discard,
+		ErrWriter: io.Discard,
 		Commands: []*Command{
 			{
 				Name:  "bar",
@@ -281,7 +281,7 @@ func TestCommand_Run_SubcommandsCanUseErrWriter(t *testing.T) {
 						Name:  "baz",
 						Usage: "this is for testing",
 						Action: func(c *Context) error {
-							if c.App.ErrWriter != ioutil.Discard {
+							if c.App.ErrWriter != io.Discard {
 								return fmt.Errorf("ErrWriter not passed")
 							}
 
@@ -325,7 +325,7 @@ func TestCommandSkipFlagParsing(t *testing.T) {
 					},
 				},
 			},
-			Writer: ioutil.Discard,
+			Writer: io.Discard,
 		}
 
 		err := app.Run(c.testArgs)
@@ -377,7 +377,6 @@ func TestCommand_Run_CustomShellCompleteAcceptsMalformedFlags(t *testing.T) {
 		expect(t, err, nil)
 		expect(t, stdout, c.expectedOut)
 	}
-
 }
 
 func TestCommand_NoVersionFlagOnCommands(t *testing.T) {
@@ -406,7 +405,7 @@ func TestCommand_NoVersionFlagOnCommands(t *testing.T) {
 func TestCommand_CanAddVFlagOnCommands(t *testing.T) {
 	app := &App{
 		Version: "some version",
-		Writer:  ioutil.Discard,
+		Writer:  io.Discard,
 		Commands: []*Command{
 			{
 				Name:        "bar",
@@ -426,7 +425,6 @@ func TestCommand_CanAddVFlagOnCommands(t *testing.T) {
 }
 
 func TestCommand_VisibleSubcCommands(t *testing.T) {
-
 	subc1 := &Command{
 		Name:  "subc1",
 		Usage: "subc1 command1",
@@ -453,7 +451,6 @@ func TestCommand_VisibleSubcCommands(t *testing.T) {
 }
 
 func TestCommand_VisibleFlagCategories(t *testing.T) {
-
 	c := &Command{
 		Name:  "bar",
 		Usage: "this is for testing",

--- a/context_test.go
+++ b/context_test.go
@@ -363,14 +363,16 @@ func TestNonNilContext(t *testing.T) {
 	}
 }
 
+type testKey struct{}
+
 // TestContextPropagation tests that
 // *cli.Context always has a valid
 // context.Context
 func TestContextPropagation(t *testing.T) {
 	parent := NewContext(nil, nil, nil)
-	parent.Context = context.WithValue(context.Background(), "key", "val")
+	parent.Context = context.WithValue(context.Background(), testKey{}, "val")
 	ctx := NewContext(nil, nil, parent)
-	val := ctx.Context.Value("key")
+	val := ctx.Context.Value(testKey{})
 	if val == nil {
 		t.Fatal("expected a parent context to be inherited but got nil")
 	}

--- a/errors_test.go
+++ b/errors_test.go
@@ -122,7 +122,7 @@ func (f *ErrorWithFormat) Format(s fmt.State, verb rune) {
 func TestHandleExitCoder_ErrorWithFormat(t *testing.T) {
 	called := false
 
-	OsExiter = func(rc int) {
+	OsExiter = func(int) {
 		if !called {
 			called = true
 		}
@@ -144,7 +144,7 @@ func TestHandleExitCoder_ErrorWithFormat(t *testing.T) {
 func TestHandleExitCoder_MultiErrorWithFormat(t *testing.T) {
 	called := false
 
-	OsExiter = func(rc int) {
+	OsExiter = func(int) {
 		if !called {
 			called = true
 		}

--- a/fish_test.go
+++ b/fish_test.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -135,7 +135,7 @@ Should be a part of the same code block
 }
 
 func expectFileContent(t *testing.T, file, got string) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	// Ignore windows line endings
 	// TODO: Replace with bytes.ReplaceAll when support for Go 1.11 is dropped
 	data = bytes.Replace(data, []byte("\r\n"), []byte("\n"), -1)

--- a/flag.go
+++ b/flag.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"runtime"
@@ -180,7 +180,7 @@ func flagSet(name string, flags []Flag) (*flag.FlagSet, error) {
 			return nil, err
 		}
 	}
-	set.SetOutput(ioutil.Discard)
+	set.SetOutput(io.Discard)
 	return set, nil
 }
 
@@ -381,7 +381,7 @@ func flagFromEnvOrFile(envVars []string, filePath string) (value string, fromWhe
 	}
 	for _, fileVar := range strings.Split(filePath, ",") {
 		if fileVar != "" {
-			if data, err := ioutil.ReadFile(fileVar); err == nil {
+			if data, err := os.ReadFile(fileVar); err == nil {
 				return string(data), fmt.Sprintf("file %q", filePath), true
 			}
 		}

--- a/flag_slice_impl.go
+++ b/flag_slice_impl.go
@@ -63,7 +63,7 @@ func (i *SliceBase[T, C, VC]) Set(value string) error {
 		}
 		tmp, ok := i.value.Get().(T)
 		if !ok {
-			return fmt.Errorf("Unable to cast %v", i.value)
+			return fmt.Errorf("unable to cast %v", i.value)
 		}
 		*i.slice = append(*i.slice, tmp)
 	}

--- a/flag_test.go
+++ b/flag_test.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
@@ -76,7 +75,6 @@ func TestBoolFlagApply_SetsCount(t *testing.T) {
 }
 
 func TestBoolFlagCountFromContext(t *testing.T) {
-
 	boolCountTests := []struct {
 		input         []string
 		expectedVal   bool
@@ -109,8 +107,7 @@ func TestBoolFlagCountFromContext(t *testing.T) {
 }
 
 func TestFlagsFromEnv(t *testing.T) {
-
-	var flagTests = []struct {
+	flagTests := []struct {
 		input     string
 		output    interface{}
 		flag      Flag
@@ -1041,8 +1038,12 @@ var int64SliceFlagTests = []struct {
 }{
 	{"heads", nil, []int64{}, "--heads value [ --heads value ]\t"},
 	{"H", nil, []int64{}, "-H value [ -H value ]\t"},
-	{"heads", []string{"H"}, []int64{2, 17179869184},
-		"--heads value, -H value [ --heads value, -H value ]\t(default: 2, 17179869184)"},
+	{
+		"heads",
+		[]string{"H"},
+		[]int64{2, 17179869184},
+		"--heads value, -H value [ --heads value, -H value ]\t(default: 2, 17179869184)",
+	},
 }
 
 func TestInt64SliceFlagHelpOutput(t *testing.T) {
@@ -1159,6 +1160,7 @@ func TestInt64SliceFlag_SetFromParentContext(t *testing.T) {
 		t.Errorf("child context unable to view parent flag: %v != %v", expected, ctx.Int64Slice("numbers"))
 	}
 }
+
 func TestInt64SliceFlag_ReturnNil(t *testing.T) {
 	fl := &Int64SliceFlag{}
 	set := flag.NewFlagSet("test", 0)
@@ -1191,8 +1193,12 @@ var uintSliceFlagTests = []struct {
 }{
 	{"heads", nil, []uint{}, "--heads value [ --heads value ]\t"},
 	{"H", nil, []uint{}, "-H value [ -H value ]\t"},
-	{"heads", []string{"H"}, []uint{2, 17179869184},
-		"--heads value, -H value [ --heads value, -H value ]\t(default: 2, 17179869184)"},
+	{
+		"heads",
+		[]string{"H"},
+		[]uint{2, 17179869184},
+		"--heads value, -H value [ --heads value, -H value ]\t(default: 2, 17179869184)",
+	},
 }
 
 func TestUintSliceFlagHelpOutput(t *testing.T) {
@@ -1310,6 +1316,7 @@ func TestUintSliceFlag_SetFromParentContext(t *testing.T) {
 		t.Errorf("child context unable to view parent flag: %v != %v", expected, ctx.UintSlice("numbers"))
 	}
 }
+
 func TestUintSliceFlag_ReturnNil(t *testing.T) {
 	fl := &UintSliceFlag{}
 	set := flag.NewFlagSet("test", 0)
@@ -1334,8 +1341,12 @@ var uint64SliceFlagTests = []struct {
 }{
 	{"heads", nil, []uint64{}, "--heads value [ --heads value ]\t"},
 	{"H", nil, []uint64{}, "-H value [ -H value ]\t"},
-	{"heads", []string{"H"}, []uint64{2, 17179869184},
-		"--heads value, -H value [ --heads value, -H value ]\t(default: 2, 17179869184)"},
+	{
+		"heads",
+		[]string{"H"},
+		[]uint64{2, 17179869184},
+		"--heads value, -H value [ --heads value, -H value ]\t(default: 2, 17179869184)",
+	},
 }
 
 func TestUint64SliceFlagHelpOutput(t *testing.T) {
@@ -1451,6 +1462,7 @@ func TestUint64SliceFlag_SetFromParentContext(t *testing.T) {
 		t.Errorf("child context unable to view parent flag: %v != %v", expected, ctx.Uint64Slice("numbers"))
 	}
 }
+
 func TestUint64SliceFlag_ReturnNil(t *testing.T) {
 	fl := &Uint64SliceFlag{}
 	set := flag.NewFlagSet("test", 0)
@@ -1529,8 +1541,12 @@ var float64SliceFlagTests = []struct {
 }{
 	{"heads", nil, []float64{}, "--heads value [ --heads value ]\t"},
 	{"H", nil, []float64{}, "-H value [ -H value ]\t"},
-	{"heads", []string{"H"}, []float64{0.1234, -10.5},
-		"--heads value, -H value [ --heads value, -H value ]\t(default: 0.1234, -10.5)"},
+	{
+		"heads",
+		[]string{"H"},
+		[]float64{0.1234, -10.5},
+		"--heads value, -H value [ --heads value, -H value ]\t(default: 0.1234, -10.5)",
+	},
 }
 
 func TestFloat64SliceFlagHelpOutput(t *testing.T) {
@@ -1665,7 +1681,7 @@ func TestParseDestinationString(t *testing.T) {
 				Destination: &dest,
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(*Context) error {
 			if dest != "10" {
 				t.Errorf("expected destination String 10")
 			}
@@ -1972,7 +1988,7 @@ func TestParseMultiStringSliceFromEnvWithDestination(t *testing.T) {
 		Flags: []Flag{
 			&StringSliceFlag{Name: "intervals", Aliases: []string{"i"}, Destination: &dest, EnvVars: []string{"APP_INTERVALS"}},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(*Context) error {
 			if !reflect.DeepEqual(dest, []string{"20", "30", "40"}) {
 				t.Errorf("main name not set from env")
 			}
@@ -2010,7 +2026,7 @@ func TestParseDestinationInt(t *testing.T) {
 				Destination: &dest,
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(*Context) error {
 			if dest != 10 {
 				t.Errorf("expected destination Int 10")
 			}
@@ -2258,7 +2274,7 @@ func TestParseDestinationFloat64(t *testing.T) {
 				Destination: &dest,
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(*Context) error {
 			if dest != 10.2 {
 				t.Errorf("expected destination Float64 10.2")
 			}
@@ -2399,7 +2415,7 @@ func TestParseDestinationBool(t *testing.T) {
 				Destination: &dest,
 			},
 		},
-		Action: func(ctx *Context) error {
+		Action: func(*Context) error {
 			if dest != true {
 				t.Errorf("expected destination Bool true")
 			}
@@ -2449,7 +2465,7 @@ func TestParseMultiBoolFromEnvCascade(t *testing.T) {
 }
 
 func TestParseBoolFromEnv(t *testing.T) {
-	var boolFlagTests = []struct {
+	boolFlagTests := []struct {
 		input  string
 		output bool
 	}{
@@ -2520,7 +2536,7 @@ func (p *Parser) Get() interface{} {
 }
 
 func TestFlagFromFile(t *testing.T) {
-	temp, err := ioutil.TempFile("", "urfave_cli_test")
+	temp, err := os.CreateTemp("", "urfave_cli_test")
 	if err != nil {
 		t.Error(err)
 		return
@@ -2536,7 +2552,7 @@ func TestFlagFromFile(t *testing.T) {
 		_ = os.Remove(temp.Name())
 	}()
 
-	var filePathTests = []struct {
+	filePathTests := []struct {
 		path     string
 		name     []string
 		expected string
@@ -2687,7 +2703,7 @@ func TestTimestampFlagApplyValue(t *testing.T) {
 func TestTimestampFlagApply_Fail_Parse_Wrong_Layout(t *testing.T) {
 	fl := TimestampFlag{Name: "time", Aliases: []string{"t"}, Config: TimestampConfig{Layout: "randomlayout"}}
 	set := flag.NewFlagSet("test", 0)
-	set.SetOutput(ioutil.Discard)
+	set.SetOutput(io.Discard)
 	_ = fl.Apply(set)
 
 	err := set.Parse([]string{"--time", "2006-01-02T15:04:05Z"})
@@ -2697,7 +2713,7 @@ func TestTimestampFlagApply_Fail_Parse_Wrong_Layout(t *testing.T) {
 func TestTimestampFlagApply_Fail_Parse_Wrong_Time(t *testing.T) {
 	fl := TimestampFlag{Name: "time", Aliases: []string{"t"}, Config: TimestampConfig{Layout: "Jan 2, 2006 at 3:04pm (MST)"}}
 	set := flag.NewFlagSet("test", 0)
-	set.SetOutput(ioutil.Discard)
+	set.SetOutput(io.Discard)
 	_ = fl.Apply(set)
 
 	err := set.Parse([]string{"--time", "2006-01-02T15:04:05Z"})
@@ -2791,7 +2807,7 @@ func TestFlagDefaultValue(t *testing.T) {
 	}
 	for i, v := range cases {
 		set := flag.NewFlagSet("test", 0)
-		set.SetOutput(ioutil.Discard)
+		set.SetOutput(io.Discard)
 		_ = v.flag.Apply(set)
 		if err := set.Parse(v.toParse); err != nil {
 			t.Error(err)
@@ -2951,7 +2967,7 @@ func TestFlagDefaultValueWithEnv(t *testing.T) {
 			os.Setenv(key, val)
 		}
 		set := flag.NewFlagSet("test", 0)
-		set.SetOutput(ioutil.Discard)
+		set.SetOutput(io.Discard)
 		if err := v.flag.Apply(set); err != nil {
 			t.Fatal(err)
 		}
@@ -2973,37 +2989,37 @@ type flagValueTestCase struct {
 
 func TestFlagValue(t *testing.T) {
 	cases := []*flagValueTestCase{
-		&flagValueTestCase{
+		{
 			name:    "stringSlice",
 			flag:    &StringSliceFlag{Name: "flag", Value: []string{"default1", "default2"}},
 			toParse: []string{"--flag", "parsed,parsed2", "--flag", "parsed3,parsed4"},
 			expect:  `[parsed parsed2 parsed3 parsed4]`,
 		},
-		&flagValueTestCase{
+		{
 			name:    "float64Slice",
 			flag:    &Float64SliceFlag{Name: "flag", Value: []float64{1.1, 2.2}},
 			toParse: []string{"--flag", "13.3,14.4", "--flag", "15.5,16.6"},
 			expect:  `[]float64{13.3, 14.4, 15.5, 16.6}`,
 		},
-		&flagValueTestCase{
+		{
 			name:    "int64Slice",
 			flag:    &Int64SliceFlag{Name: "flag", Value: []int64{1, 2}},
 			toParse: []string{"--flag", "13,14", "--flag", "15,16"},
 			expect:  `[]int64{13, 14, 15, 16}`,
 		},
-		&flagValueTestCase{
+		{
 			name:    "intSlice",
 			flag:    &IntSliceFlag{Name: "flag", Value: []int{1, 2}},
 			toParse: []string{"--flag", "13,14", "--flag", "15,16"},
 			expect:  `[]int{13, 14, 15, 16}`,
 		},
-		&flagValueTestCase{
+		{
 			name:    "uint64Slice",
 			flag:    &Uint64SliceFlag{Name: "flag", Value: []uint64{1, 2}},
 			toParse: []string{"--flag", "13,14", "--flag", "15,16"},
 			expect:  `[]uint64{13, 14, 15, 16}`,
 		},
-		&flagValueTestCase{
+		{
 			name:    "uintSlice",
 			flag:    &UintSliceFlag{Name: "flag", Value: []uint{1, 2}},
 			toParse: []string{"--flag", "13,14", "--flag", "15,16"},
@@ -3012,7 +3028,7 @@ func TestFlagValue(t *testing.T) {
 	}
 	for i, v := range cases {
 		set := flag.NewFlagSet("test", 0)
-		set.SetOutput(ioutil.Discard)
+		set.SetOutput(io.Discard)
 		_ = v.flag.Apply(set)
 		if err := set.Parse(v.toParse); err != nil {
 			t.Error(err)

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,8 @@ module github.com/urfave/cli/v3
 go 1.18
 
 require (
-	github.com/BurntSushi/toml v1.1.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.2
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673
-	gopkg.in/yaml.v3 v3.0.1
 )
 
-require (
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/exp v0.0.0-20221002003631-540bb7301a08 // indirect
-)
+require github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,6 @@
-github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
-github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
-golang.org/x/exp v0.0.0-20221002003631-540bb7301a08 h1:LtBIgSqNhkuC9gA3BFjGy5obHQT1lnmNsMDFSqWzQ5w=
-golang.org/x/exp v0.0.0-20221002003631-540bb7301a08/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/help.go
+++ b/help.go
@@ -241,7 +241,6 @@ func ShowCommandHelpAndExit(c *Context, command string, code int) {
 
 // ShowCommandHelp prints help for the given command
 func ShowCommandHelp(ctx *Context, command string) error {
-
 	commands := ctx.App.Commands
 	if ctx.Command.Subcommands != nil {
 		commands = ctx.Command.Subcommands
@@ -328,7 +327,6 @@ func ShowCommandCompletions(ctx *Context, command string) {
 			DefaultCompleteWithFlags(c)(ctx)
 		}
 	}
-
 }
 
 // printHelpCustom is the default implementation of HelpPrinterCustom.
@@ -336,7 +334,6 @@ func ShowCommandCompletions(ctx *Context, command string) {
 // The customFuncs map will be combined with a default template.FuncMap to
 // allow using arbitrary functions in template rendering.
 func printHelpCustom(out io.Writer, templ string, data interface{}, customFuncs map[string]interface{}) {
-
 	const maxLineLength = 10000
 
 	funcMap := template.FuncMap{
@@ -417,24 +414,6 @@ func checkHelp(cCtx *Context) bool {
 	return found
 }
 
-func checkCommandHelp(c *Context, name string) bool {
-	if c.Bool("h") || c.Bool("help") {
-		_ = ShowCommandHelp(c, name)
-		return true
-	}
-
-	return false
-}
-
-func checkSubcommandHelp(cCtx *Context) bool {
-	if cCtx.Bool("h") || cCtx.Bool("help") {
-		_ = ShowSubcommandHelp(cCtx)
-		return true
-	}
-
-	return false
-}
-
 func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
 	if !a.EnableBashCompletion {
 		return false, arguments
@@ -505,7 +484,6 @@ func wrap(input string, offset int, wrapAt int) string {
 				ss = append(ss, wrapped)
 			} else {
 				ss = append(ss, padding+wrapped)
-
 			}
 
 		}

--- a/help_test.go
+++ b/help_test.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -179,7 +178,7 @@ func Test_helpCommand_InHelpOutput(t *testing.T) {
 }
 
 func Test_helpCommand_HelpName(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name string
 		args []string
 		want string
@@ -311,7 +310,7 @@ func TestShowAppHelp_CommandAliases(t *testing.T) {
 }
 
 func TestShowCommandHelp_AppendHelp(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name            string
 		hideHelp        bool
 		hideHelpCommand bool
@@ -391,7 +390,7 @@ func TestShowCommandHelp_HelpPrinter(t *testing.T) {
 		{
 			name:     "no-command",
 			template: "",
-			printer: func(w io.Writer, templ string, data interface{}) {
+			printer: func(w io.Writer, _ string, _ interface{}) {
 				fmt.Fprint(w, "yo")
 			},
 			command:      "",
@@ -476,7 +475,7 @@ func TestShowCommandHelp_HelpPrinterCustom(t *testing.T) {
 		{
 			name:     "no-command",
 			template: "",
-			printer: func(w io.Writer, templ string, data interface{}, fm map[string]interface{}) {
+			printer: func(w io.Writer, _ string, _ interface{}, _ map[string]interface{}) {
 				fmt.Fprint(w, "yo")
 			},
 			command:      "",
@@ -486,7 +485,7 @@ func TestShowCommandHelp_HelpPrinterCustom(t *testing.T) {
 		{
 			name:     "standard-command",
 			template: "",
-			printer: func(w io.Writer, templ string, data interface{}, fm map[string]interface{}) {
+			printer: func(w io.Writer, _ string, _ interface{}, _ map[string]interface{}) {
 				fmt.Fprint(w, "yo")
 			},
 			command:      "my-command",
@@ -846,7 +845,7 @@ func TestShowAppHelp_HelpPrinter(t *testing.T) {
 		{
 			name:     "standard-command",
 			template: "",
-			printer: func(w io.Writer, templ string, data interface{}) {
+			printer: func(w io.Writer, _ string, _ interface{}) {
 				fmt.Fprint(w, "yo")
 			},
 			wantTemplate: AppHelpTemplate,
@@ -913,7 +912,7 @@ func TestShowAppHelp_HelpPrinterCustom(t *testing.T) {
 		{
 			name:     "standard-command",
 			template: "",
-			printer: func(w io.Writer, templ string, data interface{}, fm map[string]interface{}) {
+			printer: func(w io.Writer, _ string, _ interface{}, _ map[string]interface{}) {
 				fmt.Fprint(w, "yo")
 			},
 			wantTemplate: AppHelpTemplate,
@@ -1133,7 +1132,7 @@ App UsageText`,
 func TestHideHelpCommand(t *testing.T) {
 	app := &App{
 		HideHelpCommand: true,
-		Writer:          ioutil.Discard,
+		Writer:          io.Discard,
 	}
 
 	err := app.Run([]string{"foo", "help"})
@@ -1153,7 +1152,7 @@ func TestHideHelpCommand(t *testing.T) {
 func TestHideHelpCommand_False(t *testing.T) {
 	app := &App{
 		HideHelpCommand: false,
-		Writer:          ioutil.Discard,
+		Writer:          io.Discard,
 	}
 
 	err := app.Run([]string{"foo", "help"})
@@ -1171,7 +1170,7 @@ func TestHideHelpCommand_WithHideHelp(t *testing.T) {
 	app := &App{
 		HideHelp:        true, // effective (hides both command and flag)
 		HideHelpCommand: true, // ignored
-		Writer:          ioutil.Discard,
+		Writer:          io.Discard,
 	}
 
 	err := app.Run([]string{"foo", "help"})
@@ -1200,7 +1199,7 @@ func newContextFromStringSlice(ss []string) *Context {
 func TestHideHelpCommand_RunAsSubcommand(t *testing.T) {
 	app := &App{
 		HideHelpCommand: true,
-		Writer:          ioutil.Discard,
+		Writer:          io.Discard,
 		Commands: []*Command{
 			{
 				Name: "dummy",
@@ -1225,7 +1224,7 @@ func TestHideHelpCommand_RunAsSubcommand(t *testing.T) {
 func TestHideHelpCommand_RunAsSubcommand_False(t *testing.T) {
 	app := &App{
 		HideHelpCommand: false,
-		Writer:          ioutil.Discard,
+		Writer:          io.Discard,
 		Commands: []*Command{
 			{
 				Name: "dummy",
@@ -1246,7 +1245,7 @@ func TestHideHelpCommand_RunAsSubcommand_False(t *testing.T) {
 
 func TestHideHelpCommand_WithSubcommands(t *testing.T) {
 	app := &App{
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 		Commands: []*Command{
 			{
 				Name: "dummy",
@@ -1368,7 +1367,6 @@ func TestWrap(t *testing.T) {
 }
 
 func TestWrappedHelp(t *testing.T) {
-
 	// Reset HelpPrinter after this test.
 	defer func(old helpPrinter) {
 		HelpPrinter = old
@@ -1378,7 +1376,8 @@ func TestWrappedHelp(t *testing.T) {
 	app := &App{
 		Writer: output,
 		Flags: []Flag{
-			&BoolFlag{Name: "foo",
+			&BoolFlag{
+				Name:    "foo",
 				Aliases: []string{"h"},
 				Usage:   "here's a really long help text line, let's see where it wraps. blah blah blah and so on.",
 			},
@@ -1462,7 +1461,6 @@ COPYRIGHT:
 }
 
 func TestWrappedCommandHelp(t *testing.T) {
-
 	// Reset HelpPrinter after this test.
 	defer func(old helpPrinter) {
 		HelpPrinter = old
@@ -1524,7 +1522,6 @@ OPTIONS:
 }
 
 func TestWrappedSubcommandHelp(t *testing.T) {
-
 	// Reset HelpPrinter after this test.
 	defer func(old helpPrinter) {
 		HelpPrinter = old
@@ -1594,7 +1591,6 @@ OPTIONS:
 }
 
 func TestWrappedHelpSubcommand(t *testing.T) {
-
 	// Reset HelpPrinter after this test.
 	defer func(old helpPrinter) {
 		HelpPrinter = old


### PR DESCRIPTION
I ran the linter to find functions, methods, and variables not being used as well as ran go mod tidy. 

Plus, ioutil as of Go1.17 has been deprecated, so replaced all calls to os/io functions. 