### PR TITLE
Add usage example for `urfave_cli_no_docs` flag

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,10 @@ When set, this removes `ToMarkdown` and `ToMan` methods, so your application
 won't be able to call those. This reduces the resulting binary size by about
 300-400 KB (measured using Go 1.18.1 on Linux/amd64), due to fewer dependencies.
 
+```
+$ go build -tags urfave_cli_no_docs
+```
+
 ### Supported platforms
 
 cli is tested against multiple versions of Go on Linux, and against the latest


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

I haven't used custom build flags, so it was not obvious for me how to use it. I thought I can specify it in go code, but it came out that it can only be set from command line.

## Which issue(s) this PR fixes:

Not really fixes, but relates to https://github.com/urfave/cli/discussions/1594

## Special notes for your reviewer:

Would be nice to link `ToMarkdown` and `ToMan` to usage examples as I don't really get where these can be useful.
