### PR TITLE
Feature:(issue_351) Add support for generation of shell completion sc…

### DIFF
--- a/app.go
+++ b/app.go
@@ -269,7 +269,7 @@ func (a *App) newRootCommand() *Command {
 		UsageText:              a.UsageText,
 		Description:            a.Description,
 		ArgsUsage:              a.ArgsUsage,
-		BashComplete:           a.ShellComplete,
+		ShellComplete:          a.ShellComplete,
 		Before:                 a.Before,
 		After:                  a.After,
 		Action:                 a.Action,

--- a/app.go
+++ b/app.go
@@ -51,8 +51,10 @@ type App struct {
 	Commands []*Command
 	// List of flags to parse
 	Flags []Flag
-	// Boolean to enable bash completion commands
-	EnableBashCompletion bool
+	// Boolean to enable shell completion commands
+	EnableShellCompletion bool
+	// Shell Completion generation command name
+	ShellCompletionCommandName string
 	// Boolean to hide built-in help command and help flag
 	HideHelp bool
 	// Boolean to hide built-in help command but keep help flag.
@@ -65,7 +67,7 @@ type App struct {
 	// flagCategories contains the categorized flags and is populated on app startup
 	flagCategories FlagCategories
 	// An action to execute when the shell completion flag is set
-	BashComplete BashCompleteFunc
+	ShellComplete ShellCompleteFunc
 	// An action to execute before any subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no subcommands are run
 	Before BeforeFunc
@@ -131,14 +133,14 @@ type SuggestCommandFunc func(commands []*Command, provided string) string
 // Usage, Version and Action.
 func NewApp() *App {
 	return &App{
-		Name:         filepath.Base(os.Args[0]),
-		Usage:        "A new cli application",
-		UsageText:    "",
-		BashComplete: DefaultAppComplete,
-		Action:       helpCommand.Action,
-		Reader:       os.Stdin,
-		Writer:       os.Stdout,
-		ErrWriter:    os.Stderr,
+		Name:          filepath.Base(os.Args[0]),
+		Usage:         "A new cli application",
+		UsageText:     "",
+		ShellComplete: DefaultAppComplete,
+		Action:        helpCommand.Action,
+		Reader:        os.Stdin,
+		Writer:        os.Stdout,
+		ErrWriter:     os.Stderr,
 	}
 }
 
@@ -168,8 +170,8 @@ func (a *App) Setup() {
 		a.HideVersion = true
 	}
 
-	if a.BashComplete == nil {
-		a.BashComplete = DefaultAppComplete
+	if a.ShellComplete == nil {
+		a.ShellComplete = DefaultAppComplete
 	}
 
 	if a.Action == nil {
@@ -227,6 +229,13 @@ func (a *App) Setup() {
 		a.appendFlag(VersionFlag)
 	}
 
+	if a.EnableShellCompletion {
+		if a.ShellCompletionCommandName != "" {
+			completionCommand.Name = a.ShellCompletionCommandName
+		}
+		a.appendCommand(completionCommand)
+	}
+
 	a.categories = newCommandCategories()
 	for _, command := range a.Commands {
 		a.categories.AddCommand(command.Category, command)
@@ -260,7 +269,7 @@ func (a *App) newRootCommand() *Command {
 		UsageText:              a.UsageText,
 		Description:            a.Description,
 		ArgsUsage:              a.ArgsUsage,
-		BashComplete:           a.BashComplete,
+		BashComplete:           a.ShellComplete,
 		Before:                 a.Before,
 		After:                  a.After,
 		Action:                 a.Action,

--- a/app_test.go
+++ b/app_test.go
@@ -232,11 +232,11 @@ func ExampleApp_Run_subcommandNoAction() {
 
 func ExampleApp_Run_bashComplete_withShortFlag() {
 	os.Setenv("SHELL", "bash")
-	os.Args = []string{"greet", "-", "--generate-bash-completion"}
+	os.Args = []string{"greet", "-", "--generate-shell-completion"}
 
 	app := NewApp()
 	app.Name = "greet"
-	app.EnableBashCompletion = true
+	app.EnableShellCompletion = true
 	app.Flags = []Flag{
 		&IntFlag{
 			Name:    "other",
@@ -260,11 +260,11 @@ func ExampleApp_Run_bashComplete_withShortFlag() {
 
 func ExampleApp_Run_bashComplete_withLongFlag() {
 	os.Setenv("SHELL", "bash")
-	os.Args = []string{"greet", "--s", "--generate-bash-completion"}
+	os.Args = []string{"greet", "--s", "--generate-shell-completion"}
 
 	app := NewApp()
 	app.Name = "greet"
-	app.EnableBashCompletion = true
+	app.EnableShellCompletion = true
 	app.Flags = []Flag{
 		&IntFlag{
 			Name:    "other",
@@ -290,11 +290,11 @@ func ExampleApp_Run_bashComplete_withLongFlag() {
 
 func ExampleApp_Run_bashComplete_withMultipleLongFlag() {
 	os.Setenv("SHELL", "bash")
-	os.Args = []string{"greet", "--st", "--generate-bash-completion"}
+	os.Args = []string{"greet", "--st", "--generate-shell-completion"}
 
 	app := NewApp()
 	app.Name = "greet"
-	app.EnableBashCompletion = true
+	app.EnableShellCompletion = true
 	app.Flags = []Flag{
 		&IntFlag{
 			Name:    "int-flag",
@@ -323,11 +323,11 @@ func ExampleApp_Run_bashComplete_withMultipleLongFlag() {
 
 func ExampleApp_Run_bashComplete() {
 	os.Setenv("SHELL", "bash")
-	os.Args = []string{"greet", "--generate-bash-completion"}
+	os.Args = []string{"greet", "--generate-shell-completion"}
 
 	app := &App{
-		Name:                 "greet",
-		EnableBashCompletion: true,
+		Name:                  "greet",
+		EnableShellCompletion: true,
 		Commands: []*Command{
 			{
 				Name:        "describeit",
@@ -361,12 +361,12 @@ func ExampleApp_Run_bashComplete() {
 
 func ExampleApp_Run_zshComplete() {
 	// set args for examples sake
-	os.Args = []string{"greet", "--generate-bash-completion"}
+	os.Args = []string{"greet", "--generate-shell-completion"}
 	_ = os.Setenv("SHELL", "/usr/bin/zsh")
 
 	app := NewApp()
 	app.Name = "greet"
-	app.EnableBashCompletion = true
+	app.EnableShellCompletion = true
 	app.Commands = []*Command{
 		{
 			Name:        "describeit",
@@ -1369,7 +1369,7 @@ func TestApp_BeforeAfterFuncShellCompletion(t *testing.T) {
 	var err error
 
 	app := &App{
-		EnableBashCompletion: true,
+		EnableShellCompletion: true,
 		Before: func(*Context) error {
 			counts.Total++
 			counts.Before = counts.Total
@@ -1397,7 +1397,7 @@ func TestApp_BeforeAfterFuncShellCompletion(t *testing.T) {
 	}
 
 	// run with the Before() func succeeding
-	err = app.Run([]string{"command", "--opt", "succeed", "sub", "--generate-bash-completion"})
+	err = app.Run([]string{"command", "--opt", "succeed", "sub", "--generate-shell-completion"})
 
 	if err != nil {
 		t.Fatalf("Run error: %s", err)
@@ -1736,8 +1736,8 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	resetCounts := func() { counts = &opCounts{} }
 
 	app := &App{
-		EnableBashCompletion: true,
-		BashComplete: func(*Context) {
+		EnableShellCompletion: true,
+		ShellComplete: func(*Context) {
 			counts.Total++
 			counts.ShellComplete = counts.Total
 		},
@@ -1803,7 +1803,7 @@ func TestApp_OrderOfOperations(t *testing.T) {
 
 	resetCounts()
 
-	_ = app.Run([]string{"command", fmt.Sprintf("--%s", "generate-bash-completion")})
+	_ = app.Run([]string{"command", fmt.Sprintf("--%s", "generate-shell-completion")})
 	expect(t, counts.ShellComplete, 1)
 	expect(t, counts.Total, 1)
 
@@ -2618,8 +2618,8 @@ func TestShellCompletionForIncompleteFlags(t *testing.T) {
 				Name: "test-completion",
 			},
 		},
-		EnableBashCompletion: true,
-		BashComplete: func(ctx *Context) {
+		EnableShellCompletion: true,
+		ShellComplete: func(ctx *Context) {
 			for _, command := range ctx.App.Commands {
 				if command.Hidden {
 					continue
@@ -2651,7 +2651,7 @@ func TestShellCompletionForIncompleteFlags(t *testing.T) {
 		},
 		Writer: io.Discard,
 	}
-	err := app.Run([]string{"", "--test-completion", "--" + "generate-bash-completion"})
+	err := app.Run([]string{"", "--test-completion", "--" + "generate-shell-completion"})
 	if err != nil {
 		t.Errorf("app should not return an error: %s", err)
 	}

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -8,9 +8,9 @@ _cli_bash_autocomplete() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     if [[ "$cur" == "-"* ]]; then
-      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-shell-completion )
     else
-      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-shell-completion )
     fi
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     return 0

--- a/autocomplete/powershell_autocomplete.ps1
+++ b/autocomplete/powershell_autocomplete.ps1
@@ -2,7 +2,7 @@ $fn = $($MyInvocation.MyCommand.Name)
 $name = $fn -replace "(.*)\.ps1$", '$1'
 Register-ArgumentCompleter -Native -CommandName $name -ScriptBlock {
      param($commandName, $wordToComplete, $cursorPosition)
-     $other = "$wordToComplete --generate-bash-completion"
+     $other = "$wordToComplete --generate-shell-completion"
          Invoke-Expression $other | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
          }

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -5,9 +5,9 @@ _cli_zsh_autocomplete() {
   local cur
   cur=${words[-1]}
   if [[ "$cur" == "-"* ]]; then
-    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-shell-completion)}")
   else
-    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-shell-completion)}")
   fi
 
   if [[ "${opts[1]}" != "" ]]; then

--- a/command.go
+++ b/command.go
@@ -25,7 +25,7 @@ type Command struct {
 	// The category the command is part of
 	Category string
 	// The function to call when checking for bash command completions
-	BashComplete BashCompleteFunc
+	BashComplete ShellCompleteFunc
 	// An action to execute before any sub-subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no sub-subcommands are run
 	Before BeforeFunc

--- a/command_test.go
+++ b/command_test.go
@@ -349,8 +349,8 @@ func TestCommand_Run_CustomShellCompleteAcceptsMalformedFlags(t *testing.T) {
 	for _, c := range cases {
 		var outputBuffer bytes.Buffer
 		app := &App{
-			Writer:               &outputBuffer,
-			EnableBashCompletion: true,
+			Writer:                &outputBuffer,
+			EnableShellCompletion: true,
 			Commands: []*Command{
 				{
 					Name:  "bar",
@@ -370,7 +370,7 @@ func TestCommand_Run_CustomShellCompleteAcceptsMalformedFlags(t *testing.T) {
 
 		osArgs := args{"foo", "bar"}
 		osArgs = append(osArgs, c.testArgs...)
-		osArgs = append(osArgs, "--generate-bash-completion")
+		osArgs = append(osArgs, "--generate-shell-completion")
 
 		err := app.Run(osArgs)
 		stdout := outputBuffer.String()

--- a/command_test.go
+++ b/command_test.go
@@ -361,7 +361,7 @@ func TestCommand_Run_CustomShellCompleteAcceptsMalformedFlags(t *testing.T) {
 							Usage: "A number to parse",
 						},
 					},
-					BashComplete: func(c *Context) {
+					ShellComplete: func(c *Context) {
 						fmt.Fprintf(c.App.Writer, "found %d args", c.NArg())
 					},
 				},

--- a/completion.go
+++ b/completion.go
@@ -40,6 +40,8 @@ var completionCommand = &Command{
 		for k := range shellCompletions {
 			shells = append(shells, k)
 		}
+		
+		sort.Strings(shells)
 
 		if ctx.Args().Len() == 0 {
 			return Exit(fmt.Sprintf("no shell provided for completion command. available shells are %+v", shells), 1)

--- a/completion.go
+++ b/completion.go
@@ -1,8 +1,9 @@
 package cli
 
 import (
-	_ "embed"
+	"embed"
 	"fmt"
+	"sort"
 )
 
 const (
@@ -40,7 +41,7 @@ var completionCommand = &Command{
 		for k := range shellCompletions {
 			shells = append(shells, k)
 		}
-		
+
 		sort.Strings(shells)
 
 		if ctx.Args().Len() == 0 {

--- a/completion.go
+++ b/completion.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	_ "embed"
+	"fmt"
+)
+
+const (
+	completionCommandName = "generate-completion"
+)
+
+//go:embed autocomplete/bash_autocomplete
+var bash_autocomplete string
+
+//go:embed autocomplete/powershell_autocomplete.ps1
+var powershell_autocomplete string
+
+//go:embed autocomplete/zsh_autocomplete
+var zsh_autocomplete string
+
+type renderCompletion func(a *App) (string, error)
+
+func getCompletion(s string) renderCompletion {
+	return func(a *App) (string, error) {
+		return s, nil
+	}
+}
+
+var shellCompletions = map[string]renderCompletion{
+	"bash": getCompletion(bash_autocomplete),
+	"ps":   getCompletion(powershell_autocomplete),
+	"zsh":  getCompletion(zsh_autocomplete),
+	"fish": func(a *App) (string, error) {
+		return a.ToFishCompletion()
+	},
+}
+
+var completionCommand = &Command{
+	Name:   completionCommandName,
+	Hidden: true,
+	Action: func(ctx *Context) error {
+		var shells []string
+		for k := range shellCompletions {
+			shells = append(shells, k)
+		}
+
+		if ctx.Args().Len() == 0 {
+			return Exit(fmt.Sprintf("no shell provided for completion command. available shells are %+v", shells), 1)
+		}
+		s := ctx.Args().First()
+
+		if rc, ok := shellCompletions[s]; !ok {
+			return Exit(fmt.Sprintf("unknown shell %s, available shells are %+v", s, shells), 1)
+		} else if c, err := rc(ctx.App); err != nil {
+			return Exit(err, 1)
+		} else {
+			ctx.App.Writer.Write([]byte(c))
+		}
+		return nil
+	},
+}

--- a/completion.go
+++ b/completion.go
@@ -9,30 +9,27 @@ const (
 	completionCommandName = "generate-completion"
 )
 
-//go:embed autocomplete/bash_autocomplete
-var bash_autocomplete string
+var (
+	//go:embed autocomplete
+	autoCompleteFS embed.FS
 
-//go:embed autocomplete/powershell_autocomplete.ps1
-var powershell_autocomplete string
-
-//go:embed autocomplete/zsh_autocomplete
-var zsh_autocomplete string
+	shellCompletions = map[string]renderCompletion{
+		"bash": getCompletion("autocomplete/bash_autocomplete"),
+		"ps":   getCompletion("autocomplete/powershell_autocomplete.ps1"),
+		"zsh":  getCompletion("autocomplete/zsh_autocomplete"),
+		"fish": func(a *App) (string, error) {
+			return a.ToFishCompletion()
+		},
+	}
+)
 
 type renderCompletion func(a *App) (string, error)
 
 func getCompletion(s string) renderCompletion {
 	return func(a *App) (string, error) {
-		return s, nil
+		b, err := autoCompleteFS.ReadFile(s)
+		return string(b), err
 	}
-}
-
-var shellCompletions = map[string]renderCompletion{
-	"bash": getCompletion(bash_autocomplete),
-	"ps":   getCompletion(powershell_autocomplete),
-	"zsh":  getCompletion(zsh_autocomplete),
-	"fish": func(a *App) (string, error) {
-		return a.ToFishCompletion()
-	},
 }
 
 var completionCommand = &Command{

--- a/completion_test.go
+++ b/completion_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCompletionDisable(t *testing.T) {
+	a := &App{}
+	err := a.Run([]string{"foo", completionCommandName})
+	if err == nil {
+		t.Error("Expected error for no help topic for completion")
+	}
+}
+
+func TestCompletionEnable(t *testing.T) {
+	a := &App{
+		EnableShellCompletion: true,
+	}
+	err := a.Run([]string{"foo", completionCommandName})
+	if err == nil || !strings.Contains(err.Error(), "no shell provided") {
+		t.Errorf("expected no shell provided error instead got [%v]", err)
+	}
+}
+
+func TestCompletionEnableDiffCommandName(t *testing.T) {
+	defer func() {
+		completionCommand.Name = completionCommandName
+	}()
+
+	a := &App{
+		EnableShellCompletion:      true,
+		ShellCompletionCommandName: "junky",
+	}
+	err := a.Run([]string{"foo", "junky"})
+	if err == nil || !strings.Contains(err.Error(), "no shell provided") {
+		t.Errorf("expected no shell provided error instead got [%v]", err)
+	}
+}
+
+func TestCompletionShell(t *testing.T) {
+	for k := range shellCompletions {
+		var b bytes.Buffer
+		t.Run(k, func(t *testing.T) {
+			a := &App{
+				EnableShellCompletion: true,
+				Writer:                &b,
+			}
+			err := a.Run([]string{"foo", completionCommandName, k})
+			if err != nil {
+				t.Error(err)
+			}
+		})
+		output := b.String()
+		if !strings.Contains(output, k) {
+			t.Errorf("Expected output to contain shell name %v", output)
+		}
+	}
+}
+
+func TestCompletionInvalidShell(t *testing.T) {
+	a := &App{
+		EnableShellCompletion: true,
+	}
+	err := a.Run([]string{"foo", completionCommandName, "junky-sheell"})
+	if err == nil {
+		t.Error("Expected error for invalid shell")
+	}
+}

--- a/fish.go
+++ b/fish.go
@@ -115,11 +115,6 @@ func (a *App) prepareFishCommands(commands []*Command, allCommands *[]string, pr
 func (a *App) prepareFishFlags(flags []Flag, previousCommands []string) []string {
 	completions := []string{}
 	for _, f := range flags {
-		flag, ok := f.(DocGenerationFlag)
-		if !ok {
-			continue
-		}
-
 		completion := &strings.Builder{}
 		completion.WriteString(fmt.Sprintf(
 			"complete -c %s -n '%s'",
@@ -129,7 +124,7 @@ func (a *App) prepareFishFlags(flags []Flag, previousCommands []string) []string
 
 		fishAddFileFlag(f, completion)
 
-		for idx, opt := range flag.Names() {
+		for idx, opt := range f.Names() {
 			if idx == 0 {
 				completion.WriteString(fmt.Sprintf(
 					" -l %s", strings.TrimSpace(opt),
@@ -142,13 +137,15 @@ func (a *App) prepareFishFlags(flags []Flag, previousCommands []string) []string
 			}
 		}
 
-		if flag.TakesValue() {
-			completion.WriteString(" -r")
-		}
+		if flag, ok := f.(DocGenerationFlag); ok {
+			if flag.TakesValue() {
+				completion.WriteString(" -r")
+			}
 
-		if flag.GetUsage() != "" {
-			completion.WriteString(fmt.Sprintf(" -d '%s'",
-				escapeSingleQuotes(flag.GetUsage())))
+			if flag.GetUsage() != "" {
+				completion.WriteString(fmt.Sprintf(" -d '%s'",
+					escapeSingleQuotes(flag.GetUsage())))
+			}
 		}
 
 		completions = append(completions, completion.String())

--- a/flag.go
+++ b/flag.go
@@ -29,7 +29,7 @@ var (
 
 // BashCompletionFlag enables bash-completion for all commands and subcommands
 var BashCompletionFlag Flag = &BoolFlag{
-	Name:   "generate-bash-completion",
+	Name:   "generate-shell-completion",
 	Hidden: true,
 }
 

--- a/funcs.go
+++ b/funcs.go
@@ -1,7 +1,7 @@
 package cli
 
-// BashCompleteFunc is an action to execute when the shell completion flag is set
-type BashCompleteFunc func(*Context)
+// ShellCompleteFunc is an action to execute when the shell completion flag is set
+type ShellCompleteFunc func(*Context)
 
 // BeforeFunc is an action to execute before any subcommands are run, but after
 // the context is ready if a non-nil error is returned, no subcommands are run

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -212,9 +212,6 @@ func ShowAppHelpAndExit(c *Context, exitCode int)
     ShowAppHelpAndExit - Prints the list of subcommands for the app and exits
     with exit code.
 
-func ShowCommandCompletions(ctx *Context, command string)
-    ShowCommandCompletions prints the custom completions for a given command
-
 func ShowCommandHelp(ctx *Context, command string) error
     ShowCommandHelp prints help for the given command
 
@@ -469,8 +466,8 @@ type Command struct {
 	ArgsUsage string
 	// The category the command is part of
 	Category string
-	// The function to call when checking for bash command completions
-	BashComplete ShellCompleteFunc
+	// The function to call when checking for shell command completions
+	ShellComplete ShellCompleteFunc
 	// An action to execute before any sub-subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no sub-subcommands are run
 	Before BeforeFunc

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -273,8 +273,10 @@ type App struct {
 	Commands []*Command
 	// List of flags to parse
 	Flags []Flag
-	// Boolean to enable bash completion commands
-	EnableBashCompletion bool
+	// Boolean to enable shell completion commands
+	EnableShellCompletion bool
+	// Shell Completion generation command name
+	ShellCompletionCommandName string
 	// Boolean to hide built-in help command and help flag
 	HideHelp bool
 	// Boolean to hide built-in help command but keep help flag.
@@ -284,7 +286,7 @@ type App struct {
 	HideVersion bool
 
 	// An action to execute when the shell completion flag is set
-	BashComplete BashCompleteFunc
+	ShellComplete ShellCompleteFunc
 	// An action to execute before any subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no subcommands are run
 	Before BeforeFunc
@@ -432,10 +434,6 @@ func (a *Author) String() string
     String makes Author comply to the Stringer interface, to allow an easy print
     in the templating process
 
-type BashCompleteFunc func(*Context)
-    BashCompleteFunc is an action to execute when the shell completion flag is
-    set
-
 type BeforeFunc func(*Context) error
     BeforeFunc is an action to execute before any subcommands are run, but after
     the context is ready if a non-nil error is returned, no subcommands are run
@@ -472,7 +470,7 @@ type Command struct {
 	// The category the command is part of
 	Category string
 	// The function to call when checking for bash command completions
-	BashComplete BashCompleteFunc
+	BashComplete ShellCompleteFunc
 	// An action to execute before any sub-subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no sub-subcommands are run
 	Before BeforeFunc
@@ -756,7 +754,7 @@ type Flag interface {
     implemented.
 
 var BashCompletionFlag Flag = &BoolFlag{
-	Name:   "generate-bash-completion",
+	Name:   "generate-shell-completion",
 	Hidden: true,
 }
     BashCompletionFlag enables bash-completion for all commands and subcommands
@@ -998,6 +996,10 @@ type Serializer interface {
 	Serialize() string
 }
     Serializer is used to circumvent the limitations of flag.FlagSet.Set
+
+type ShellCompleteFunc func(*Context)
+    ShellCompleteFunc is an action to execute when the shell completion flag is
+    set
 
 type SliceBase[T any, C any, VC ValueCreator[T, C]] struct {
 	// Has unexported fields.

--- a/help.go
+++ b/help.go
@@ -312,8 +312,8 @@ func printVersion(cCtx *Context) {
 // ShowCompletions prints the lists of commands within a given context
 func ShowCompletions(cCtx *Context) {
 	a := cCtx.App
-	if a != nil && a.BashComplete != nil {
-		a.BashComplete(cCtx)
+	if a != nil && a.ShellComplete != nil {
+		a.ShellComplete(cCtx)
 	}
 }
 
@@ -415,14 +415,14 @@ func checkHelp(cCtx *Context) bool {
 }
 
 func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
-	if !a.EnableBashCompletion {
+	if !a.EnableShellCompletion {
 		return false, arguments
 	}
 
 	pos := len(arguments) - 1
 	lastArg := arguments[pos]
 
-	if lastArg != "--generate-bash-completion" {
+	if lastArg != "--generate-shell-completion" {
 		return false, arguments
 	}
 

--- a/help.go
+++ b/help.go
@@ -311,21 +311,9 @@ func printVersion(cCtx *Context) {
 
 // ShowCompletions prints the lists of commands within a given context
 func ShowCompletions(cCtx *Context) {
-	a := cCtx.App
-	if a != nil && a.ShellComplete != nil {
-		a.ShellComplete(cCtx)
-	}
-}
-
-// ShowCommandCompletions prints the custom completions for a given command
-func ShowCommandCompletions(ctx *Context, command string) {
-	c := ctx.App.Command(command)
+	c := cCtx.Command
 	if c != nil {
-		if c.BashComplete != nil {
-			c.BashComplete(ctx)
-		} else {
-			DefaultCompleteWithFlags(c)(ctx)
-		}
+		c.ShellComplete(cCtx)
 	}
 }
 
@@ -436,22 +424,13 @@ func checkCompletions(cCtx *Context) bool {
 
 	if args := cCtx.Args(); args.Present() {
 		name := args.First()
-		if cmd := cCtx.App.Command(name); cmd != nil {
+		if cmd := cCtx.Command.Command(name); cmd != nil {
 			// let the command handle the completion
 			return false
 		}
 	}
 
 	ShowCompletions(cCtx)
-	return true
-}
-
-func checkCommandCompletions(c *Context, name string) bool {
-	if !c.shellComplete {
-		return false
-	}
-
-	ShowCommandCompletions(c, name)
 	return true
 }
 

--- a/help_test.go
+++ b/help_test.go
@@ -1316,7 +1316,7 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 					&StringFlag{Name: "hat-shape"},
 				},
 			},
-			argv:     []string{"cmd", "--e", "--generate-bash-completion"},
+			argv:     []string{"cmd", "--e", "--generate-shell-completion"},
 			expected: "--excitement\n",
 		},
 		{
@@ -1338,7 +1338,7 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 					&StringFlag{Name: "hat-shape"},
 				},
 			},
-			argv:     []string{"cmd", "--generate-bash-completion"},
+			argv:     []string{"cmd", "--generate-shell-completion"},
 			expected: "futz\n",
 		},
 	} {

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -212,9 +212,6 @@ func ShowAppHelpAndExit(c *Context, exitCode int)
     ShowAppHelpAndExit - Prints the list of subcommands for the app and exits
     with exit code.
 
-func ShowCommandCompletions(ctx *Context, command string)
-    ShowCommandCompletions prints the custom completions for a given command
-
 func ShowCommandHelp(ctx *Context, command string) error
     ShowCommandHelp prints help for the given command
 
@@ -469,8 +466,8 @@ type Command struct {
 	ArgsUsage string
 	// The category the command is part of
 	Category string
-	// The function to call when checking for bash command completions
-	BashComplete ShellCompleteFunc
+	// The function to call when checking for shell command completions
+	ShellComplete ShellCompleteFunc
 	// An action to execute before any sub-subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no sub-subcommands are run
 	Before BeforeFunc

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -273,8 +273,10 @@ type App struct {
 	Commands []*Command
 	// List of flags to parse
 	Flags []Flag
-	// Boolean to enable bash completion commands
-	EnableBashCompletion bool
+	// Boolean to enable shell completion commands
+	EnableShellCompletion bool
+	// Shell Completion generation command name
+	ShellCompletionCommandName string
 	// Boolean to hide built-in help command and help flag
 	HideHelp bool
 	// Boolean to hide built-in help command but keep help flag.
@@ -284,7 +286,7 @@ type App struct {
 	HideVersion bool
 
 	// An action to execute when the shell completion flag is set
-	BashComplete BashCompleteFunc
+	ShellComplete ShellCompleteFunc
 	// An action to execute before any subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no subcommands are run
 	Before BeforeFunc
@@ -432,10 +434,6 @@ func (a *Author) String() string
     String makes Author comply to the Stringer interface, to allow an easy print
     in the templating process
 
-type BashCompleteFunc func(*Context)
-    BashCompleteFunc is an action to execute when the shell completion flag is
-    set
-
 type BeforeFunc func(*Context) error
     BeforeFunc is an action to execute before any subcommands are run, but after
     the context is ready if a non-nil error is returned, no subcommands are run
@@ -472,7 +470,7 @@ type Command struct {
 	// The category the command is part of
 	Category string
 	// The function to call when checking for bash command completions
-	BashComplete BashCompleteFunc
+	BashComplete ShellCompleteFunc
 	// An action to execute before any sub-subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no sub-subcommands are run
 	Before BeforeFunc
@@ -756,7 +754,7 @@ type Flag interface {
     implemented.
 
 var BashCompletionFlag Flag = &BoolFlag{
-	Name:   "generate-bash-completion",
+	Name:   "generate-shell-completion",
 	Hidden: true,
 }
     BashCompletionFlag enables bash-completion for all commands and subcommands
@@ -998,6 +996,10 @@ type Serializer interface {
 	Serialize() string
 }
     Serializer is used to circumvent the limitations of flag.FlagSet.Set
+
+type ShellCompleteFunc func(*Context)
+    ShellCompleteFunc is an action to execute when the shell completion flag is
+    set
 
 type SliceBase[T any, C any, VC ValueCreator[T, C]] struct {
 	// Has unexported fields.


### PR DESCRIPTION
…ripts

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- cleanup
- feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->
Fixes #351 
## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->
 Add new tests 
```
go test -run=TestCompletion
```
## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
EnableBashCompletion has been renamed to EnableShellCompletion. When enabled completions can be generated on the fly and sourced in current shell environment

PROG=cli-app source <(cli-app generate-completion bash)

Supported shells are bash, fish, zsh, powershell
```
