### PR TITLE
Remove `Author` type

### DIFF
--- a/app.go
+++ b/app.go
@@ -79,7 +79,7 @@ type App struct {
 	// Execute this function when an invalid flag is accessed from the context
 	InvalidFlagAccessHandler InvalidFlagAccessFunc
 	// List of all authors who contributed
-	Authors []*Author
+	Authors []string
 	// Copyright of the binary if any
 	Copyright string
 	// Reader reader to write input to (useful for tests)
@@ -432,22 +432,6 @@ func runFlagActions(c *Context, fs []Flag) error {
 		}
 	}
 	return nil
-}
-
-// Author represents someone who has contributed to a cli project.
-type Author struct {
-	Name  string // The Authors name
-	Email string // The Authors email
-}
-
-// String makes Author comply to the Stringer interface, to allow an easy print in the templating process
-func (a *Author) String() string {
-	e := ""
-	if a.Email != "" {
-		e = " <" + a.Email + ">"
-	}
-
-	return fmt.Sprintf("%v%v", a.Name, e)
 }
 
 func checkStringSliceIncludes(want string, sSlice []string) bool {

--- a/app_test.go
+++ b/app_test.go
@@ -45,7 +45,7 @@ func ExampleApp_Run() {
 			return nil
 		},
 		UsageText: "app [first_arg] [second_arg]",
-		Authors:   []*Author{{Name: "Oliver Allen", Email: "oliver@toyshop.example.com"}},
+		Authors:   []string{"Oliver Allen <oliver@toyshop.example.com>"},
 	}
 
 	app.Run(os.Args)
@@ -100,9 +100,9 @@ func ExampleApp_Run_appHelp() {
 		Name:        "greet",
 		Version:     "0.1.0",
 		Description: "This is how we describe greet the app",
-		Authors: []*Author{
-			{Name: "Harrison", Email: "harrison@lolwut.com"},
-			{Name: "Oliver Allen", Email: "oliver@toyshop.com"},
+		Authors: []string{
+			"Harrison <harrison@lolwut.com>",
+			"Oliver Allen <oliver@toyshop.com>",
 		},
 		Flags: []Flag{
 			&StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},

--- a/docs_test.go
+++ b/docs_test.go
@@ -49,7 +49,7 @@ func TestToMarkdownNoCommands(t *testing.T) {
 func TestToMarkdownNoAuthors(t *testing.T) {
 	// Given
 	app := testApp()
-	app.Authors = []*Author{}
+	app.Authors = []string{}
 
 	// When
 	res, err := app.ToMarkdown()

--- a/fish_test.go
+++ b/fish_test.go
@@ -127,9 +127,9 @@ Should be a part of the same code block
 	app.UsageText = "app [first_arg] [second_arg]"
 	app.Description = `Description of the application.`
 	app.Usage = "Some app"
-	app.Authors = []*Author{
-		{Name: "Harrison", Email: "harrison@lolwut.com"},
-		{Name: "Oliver Allen", Email: "oliver@toyshop.com"},
+	app.Authors = []string{
+		"Harrison <harrison@lolwut.com>",
+		"Oliver Allen <oliver@toyshop.com>",
 	}
 	return app
 }

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -294,7 +294,7 @@ type App struct {
 	// Execute this function when an invalid flag is accessed from the context
 	InvalidFlagAccessHandler InvalidFlagAccessFunc
 	// List of all authors who contributed
-	Authors []*Author
+	Authors []string
 	// Copyright of the binary if any
 	Copyright string
 	// Reader reader to write input to (useful for tests)
@@ -398,16 +398,6 @@ type Args interface {
 	// Slice returns a copy of the internal slice
 	Slice() []string
 }
-
-type Author struct {
-	Name  string // The Authors name
-	Email string // The Authors email
-}
-    Author represents someone who has contributed to a cli project.
-
-func (a *Author) String() string
-    String makes Author comply to the Stringer interface, to allow an easy print
-    in the templating process
 
 type BeforeFunc func(*Context) error
     BeforeFunc is an action to execute before any subcommands are run, but after

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -294,7 +294,7 @@ type App struct {
 	// Execute this function when an invalid flag is accessed from the context
 	InvalidFlagAccessHandler InvalidFlagAccessFunc
 	// List of all authors who contributed
-	Authors []*Author
+	Authors []string
 	// Copyright of the binary if any
 	Copyright string
 	// Reader reader to write input to (useful for tests)
@@ -398,16 +398,6 @@ type Args interface {
 	// Slice returns a copy of the internal slice
 	Slice() []string
 }
-
-type Author struct {
-	Name  string // The Authors name
-	Email string // The Authors email
-}
-    Author represents someone who has contributed to a cli project.
-
-func (a *Author) String() string
-    String makes Author comply to the Stringer interface, to allow an easy print
-    in the templating process
 
 type BeforeFunc func(*Context) error
     BeforeFunc is an action to execute before any subcommands are run, but after


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Removes the `Author` type and accepts `string`s for the `Authors` field instead, essentially leaving any formatting considerations to whomever is using the library.

## Which issue(s) this PR fixes:

Supports #1586 given that the `Author` type is part of the `app.go` file which is slated for collapse into `command.go` and this type is adding very little value &lt;/opinions&gt;