### PR TITLE
Move suggestion-related code to suggestions.go

### DIFF
--- a/app.go
+++ b/app.go
@@ -11,18 +11,8 @@ import (
 	"strings"
 )
 
-const suggestDidYouMeanTemplate = "Did you mean %q?"
-
-var (
-	changeLogURL            = "https://github.com/urfave/cli/blob/main/docs/CHANGELOG.md"
-	appActionDeprecationURL = fmt.Sprintf("%s#deprecated-cli-app-action-signature", changeLogURL)
-	contactSysadmin         = "This is an error in the application.  Please contact the distributor of this application if this is not you."
-	ignoreFlagPrefix        = "test." // this is to ignore test flags when adding flags from other packages
-
-	SuggestFlag               SuggestFlagFunc    = suggestFlag
-	SuggestCommand            SuggestCommandFunc = suggestCommand
-	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
-)
+// ignoreFlagPrefix is to ignore test flags when adding flags from other packages
+const ignoreFlagPrefix = "test."
 
 // App is the main structure of a cli application.
 type App struct {
@@ -120,10 +110,6 @@ type App struct {
 
 	rootCommand *Command
 }
-
-type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
-
-type SuggestCommandFunc func(commands []*Command, provided string) string
 
 // Setup runs initialization code to ensure all data structures are ready for
 // `Run` or inspection prior to `Run`.  It is internally called by `Run`, but

--- a/suggestions.go
+++ b/suggestions.go
@@ -6,6 +6,18 @@ import (
 	"github.com/xrash/smetrics"
 )
 
+const suggestDidYouMeanTemplate = "Did you mean %q?"
+
+var (
+	SuggestFlag               SuggestFlagFunc    = suggestFlag
+	SuggestCommand            SuggestCommandFunc = suggestCommand
+	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
+)
+
+type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
+
+type SuggestCommandFunc func(commands []*Command, provided string) string
+
 func jaroWinkler(a, b string) float64 {
 	// magic values are from https://github.com/xrash/smetrics/blob/039620a656736e6ad994090895784a7af15e0b80/jaro-winkler.go#L8
 	const (


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Moves the suggestion-related code from `app.go` to `suggestions.go` and also remove some unused vars.

## Which issue(s) this PR fixes:

Supports #1586