### PR TITLE
Allow `any` instead of custom `*Author` type

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net/mail"
 	"os"
 	"path/filepath"
 	"sort"
@@ -79,8 +78,8 @@ type App struct {
 	OnUsageError OnUsageErrorFunc
 	// Execute this function when an invalid flag is accessed from the context
 	InvalidFlagAccessHandler InvalidFlagAccessFunc
-	// List of all authors who contributed
-	Authors []*mail.Address
+	// List of all authors who contributed (string or fmt.Stringer)
+	Authors []any // TODO: ~string | fmt.Stringer when interface unions are available
 	// Copyright of the binary if any
 	Copyright string
 	// Reader reader to write input to (useful for tests)

--- a/app.go
+++ b/app.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/mail"
 	"os"
 	"path/filepath"
 	"sort"
@@ -79,7 +80,7 @@ type App struct {
 	// Execute this function when an invalid flag is accessed from the context
 	InvalidFlagAccessHandler InvalidFlagAccessFunc
 	// List of all authors who contributed
-	Authors []*Author
+	Authors []*mail.Address
 	// Copyright of the binary if any
 	Copyright string
 	// Reader reader to write input to (useful for tests)
@@ -432,22 +433,6 @@ func runFlagActions(c *Context, fs []Flag) error {
 		}
 	}
 	return nil
-}
-
-// Author represents someone who has contributed to a cli project.
-type Author struct {
-	Name  string // The Authors name
-	Email string // The Authors email
-}
-
-// String makes Author comply to the Stringer interface, to allow an easy print in the templating process
-func (a *Author) String() string {
-	e := ""
-	if a.Email != "" {
-		e = " <" + a.Email + ">"
-	}
-
-	return fmt.Sprintf("%v%v", a.Name, e)
 }
 
 func checkStringSliceIncludes(want string, sSlice []string) bool {

--- a/app_test.go
+++ b/app_test.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/mail"
 	"os"
 	"reflect"
 	"strconv"
@@ -45,7 +46,7 @@ func ExampleApp_Run() {
 			return nil
 		},
 		UsageText: "app [first_arg] [second_arg]",
-		Authors:   []*Author{{Name: "Oliver Allen", Email: "oliver@toyshop.example.com"}},
+		Authors:   []*mail.Address{{Name: "Oliver Allen", Address: "oliver@toyshop.example.com"}},
 	}
 
 	app.Run(os.Args)
@@ -100,9 +101,9 @@ func ExampleApp_Run_appHelp() {
 		Name:        "greet",
 		Version:     "0.1.0",
 		Description: "This is how we describe greet the app",
-		Authors: []*Author{
-			{Name: "Harrison", Email: "harrison@lolwut.com"},
-			{Name: "Oliver Allen", Email: "oliver@toyshop.com"},
+		Authors: []*mail.Address{
+			{Name: "Harrison", Address: "harrison@lolwut.com"},
+			{Name: "Oliver Allen", Address: "oliver@toyshop.com"},
 		},
 		Flags: []Flag{
 			&StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},
@@ -135,8 +136,8 @@ func ExampleApp_Run_appHelp() {
 	//    This is how we describe greet the app
 	//
 	// AUTHORS:
-	//    Harrison <harrison@lolwut.com>
-	//    Oliver Allen <oliver@toyshop.com>
+	//    "Harrison" <harrison@lolwut.com>
+	//    "Oliver Allen" <oliver@toyshop.com>
 	//
 	// COMMANDS:
 	//    describeit, d  use it to see a description

--- a/app_test.go
+++ b/app_test.go
@@ -46,7 +46,7 @@ func ExampleApp_Run() {
 			return nil
 		},
 		UsageText: "app [first_arg] [second_arg]",
-		Authors:   []*mail.Address{{Name: "Oliver Allen", Address: "oliver@toyshop.example.com"}},
+		Authors:   []any{&mail.Address{Name: "Oliver Allen", Address: "oliver@toyshop.example.com"}, "gruffalo@soup-world.example.org"},
 	}
 
 	app.Run(os.Args)
@@ -101,9 +101,9 @@ func ExampleApp_Run_appHelp() {
 		Name:        "greet",
 		Version:     "0.1.0",
 		Description: "This is how we describe greet the app",
-		Authors: []*mail.Address{
-			{Name: "Harrison", Address: "harrison@lolwut.com"},
-			{Name: "Oliver Allen", Address: "oliver@toyshop.com"},
+		Authors: []any{
+			&mail.Address{Name: "Harrison", Address: "harrison@lolwut.example.com"},
+			"Oliver Allen  <oliver@toyshop.example.com>",
 		},
 		Flags: []Flag{
 			&StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},
@@ -136,8 +136,8 @@ func ExampleApp_Run_appHelp() {
 	//    This is how we describe greet the app
 	//
 	// AUTHORS:
-	//    "Harrison" <harrison@lolwut.com>
-	//    "Oliver Allen" <oliver@toyshop.com>
+	//    "Harrison" <harrison@lolwut.example.com>
+	//    Oliver Allen  <oliver@toyshop.example.com>
 	//
 	// COMMANDS:
 	//    describeit, d  use it to see a description

--- a/docs_test.go
+++ b/docs_test.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"errors"
+	"net/mail"
 	"testing"
 )
 
@@ -49,7 +50,7 @@ func TestToMarkdownNoCommands(t *testing.T) {
 func TestToMarkdownNoAuthors(t *testing.T) {
 	// Given
 	app := testApp()
-	app.Authors = []*Author{}
+	app.Authors = []*mail.Address{}
 
 	// When
 	res, err := app.ToMarkdown()

--- a/docs_test.go
+++ b/docs_test.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"errors"
-	"net/mail"
 	"testing"
 )
 
@@ -50,7 +49,7 @@ func TestToMarkdownNoCommands(t *testing.T) {
 func TestToMarkdownNoAuthors(t *testing.T) {
 	// Given
 	app := testApp()
-	app.Authors = []*mail.Address{}
+	app.Authors = []any{}
 
 	// When
 	res, err := app.ToMarkdown()

--- a/fish_test.go
+++ b/fish_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"net/mail"
 	"os"
 	"testing"
 )
@@ -127,9 +128,9 @@ Should be a part of the same code block
 	app.UsageText = "app [first_arg] [second_arg]"
 	app.Description = `Description of the application.`
 	app.Usage = "Some app"
-	app.Authors = []*Author{
-		{Name: "Harrison", Email: "harrison@lolwut.com"},
-		{Name: "Oliver Allen", Email: "oliver@toyshop.com"},
+	app.Authors = []*mail.Address{
+		{Name: "Harrison", Address: "harrison@lolwut.com"},
+		{Name: "Oliver Allen", Address: "oliver@toyshop.com"},
 	}
 	return app
 }

--- a/fish_test.go
+++ b/fish_test.go
@@ -128,9 +128,9 @@ Should be a part of the same code block
 	app.UsageText = "app [first_arg] [second_arg]"
 	app.Description = `Description of the application.`
 	app.Usage = "Some app"
-	app.Authors = []*mail.Address{
-		{Name: "Harrison", Address: "harrison@lolwut.com"},
-		{Name: "Oliver Allen", Address: "oliver@toyshop.com"},
+	app.Authors = []any{
+		"Harrison <harrison@lolwut.example.com>",
+		&mail.Address{Name: "Oliver Allen", Address: "oliver@toyshop.com"},
 	}
 	return app
 }

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -293,8 +293,8 @@ type App struct {
 	OnUsageError OnUsageErrorFunc
 	// Execute this function when an invalid flag is accessed from the context
 	InvalidFlagAccessHandler InvalidFlagAccessFunc
-	// List of all authors who contributed
-	Authors []*mail.Address
+	// List of all authors who contributed (string or fmt.Stringer)
+	Authors []any // TODO: ~string | fmt.Stringer when interface unions are available
 	// Copyright of the binary if any
 	Copyright string
 	// Reader reader to write input to (useful for tests)

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -294,7 +294,7 @@ type App struct {
 	// Execute this function when an invalid flag is accessed from the context
 	InvalidFlagAccessHandler InvalidFlagAccessFunc
 	// List of all authors who contributed
-	Authors []*Author
+	Authors []*mail.Address
 	// Copyright of the binary if any
 	Copyright string
 	// Reader reader to write input to (useful for tests)
@@ -398,16 +398,6 @@ type Args interface {
 	// Slice returns a copy of the internal slice
 	Slice() []string
 }
-
-type Author struct {
-	Name  string // The Authors name
-	Email string // The Authors email
-}
-    Author represents someone who has contributed to a cli project.
-
-func (a *Author) String() string
-    String makes Author comply to the Stringer interface, to allow an easy print
-    in the templating process
 
 type BeforeFunc func(*Context) error
     BeforeFunc is an action to execute before any subcommands are run, but after

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -293,8 +293,8 @@ type App struct {
 	OnUsageError OnUsageErrorFunc
 	// Execute this function when an invalid flag is accessed from the context
 	InvalidFlagAccessHandler InvalidFlagAccessFunc
-	// List of all authors who contributed
-	Authors []*mail.Address
+	// List of all authors who contributed (string or fmt.Stringer)
+	Authors []any // TODO: ~string | fmt.Stringer when interface unions are available
 	// Copyright of the binary if any
 	Copyright string
 	// Reader reader to write input to (useful for tests)

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -294,7 +294,7 @@ type App struct {
 	// Execute this function when an invalid flag is accessed from the context
 	InvalidFlagAccessHandler InvalidFlagAccessFunc
 	// List of all authors who contributed
-	Authors []*Author
+	Authors []*mail.Address
 	// Copyright of the binary if any
 	Copyright string
 	// Reader reader to write input to (useful for tests)
@@ -398,16 +398,6 @@ type Args interface {
 	// Slice returns a copy of the internal slice
 	Slice() []string
 }
-
-type Author struct {
-	Name  string // The Authors name
-	Email string // The Authors email
-}
-    Author represents someone who has contributed to a cli project.
-
-func (a *Author) String() string
-    String makes Author comply to the Stringer interface, to allow an easy print
-    in the templating process
 
 type BeforeFunc func(*Context) error
     BeforeFunc is an action to execute before any subcommands are run, but after


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Drop the custom `*Author` type and allow `any` with the assumption that it either implements `fmt.Stringer` or can otherwise be safely `Sprintf`'d via `%s`.

## Which issue(s) this PR fixes:

Supports #1586 given the `*Author` type was defined in `app.go` which is slated for removal.