### PR TITLE
Fixes urfave/cli#1648

### DIFF
--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -44,7 +44,7 @@ func (s *StringSlice) Set(value string) error {
 	}
 
 	for _, t := range flagSplitMultiValues(value) {
-		s.slice = append(s.slice, strings.TrimSpace(t))
+		s.slice = append(s.slice, t)
 	}
 
 	return nil


### PR DESCRIPTION
Remove trim of whitespace in `StringSliceFlag` values, matching the behavior of `StringFlag`.

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

See #1648

## Which issue(s) this PR fixes:

Fixes #1648

## Special notes for your reviewer:

I'm uncertain if the trim behavior was intentional or not as there was no tests covering it.

## Testing

Added test that verifies that parsing the same value using`StringFlag` and `StringSliceFlag`  results in equal values.

## Release Notes

```release-note
`StringSliceFlag` no nonger trims space from values, matching the behavior of `StringFlag`.
```
