### PR TITLE
Target two most recent Go versions in v2

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.17.x, 1.18.x, 1.19.x]
+        go: [1.18.x, 1.19.x]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Target the two most recent Go versions to align with the Go team supported versions.

## Which issue(s) this PR fixes:

NA 😬 