### PR TITLE
add Integer type casting when loading yaml file

### DIFF
--- a/altsrc/flag.go
+++ b/altsrc/flag.go
@@ -109,6 +109,7 @@ func (f *StringSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSour
 				continue
 			}
 			underlyingFlag.Value = &sliceValue
+			f.set.Set(n, sliceValue.Serialize())
 		}
 		if f.Destination != nil {
 			f.Destination.Set(sliceValue.Serialize())

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -128,7 +128,7 @@ func (fsm *MapInputSource) Float64(name string) (float64, error) {
 	return 0, nil
 }
 
-func CastToInt64(v interface{}) (int64, bool) {
+func castToInt64(v interface{}) (int64, bool) {
 	int64Value := int64(0)
 	isType := false
 	if v == nil {
@@ -152,7 +152,7 @@ func CastToInt64(v interface{}) (int64, bool) {
 func (fsm *MapInputSource) Int64(name string) (int64, error) {
 	otherGenericValue, exists := fsm.valueMap[name]
 	if exists {
-		otherValue, isType := CastToInt64(otherGenericValue)
+		otherValue, isType := castToInt64(otherGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "int64", otherGenericValue)
 		}
@@ -160,7 +160,7 @@ func (fsm *MapInputSource) Int64(name string) (int64, error) {
 	}
 	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
 	if exists {
-		otherValue, isType := CastToInt64(otherGenericValue)
+		otherValue, isType := castToInt64(otherGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "int64", nestedGenericValue)
 		}
@@ -170,7 +170,7 @@ func (fsm *MapInputSource) Int64(name string) (int64, error) {
 	return 0, nil
 }
 
-func CastToUint(v interface{}) (uint, bool) {
+func castToUint(v interface{}) (uint, bool) {
 	uintValue := uint(0)
 	isType := false
 	if v == nil {
@@ -209,7 +209,7 @@ func CastToUint(v interface{}) (uint, bool) {
 func (fsm *MapInputSource) Uint(name string) (uint, error) {
 	otherGenericValue, exists := fsm.valueMap[name]
 	if exists {
-		otherValue, isType := CastToUint(otherGenericValue)
+		otherValue, isType := castToUint(otherGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint", otherGenericValue)
 		}
@@ -217,7 +217,7 @@ func (fsm *MapInputSource) Uint(name string) (uint, error) {
 	}
 	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
 	if exists {
-		otherValue, isType := CastToUint(nestedGenericValue)
+		otherValue, isType := castToUint(nestedGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint", nestedGenericValue)
 		}
@@ -227,7 +227,7 @@ func (fsm *MapInputSource) Uint(name string) (uint, error) {
 	return 0, nil
 }
 
-func CastToUint64(v interface{}) (uint64, bool) {
+func castToUint64(v interface{}) (uint64, bool) {
 	uint64Value := uint64(0)
 	isType := false
 	if v == nil {
@@ -263,7 +263,7 @@ func CastToUint64(v interface{}) (uint64, bool) {
 func (fsm *MapInputSource) Uint64(name string) (uint64, error) {
 	otherGenericValue, exists := fsm.valueMap[name]
 	if exists {
-		otherValue, isType := CastToUint64(otherGenericValue)
+		otherValue, isType := castToUint64(otherGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint64", otherGenericValue)
 		}
@@ -271,7 +271,7 @@ func (fsm *MapInputSource) Uint64(name string) (uint64, error) {
 	}
 	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
 	if exists {
-		otherValue, isType := CastToUint64(nestedGenericValue)
+		otherValue, isType := castToUint64(nestedGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint64", nestedGenericValue)
 		}
@@ -378,7 +378,7 @@ func (fsm *MapInputSource) Int64Slice(name string) ([]int64, error) {
 
 	var int64Slice = make([]int64, 0, len(otherValue))
 	for i, v := range otherValue {
-		int64Value, isType := CastToInt64(v)
+		int64Value, isType := castToInt64(v)
 		if !isType {
 			return nil, incorrectTypeForFlagError(fmt.Sprintf("%s[%d]", name, i), "int64", v)
 		}

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -200,6 +200,9 @@ func castToUint(v interface{}) (uint, bool) {
 			uintValue = uint(int64Value)
 			isType = true
 		}
+	case reflect.Uint:
+		uintValue = v.(uint)
+		isType = true
 	case reflect.Uint64:
 		uint64Value := v.(uint64)
 		if uint64Value <= math.MaxUint {

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -128,7 +128,7 @@ func (fsm *MapInputSource) Float64(name string) (float64, error) {
 	return 0, nil
 }
 
-func castToInt64(v interface{}) (int64, bool) {
+func CastToInt64(v interface{}) (int64, bool) {
 	int64Value := int64(0)
 	isType := false
 	if v == nil {
@@ -152,7 +152,7 @@ func castToInt64(v interface{}) (int64, bool) {
 func (fsm *MapInputSource) Int64(name string) (int64, error) {
 	otherGenericValue, exists := fsm.valueMap[name]
 	if exists {
-		otherValue, isType := castToInt64(otherGenericValue)
+		otherValue, isType := CastToInt64(otherGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "int64", otherGenericValue)
 		}
@@ -160,7 +160,7 @@ func (fsm *MapInputSource) Int64(name string) (int64, error) {
 	}
 	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
 	if exists {
-		otherValue, isType := castToInt64(otherGenericValue)
+		otherValue, isType := CastToInt64(otherGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "int64", nestedGenericValue)
 		}
@@ -170,7 +170,7 @@ func (fsm *MapInputSource) Int64(name string) (int64, error) {
 	return 0, nil
 }
 
-func castToUint(v interface{}) (uint, bool) {
+func CastToUint(v interface{}) (uint, bool) {
 	uintValue := uint(0)
 	isType := false
 	if v == nil {
@@ -209,7 +209,7 @@ func castToUint(v interface{}) (uint, bool) {
 func (fsm *MapInputSource) Uint(name string) (uint, error) {
 	otherGenericValue, exists := fsm.valueMap[name]
 	if exists {
-		otherValue, isType := castToUint(otherGenericValue)
+		otherValue, isType := CastToUint(otherGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint", otherGenericValue)
 		}
@@ -217,7 +217,7 @@ func (fsm *MapInputSource) Uint(name string) (uint, error) {
 	}
 	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
 	if exists {
-		otherValue, isType := castToUint(nestedGenericValue)
+		otherValue, isType := CastToUint(nestedGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint", nestedGenericValue)
 		}
@@ -227,7 +227,7 @@ func (fsm *MapInputSource) Uint(name string) (uint, error) {
 	return 0, nil
 }
 
-func castToUint64(v interface{}) (uint64, bool) {
+func CastToUint64(v interface{}) (uint64, bool) {
 	uint64Value := uint64(0)
 	isType := false
 	if v == nil {
@@ -263,7 +263,7 @@ func castToUint64(v interface{}) (uint64, bool) {
 func (fsm *MapInputSource) Uint64(name string) (uint64, error) {
 	otherGenericValue, exists := fsm.valueMap[name]
 	if exists {
-		otherValue, isType := castToUint64(otherGenericValue)
+		otherValue, isType := CastToUint64(otherGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint64", otherGenericValue)
 		}
@@ -271,7 +271,7 @@ func (fsm *MapInputSource) Uint64(name string) (uint64, error) {
 	}
 	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
 	if exists {
-		otherValue, isType := castToUint64(nestedGenericValue)
+		otherValue, isType := CastToUint64(nestedGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint64", nestedGenericValue)
 		}
@@ -378,7 +378,7 @@ func (fsm *MapInputSource) Int64Slice(name string) ([]int64, error) {
 
 	var int64Slice = make([]int64, 0, len(otherValue))
 	for i, v := range otherValue {
-		int64Value, isType := castToInt64(v)
+		int64Value, isType := CastToInt64(v)
 		if !isType {
 			return nil, incorrectTypeForFlagError(fmt.Sprintf("%s[%d]", name, i), "int64", v)
 		}

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -136,21 +136,14 @@ func castToInt64(v interface{}) (int64, bool) {
 	}
 
 	// There are only four cases(int, int64, uint64, float64) when parsing the integer in yaml.v3 pkg
-	// But the last case, float64, is an error case so that ignored
-	vType := reflect.TypeOf(v).Kind()
-	switch vType {
-	case reflect.Int:
-		int64Value = int64(v.(int))
+	// But the cases, uint64, float64, are an error case so that ignored
+	switch value := v.(type) {
+	case int:
+		int64Value = int64(value)
 		isType = true
-	case reflect.Int64:
-		int64Value = v.(int64)
+	case int64:
+		int64Value = int64(value)
 		isType = true
-	case reflect.Uint64:
-		uint64Value := v.(uint64)
-		if uint64Value <= math.MaxInt64 {
-			int64Value = int64(uint64Value)
-			isType = true
-		}
 	}
 	return int64Value, isType
 }
@@ -186,27 +179,26 @@ func castToUint(v interface{}) (uint, bool) {
 
 	// There are only four cases(int, int64, uint64, float64) when parsing the integer in yaml.v3 pkg
 	// But the last case, float64, is an error case so that ignored
-	vType := reflect.TypeOf(v).Kind()
-	switch vType {
-	case reflect.Int:
-		intValue := v.(int)
+	switch value := v.(type) {
+	case int:
+		intValue := int(value)
 		if intValue >= 0 {
-			uintValue = uint(intValue)
+			uintValue = uint(value)
 			isType = true
 		}
-	case reflect.Int64:
-		int64Value := v.(int64)
+	case int64:
+		int64Value := int64(value)
 		if int64Value >= 0 && uint64(int64Value) <= math.MaxUint {
-			uintValue = uint(int64Value)
+			uintValue = uint(value)
 			isType = true
 		}
-	case reflect.Uint:
-		uintValue = v.(uint)
+	case uint:
+		uintValue = uint(value)
 		isType = true
-	case reflect.Uint64:
-		uint64Value := v.(uint64)
+	case uint64:
+		uint64Value := uint64(value)
 		if uint64Value <= math.MaxUint {
-			uintValue = uint(uint64Value)
+			uintValue = uint(value)
 			isType = true
 		}
 	}
@@ -244,22 +236,24 @@ func castToUint64(v interface{}) (uint64, bool) {
 
 	// There are only four cases(int, int64, uint64, float64) when parsing the integer in yaml.v3 pkg
 	// But the last case, float64, is an error case so that ignored
-	vType := reflect.TypeOf(v).Kind()
-	switch vType {
-	case reflect.Int:
-		intValue := v.(int)
+	switch value := v.(type) {
+	case int:
+		intValue := int(value)
 		if intValue >= 0 {
 			uint64Value = uint64(intValue)
 			isType = true
 		}
-	case reflect.Int64:
-		int64Value := v.(int64)
+	case int64:
+		int64Value := int64(value)
 		if int64Value >= 0 {
 			uint64Value = uint64(int64Value)
 			isType = true
 		}
-	case reflect.Uint64:
-		uint64Value = v.(uint64)
+	case uint:
+		uint64Value = uint64(value)
+		isType = true
+	case uint64:
+		uint64Value = uint64(value)
 		isType = true
 	}
 	return uint64Value, isType

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -269,7 +269,7 @@ func castToUint64(v interface{}) (uint64, bool) {
 func (fsm *MapInputSource) Uint64(name string) (uint64, error) {
 	otherGenericValue, exists := fsm.valueMap[name]
 	if exists {
-		otherValue, isType := otherGenericValue.(uint64)
+		otherValue, isType := castToUint64(otherGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint64", otherGenericValue)
 		}
@@ -277,7 +277,7 @@ func (fsm *MapInputSource) Uint64(name string) (uint64, error) {
 	}
 	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
 	if exists {
-		otherValue, isType := nestedGenericValue.(uint64)
+		otherValue, isType := castToUint64(nestedGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "uint64", nestedGenericValue)
 		}

--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -131,6 +131,9 @@ func (fsm *MapInputSource) Float64(name string) (float64, error) {
 func castToInt64(v interface{}) (int64, bool) {
 	int64Value := int64(0)
 	isType := false
+	if v == nil {
+		return int64Value, true
+	}
 
 	// There are only four cases(int, int64, uint64, float64) when parsing the integer in yaml.v3 pkg
 	// But the last case, float64, is an error case so that ignored
@@ -177,6 +180,9 @@ func (fsm *MapInputSource) Int64(name string) (int64, error) {
 func castToUint(v interface{}) (uint, bool) {
 	uintValue := uint(0)
 	isType := false
+	if v == nil {
+		return uintValue, true
+	}
 
 	// There are only four cases(int, int64, uint64, float64) when parsing the integer in yaml.v3 pkg
 	// But the last case, float64, is an error case so that ignored
@@ -229,6 +235,9 @@ func (fsm *MapInputSource) Uint(name string) (uint, error) {
 func castToUint64(v interface{}) (uint64, bool) {
 	uint64Value := uint64(0)
 	isType := false
+	if v == nil {
+		return uint64Value, true
+	}
 
 	// There are only four cases(int, int64, uint64, float64) when parsing the integer in yaml.v3 pkg
 	// But the last case, float64, is an error case so that ignored

--- a/altsrc/yaml_file_loader_test.go
+++ b/altsrc/yaml_file_loader_test.go
@@ -117,26 +117,43 @@ func TestYamlFileStringSlice(t *testing.T) {
 
 func TestYamlFileUint64(t *testing.T) {
 	tests := []struct {
+		name  string
 		entry string
 		err   bool
 	}{
 		{
+			"top.test",
+			`top: 
+  test: 100`,
+			false,
+		},
+		{
+			"test",
+			"test: ",
+			false,
+		},
+		{
+			"test",
 			"test: 100", //int
 			false,
 		},
 		{
+			"test",
 			"test: -100", //int
 			true,
 		},
 		{
+			"test",
 			"test: 9223372036854775807", //int
 			false,
 		},
 		{
+			"test",
 			"test: 9223372036854775808", //uintt64
 			false,
 		},
 		{
+			"test",
 			"test: 19223372036854775808", //float64
 			true,
 		},
@@ -148,7 +165,7 @@ func TestYamlFileUint64(t *testing.T) {
 
 		testFlag := []cli.Flag{
 			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-			&altsrc.Uint64Flag{Uint64Flag: &cli.Uint64Flag{Name: "test"}},
+			&altsrc.Uint64Flag{Uint64Flag: &cli.Uint64Flag{Name: test.name}},
 		}
 		app := &cli.App{}
 		app.Flags = append(app.Flags, testFlag...)
@@ -164,26 +181,43 @@ func TestYamlFileUint64(t *testing.T) {
 
 func TestYamlFileUint(t *testing.T) {
 	tests := []struct {
+		name  string
 		entry string
 		err   bool
 	}{
 		{
+			"top.test",
+			`top: 
+  test: 100`,
+			false,
+		},
+		{
+			"test",
+			"test: ",
+			false,
+		},
+		{
+			"test",
 			"test: 100", //int
 			false,
 		},
 		{
+			"test",
 			"test: -100", //int
 			true,
 		},
 		{
+			"test",
 			"test: 9223372036854775807", //int
 			false,
 		},
 		{
+			"test",
 			"test: 9223372036854775808", //uintt64
 			false,
 		},
 		{
+			"test",
 			"test: 19223372036854775808", //float64
 			true,
 		},
@@ -195,7 +229,7 @@ func TestYamlFileUint(t *testing.T) {
 
 		testFlag := []cli.Flag{
 			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-			&altsrc.UintFlag{UintFlag: &cli.UintFlag{Name: "test"}},
+			&altsrc.UintFlag{UintFlag: &cli.UintFlag{Name: test.name}},
 		}
 		app := &cli.App{}
 		app.Flags = append(app.Flags, testFlag...)
@@ -211,26 +245,43 @@ func TestYamlFileUint(t *testing.T) {
 
 func TestYamlFileInt64(t *testing.T) {
 	tests := []struct {
+		name  string
 		entry string
 		err   bool
 	}{
 		{
+			"top.test",
+			`top: 
+  test: 100`,
+			false,
+		},
+		{
+			"test",
+			"test: ",
+			false,
+		},
+		{
+			"test",
 			"test: 100", //int
 			false,
 		},
 		{
+			"test",
 			"test: -100", //int
-			false,
+			true,
 		},
 		{
+			"test",
 			"test: 9223372036854775807", //int
 			false,
 		},
 		{
+			"test",
 			"test: 9223372036854775808", //uintt64
-			true,
+			false,
 		},
 		{
+			"test",
 			"test: 19223372036854775808", //float64
 			true,
 		},
@@ -242,7 +293,7 @@ func TestYamlFileInt64(t *testing.T) {
 
 		testFlag := []cli.Flag{
 			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-			&altsrc.Int64Flag{Int64Flag: &cli.Int64Flag{Name: "test"}},
+			&altsrc.Int64Flag{Int64Flag: &cli.Int64Flag{Name: test.name}},
 		}
 		app := &cli.App{}
 		app.Flags = append(app.Flags, testFlag...)

--- a/altsrc/yaml_file_loader_test.go
+++ b/altsrc/yaml_file_loader_test.go
@@ -91,12 +91,13 @@ func ExampleApp_Run_yamlFileLoaderDuration() {
 }
 
 func TestYamlFileInt64Slice(t *testing.T) {
-	_ = ioutil.WriteFile("current.yaml", []byte(`top: [100, 9223372036854775808]`), 0666)
+	_ = ioutil.WriteFile("current.yaml", []byte(`top: 
+  test: [100, 9223372036854775808]`), 0666)
 	defer os.Remove("current.yaml")
 
 	testFlag := []cli.Flag{
 		&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-		&altsrc.Int64SliceFlag{Int64SliceFlag: &cli.Int64SliceFlag{Name: "top", EnvVars: []string{"THE_TEST"}}},
+		&altsrc.Int64SliceFlag{Int64SliceFlag: &cli.Int64SliceFlag{Name: "top.test"}},
 	}
 	app := &cli.App{}
 	app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
@@ -105,7 +106,7 @@ func TestYamlFileInt64Slice(t *testing.T) {
 
 	test := []string{"testApp", "--conf", "current.yaml"}
 	if err := app.Run(test); err == nil {
-		t.Error("Should return the mismatch type error")
+		t.Error("should return the mismatch type error")
 	}
 }
 

--- a/altsrc/yaml_file_loader_test.go
+++ b/altsrc/yaml_file_loader_test.go
@@ -268,7 +268,7 @@ func TestYamlFileInt64(t *testing.T) {
 		{
 			"test",
 			"test: -100", //int
-			true,
+			false,
 		},
 		{
 			"test",
@@ -278,7 +278,7 @@ func TestYamlFileInt64(t *testing.T) {
 		{
 			"test",
 			"test: 9223372036854775808", //uintt64
-			false,
+			true,
 		},
 		{
 			"test",

--- a/altsrc/yaml_file_loader_test.go
+++ b/altsrc/yaml_file_loader_test.go
@@ -106,7 +106,7 @@ func TestYamlFileInt64Slice(t *testing.T) {
 
 	test := []string{"testApp", "--conf", "current.yaml"}
 	if err := app.Run(test); err == nil {
-		t.Error("should return the mismatch type error")
+		t.Error("should return the mismatch error")
 	}
 }
 

--- a/altsrc/yaml_file_loader_test.go
+++ b/altsrc/yaml_file_loader_test.go
@@ -1,4 +1,4 @@
-package altsrc
+package altsrc_test
 
 import (
 	"errors"
@@ -6,12 +6,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/urfave/cli/v2"
-	// "github.com/urfave/cli/v2/altsrc"
+	"github.com/urfave/cli/v2/altsrc"
 )
 
 func ExampleApp_Run_yamlFileLoaderDuration() {
@@ -36,11 +35,11 @@ func ExampleApp_Run_yamlFileLoaderDuration() {
 			} else if !context.IsSet(configFlag) && !fileExists(configFile) {
 				return nil
 			}
-			inputSource, err := NewYamlSourceFromFile(configFile)
+			inputSource, err := altsrc.NewYamlSourceFromFile(configFile)
 			if err != nil {
 				return err
 			}
-			return ApplyInputSourceValues(context, inputSource, flags)
+			return altsrc.ApplyInputSourceValues(context, inputSource, flags)
 		}
 	}
 
@@ -53,7 +52,7 @@ func ExampleApp_Run_yamlFileLoaderDuration() {
 			DefaultText: "../testdata/empty.yml",
 			Usage:       "config file",
 		},
-		NewDurationFlag(
+		altsrc.NewDurationFlag(
 			&cli.DurationFlag{
 				Name:    "keepalive-interval",
 				Aliases: []string{"k"},
@@ -96,11 +95,11 @@ func TestYamlFileInt64Slice(t *testing.T) {
 	defer os.Remove("current.yaml")
 
 	testFlag := []cli.Flag{
-		&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-		&Int64SliceFlag{Int64SliceFlag: &cli.Int64SliceFlag{Name: "top.test"}},
+		&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+		&altsrc.Int64SliceFlag{Int64SliceFlag: &cli.Int64SliceFlag{Name: "top.test"}},
 	}
 	app := &cli.App{}
-	app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
+	app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
 	app.Action = func(c *cli.Context) error { return nil }
 	app.Flags = append(app.Flags, testFlag...)
 
@@ -116,11 +115,11 @@ func TestYamlFileStringSlice(t *testing.T) {
 	defer os.Remove("current.yaml")
 
 	testFlag := []cli.Flag{
-		&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-		&StringSliceFlag{StringSliceFlag: &cli.StringSliceFlag{Name: "top.test", EnvVars: []string{"THE_TEST"}}},
+		&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+		&altsrc.StringSliceFlag{StringSliceFlag: &cli.StringSliceFlag{Name: "top.test", EnvVars: []string{"THE_TEST"}}},
 	}
 	app := &cli.App{}
-	app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
+	app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
 	app.Action = func(c *cli.Context) error {
 		if c.IsSet("top.test") {
 			return nil
@@ -185,12 +184,12 @@ func TestYamlFileUint64(t *testing.T) {
 		defer os.Remove("current.yaml")
 
 		testFlag := []cli.Flag{
-			&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-			&Uint64Flag{Uint64Flag: &cli.Uint64Flag{Name: test.name}},
+			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+			&altsrc.Uint64Flag{Uint64Flag: &cli.Uint64Flag{Name: test.name}},
 		}
 		app := &cli.App{}
 		app.Flags = append(app.Flags, testFlag...)
-		app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
+		app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
 
 		appCmd := []string{"testApp", "--conf", "current.yaml"}
 		err := app.Run(appCmd)
@@ -249,12 +248,12 @@ func TestYamlFileUint(t *testing.T) {
 		defer os.Remove("current.yaml")
 
 		testFlag := []cli.Flag{
-			&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-			&UintFlag{UintFlag: &cli.UintFlag{Name: test.name}},
+			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+			&altsrc.UintFlag{UintFlag: &cli.UintFlag{Name: test.name}},
 		}
 		app := &cli.App{}
 		app.Flags = append(app.Flags, testFlag...)
-		app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
+		app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
 
 		appCmd := []string{"testApp", "--conf", "current.yaml"}
 		err := app.Run(appCmd)
@@ -313,50 +312,17 @@ func TestYamlFileInt64(t *testing.T) {
 		defer os.Remove("current.yaml")
 
 		testFlag := []cli.Flag{
-			&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-			&Int64Flag{Int64Flag: &cli.Int64Flag{Name: test.name}},
+			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+			&altsrc.Int64Flag{Int64Flag: &cli.Int64Flag{Name: test.name}},
 		}
 		app := &cli.App{}
 		app.Flags = append(app.Flags, testFlag...)
-		app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
+		app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
 
 		appCmd := []string{"testApp", "--conf", "current.yaml"}
 		err := app.Run(appCmd)
 		if result := err != nil; result != test.err {
 			t.Error(i, "testcast: expect error but", err)
-		}
-	}
-}
-
-func TestCastToUint64(t *testing.T) {
-	tests := []struct {
-		value  interface{}
-		expect bool
-	}{
-		{int64(100), true},
-		{uint(100), true},
-	}
-
-	for _, test := range tests {
-		v, isType := castToUint64(test.value)
-		if isType != test.expect && reflect.TypeOf(v).Kind() != reflect.Uint64 {
-			t.Fatalf("expect %v, but %v", test.expect, isType)
-		}
-	}
-}
-
-func TestCastToUint(t *testing.T) {
-	tests := []struct {
-		value  interface{}
-		expect bool
-	}{
-		{int64(100), true},
-	}
-
-	for _, test := range tests {
-		v, isType := castToUint(test.value)
-		if isType != test.expect && reflect.TypeOf(v).Kind() != reflect.Uint64 {
-			t.Fatalf("expect %v, but %v", test.expect, isType)
 		}
 	}
 }

--- a/altsrc/yaml_file_loader_test.go
+++ b/altsrc/yaml_file_loader_test.go
@@ -1,4 +1,4 @@
-package altsrc_test
+package altsrc
 
 import (
 	"errors"
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/urfave/cli/v2"
-	"github.com/urfave/cli/v2/altsrc"
+	// "github.com/urfave/cli/v2/altsrc"
 )
 
 func ExampleApp_Run_yamlFileLoaderDuration() {
@@ -26,7 +26,7 @@ func ExampleApp_Run_yamlFileLoaderDuration() {
 		return stat != nil
 	}
 
-	// initConfigFileInputSource is like altsrc.InitInputSourceWithContext and altsrc.NewYamlSourceFromFlagFunc, but checks
+	// initConfigFileInputSource is like InitInputSourceWithContext and NewYamlSourceFromFlagFunc, but checks
 	// if the config flag is exists and only loads it if it does. If the flag is set and the file exists, it fails.
 	initConfigFileInputSource := func(configFlag string, flags []cli.Flag) cli.BeforeFunc {
 		return func(context *cli.Context) error {
@@ -36,11 +36,11 @@ func ExampleApp_Run_yamlFileLoaderDuration() {
 			} else if !context.IsSet(configFlag) && !fileExists(configFile) {
 				return nil
 			}
-			inputSource, err := altsrc.NewYamlSourceFromFile(configFile)
+			inputSource, err := NewYamlSourceFromFile(configFile)
 			if err != nil {
 				return err
 			}
-			return altsrc.ApplyInputSourceValues(context, inputSource, flags)
+			return ApplyInputSourceValues(context, inputSource, flags)
 		}
 	}
 
@@ -53,7 +53,7 @@ func ExampleApp_Run_yamlFileLoaderDuration() {
 			DefaultText: "../testdata/empty.yml",
 			Usage:       "config file",
 		},
-		altsrc.NewDurationFlag(
+		NewDurationFlag(
 			&cli.DurationFlag{
 				Name:    "keepalive-interval",
 				Aliases: []string{"k"},
@@ -96,11 +96,11 @@ func TestYamlFileInt64Slice(t *testing.T) {
 	defer os.Remove("current.yaml")
 
 	testFlag := []cli.Flag{
-		&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-		&altsrc.Int64SliceFlag{Int64SliceFlag: &cli.Int64SliceFlag{Name: "top.test"}},
+		&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+		&Int64SliceFlag{Int64SliceFlag: &cli.Int64SliceFlag{Name: "top.test"}},
 	}
 	app := &cli.App{}
-	app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
+	app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
 	app.Action = func(c *cli.Context) error { return nil }
 	app.Flags = append(app.Flags, testFlag...)
 
@@ -116,11 +116,11 @@ func TestYamlFileStringSlice(t *testing.T) {
 	defer os.Remove("current.yaml")
 
 	testFlag := []cli.Flag{
-		&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-		&altsrc.StringSliceFlag{StringSliceFlag: &cli.StringSliceFlag{Name: "top.test", EnvVars: []string{"THE_TEST"}}},
+		&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+		&StringSliceFlag{StringSliceFlag: &cli.StringSliceFlag{Name: "top.test", EnvVars: []string{"THE_TEST"}}},
 	}
 	app := &cli.App{}
-	app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
+	app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
 	app.Action = func(c *cli.Context) error {
 		if c.IsSet("top.test") {
 			return nil
@@ -185,12 +185,12 @@ func TestYamlFileUint64(t *testing.T) {
 		defer os.Remove("current.yaml")
 
 		testFlag := []cli.Flag{
-			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-			&altsrc.Uint64Flag{Uint64Flag: &cli.Uint64Flag{Name: test.name}},
+			&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+			&Uint64Flag{Uint64Flag: &cli.Uint64Flag{Name: test.name}},
 		}
 		app := &cli.App{}
 		app.Flags = append(app.Flags, testFlag...)
-		app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
+		app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
 
 		appCmd := []string{"testApp", "--conf", "current.yaml"}
 		err := app.Run(appCmd)
@@ -249,12 +249,12 @@ func TestYamlFileUint(t *testing.T) {
 		defer os.Remove("current.yaml")
 
 		testFlag := []cli.Flag{
-			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-			&altsrc.UintFlag{UintFlag: &cli.UintFlag{Name: test.name}},
+			&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+			&UintFlag{UintFlag: &cli.UintFlag{Name: test.name}},
 		}
 		app := &cli.App{}
 		app.Flags = append(app.Flags, testFlag...)
-		app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
+		app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
 
 		appCmd := []string{"testApp", "--conf", "current.yaml"}
 		err := app.Run(appCmd)
@@ -313,12 +313,12 @@ func TestYamlFileInt64(t *testing.T) {
 		defer os.Remove("current.yaml")
 
 		testFlag := []cli.Flag{
-			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
-			&altsrc.Int64Flag{Int64Flag: &cli.Int64Flag{Name: test.name}},
+			&StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+			&Int64Flag{Int64Flag: &cli.Int64Flag{Name: test.name}},
 		}
 		app := &cli.App{}
 		app.Flags = append(app.Flags, testFlag...)
-		app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
+		app.Before = InitInputSourceWithContext(testFlag, NewYamlSourceFromFlagFunc("conf"))
 
 		appCmd := []string{"testApp", "--conf", "current.yaml"}
 		err := app.Run(appCmd)
@@ -338,7 +338,7 @@ func TestCastToUint64(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, isType := altsrc.CastToUint64(test.value)
+		v, isType := castToUint64(test.value)
 		if isType != test.expect && reflect.TypeOf(v).Kind() != reflect.Uint64 {
 			t.Fatalf("expect %v, but %v", test.expect, isType)
 		}
@@ -354,7 +354,7 @@ func TestCastToUint(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, isType := altsrc.CastToUint(test.value)
+		v, isType := castToUint(test.value)
 		if isType != test.expect && reflect.TypeOf(v).Kind() != reflect.Uint64 {
 			t.Fatalf("expect %v, but %v", test.expect, isType)
 		}

--- a/altsrc/yaml_file_loader_test.go
+++ b/altsrc/yaml_file_loader_test.go
@@ -1,9 +1,12 @@
 package altsrc_test
 
 import (
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -84,4 +87,171 @@ func ExampleApp_Run_yamlFileLoaderDuration() {
 
 	// Output:
 	// keepalive 45s
+}
+
+func TestYamlFileStringSlice(t *testing.T) {
+	_ = ioutil.WriteFile("current.yaml", []byte(`top:
+  test: ["s1", "s2"]`), 0666)
+	defer os.Remove("current.yaml")
+
+	testFlag := []cli.Flag{
+		&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+		&altsrc.StringSliceFlag{StringSliceFlag: &cli.StringSliceFlag{Name: "top.test", EnvVars: []string{"THE_TEST"}}},
+	}
+	app := &cli.App{}
+	app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
+	app.Action = func(c *cli.Context) error {
+		if c.IsSet("top.test") {
+			return nil
+		} else {
+			return errors.New("top.test is not set")
+		}
+	}
+	app.Flags = append(app.Flags, testFlag...)
+
+	test := []string{"testApp", "--conf", "current.yaml"}
+	if err := app.Run(test); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestYamlFileUint64(t *testing.T) {
+	tests := []struct {
+		entry string
+		err   bool
+	}{
+		{
+			"test: 100", //int
+			false,
+		},
+		{
+			"test: -100", //int
+			true,
+		},
+		{
+			"test: 9223372036854775807", //int
+			false,
+		},
+		{
+			"test: 9223372036854775808", //uintt64
+			false,
+		},
+		{
+			"test: 19223372036854775808", //float64
+			true,
+		},
+	}
+
+	for i, test := range tests {
+		_ = ioutil.WriteFile("current.yaml", []byte(test.entry), 0666)
+		defer os.Remove("current.yaml")
+
+		testFlag := []cli.Flag{
+			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+			&altsrc.Uint64Flag{Uint64Flag: &cli.Uint64Flag{Name: "test"}},
+		}
+		app := &cli.App{}
+		app.Flags = append(app.Flags, testFlag...)
+		app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
+
+		appCmd := []string{"testApp", "--conf", "current.yaml"}
+		err := app.Run(appCmd)
+		if result := err != nil; result != test.err {
+			t.Error(i, "testcast: expect error but", err)
+		}
+	}
+}
+
+func TestYamlFileUint(t *testing.T) {
+	tests := []struct {
+		entry string
+		err   bool
+	}{
+		{
+			"test: 100", //int
+			false,
+		},
+		{
+			"test: -100", //int
+			true,
+		},
+		{
+			"test: 9223372036854775807", //int
+			false,
+		},
+		{
+			"test: 9223372036854775808", //uintt64
+			false,
+		},
+		{
+			"test: 19223372036854775808", //float64
+			true,
+		},
+	}
+
+	for i, test := range tests {
+		_ = ioutil.WriteFile("current.yaml", []byte(test.entry), 0666)
+		defer os.Remove("current.yaml")
+
+		testFlag := []cli.Flag{
+			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+			&altsrc.UintFlag{UintFlag: &cli.UintFlag{Name: "test"}},
+		}
+		app := &cli.App{}
+		app.Flags = append(app.Flags, testFlag...)
+		app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
+
+		appCmd := []string{"testApp", "--conf", "current.yaml"}
+		err := app.Run(appCmd)
+		if result := err != nil; result != test.err {
+			t.Error(i, "testcast: expect error but", err)
+		}
+	}
+}
+
+func TestYamlFileInt64(t *testing.T) {
+	tests := []struct {
+		entry string
+		err   bool
+	}{
+		{
+			"test: 100", //int
+			false,
+		},
+		{
+			"test: -100", //int
+			false,
+		},
+		{
+			"test: 9223372036854775807", //int
+			false,
+		},
+		{
+			"test: 9223372036854775808", //uintt64
+			true,
+		},
+		{
+			"test: 19223372036854775808", //float64
+			true,
+		},
+	}
+
+	for i, test := range tests {
+		_ = ioutil.WriteFile("current.yaml", []byte(test.entry), 0666)
+		defer os.Remove("current.yaml")
+
+		testFlag := []cli.Flag{
+			&altsrc.StringFlag{StringFlag: &cli.StringFlag{Name: "conf"}},
+			&altsrc.Int64Flag{Int64Flag: &cli.Int64Flag{Name: "test"}},
+		}
+		app := &cli.App{}
+		app.Flags = append(app.Flags, testFlag...)
+		app.Before = altsrc.InitInputSourceWithContext(testFlag, altsrc.NewYamlSourceFromFlagFunc("conf"))
+
+		appCmd := []string{"testApp", "--conf", "current.yaml"}
+		err := app.Run(appCmd)
+		if result := err != nil; result != test.err {
+			t.Error(i, "testcast: expect error but", err)
+		}
+	}
 }


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

- Latest v2 release (2.24.1) resolved this https://github.com/urfave/cli/issues/1592
- But also we cannot load the Uint64 flag because the casting error
- The integer from yaml file is unmarshaled to the int about lower than `9223372036854775807` regardless of the flag type
- This PR can accept even the integer that can be casted to the flag type
- IsSet()
  - The IsSet() returns `true` after loaded from yaml about all the flags except the slice flags
  - This PR can return `true` about slice flag type also

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

_(REQUIRED)_

- #1592 

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note

```
