### PR TITLE
flag: remove dependencies on shared variables

### DIFF
--- a/app.go
+++ b/app.go
@@ -121,7 +121,8 @@ type App struct {
 	// Treat all flags as normal arguments if true
 	SkipFlagParsing bool
 
-	didSetup bool
+	didSetup  bool
+	separator separatorSpec
 
 	rootCommand *Command
 }
@@ -216,6 +217,16 @@ func (a *App) Setup() {
 		})
 	}
 
+	if len(a.SliceFlagSeparator) != 0 {
+		a.separator.customized = true
+		a.separator.sep = a.SliceFlagSeparator
+	}
+
+	if a.DisableSliceFlagSeparator {
+		a.separator.customized = true
+		a.separator.disabled = true
+	}
+
 	var newCommands []*Command
 
 	for _, c := range a.Commands {
@@ -223,8 +234,8 @@ func (a *App) Setup() {
 		if c.HelpName != "" {
 			cname = c.HelpName
 		}
+		c.separator = a.separator
 		c.HelpName = fmt.Sprintf("%s %s", a.HelpName, cname)
-
 		c.flagCategories = newFlagCategoriesFromFlags(c.Flags)
 		newCommands = append(newCommands, c)
 	}
@@ -262,12 +273,6 @@ func (a *App) Setup() {
 	if a.Metadata == nil {
 		a.Metadata = make(map[string]interface{})
 	}
-
-	if len(a.SliceFlagSeparator) != 0 {
-		defaultSliceFlagSeparator = a.SliceFlagSeparator
-	}
-
-	disableSliceFlagSeparator = a.DisableSliceFlagSeparator
 }
 
 func (a *App) newRootCommand() *Command {
@@ -293,11 +298,12 @@ func (a *App) newRootCommand() *Command {
 		categories:             a.categories,
 		SkipFlagParsing:        a.SkipFlagParsing,
 		isRoot:                 true,
+		separator:              a.separator,
 	}
 }
 
 func (a *App) newFlagSet() (*flag.FlagSet, error) {
-	return flagSet(a.Name, a.Flags)
+	return flagSet(a.Name, a.Flags, a.separator)
 }
 
 func (a *App) useShortOptionHandling() bool {

--- a/app_test.go
+++ b/app_test.go
@@ -2532,7 +2532,7 @@ func TestCustomHelpVersionFlags(t *testing.T) {
 
 func TestHandleExitCoder_Default(t *testing.T) {
 	app := newTestApp()
-	fs, err := flagSet(app.Name, app.Flags)
+	fs, err := flagSet(app.Name, app.Flags, separatorSpec{})
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
 	}
@@ -2548,7 +2548,7 @@ func TestHandleExitCoder_Default(t *testing.T) {
 
 func TestHandleExitCoder_Custom(t *testing.T) {
 	app := newTestApp()
-	fs, err := flagSet(app.Name, app.Flags)
+	fs, err := flagSet(app.Name, app.Flags, separatorSpec{})
 	if err != nil {
 		t.Errorf("error creating FlagSet: %s", err)
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -425,10 +425,10 @@ func ExampleApp_Run_sliceValues() {
 
 	_ = app.Run(os.Args)
 	// Output:
-	// 0-float64Sclice cli.Float64Slice{slice:[]float64{13.3, 14.4, 15.5, 16.6}, hasBeenSet:true}
-	// 1-int64Sclice cli.Int64Slice{slice:[]int64{13, 14, 15, 16}, hasBeenSet:true}
-	// 2-intSclice cli.IntSlice{slice:[]int{13, 14, 15, 16}, hasBeenSet:true}
-	// 3-stringSclice cli.StringSlice{slice:[]string{"parsed1", "parsed2", "parsed3", "parsed4"}, hasBeenSet:true}
+	// 0-float64Sclice cli.Float64Slice{slice:[]float64{13.3, 14.4, 15.5, 16.6}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
+	// 1-int64Sclice cli.Int64Slice{slice:[]int64{13, 14, 15, 16}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
+	// 2-intSclice cli.IntSlice{slice:[]int{13, 14, 15, 16}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
+	// 3-stringSclice cli.StringSlice{slice:[]string{"parsed1", "parsed2", "parsed3", "parsed4"}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
 	// error: <nil>
 }
 

--- a/command.go
+++ b/command.go
@@ -69,6 +69,8 @@ type Command struct {
 
 	// if this is a root "special" command
 	isRoot bool
+
+	separator separatorSpec
 }
 
 type Commands []*Command
@@ -275,7 +277,7 @@ func (c *Command) Run(cCtx *Context, arguments ...string) (err error) {
 }
 
 func (c *Command) newFlagSet() (*flag.FlagSet, error) {
-	return flagSet(c.Name, c.Flags)
+	return flagSet(c.Name, c.Flags, c.separator)
 }
 
 func (c *Command) useShortOptionHandling() bool {

--- a/flag-spec.yaml
+++ b/flag-spec.yaml
@@ -20,6 +20,8 @@ flag_types:
     skip_interfaces:
       - fmt.Stringer
     struct_fields:
+      - name: separator
+        type: separatorSpec
       - name: Action
         type: "func(*Context, []float64) error"
   int:
@@ -33,6 +35,8 @@ flag_types:
     skip_interfaces:
       - fmt.Stringer
     struct_fields:
+      - name: separator
+        type: separatorSpec
       - name: Action
         type: "func(*Context, []int) error"
   int64:
@@ -46,6 +50,8 @@ flag_types:
     skip_interfaces:
       - fmt.Stringer
     struct_fields:
+      - name: separator
+        type: separatorSpec
       - name: Action
         type: "func(*Context, []int64) error"
   uint:
@@ -59,6 +65,8 @@ flag_types:
     skip_interfaces:
       - fmt.Stringer
     struct_fields:
+      - name: separator
+        type: separatorSpec
       - name: Action
         type: "func(*Context, []uint) error"
   uint64:
@@ -72,6 +80,8 @@ flag_types:
     skip_interfaces:
       - fmt.Stringer
     struct_fields:
+      - name: separator
+        type: separatorSpec
       - name: Action
         type: "func(*Context, []uint64) error"
   string:
@@ -85,6 +95,8 @@ flag_types:
     skip_interfaces:
       - fmt.Stringer
     struct_fields:
+      - name: separator
+        type: separatorSpec
       - name: TakesFile
         type: bool
       - name: Action

--- a/flag_test.go
+++ b/flag_test.go
@@ -3425,13 +3425,27 @@ func TestSliceShortOptionHandle(t *testing.T) {
 }
 
 // Test issue #1541
+func TestDefaultSliceFlagSeparator(t *testing.T) {
+	separator := separatorSpec{}
+	opts := []string{"opt1", "opt2", "opt3", "opt4"}
+	ret := separator.flagSplitMultiValues(strings.Join(opts, ","))
+	if len(ret) != 4 {
+		t.Fatalf("split slice flag failed, want: 4, but get: %d", len(ret))
+	}
+	for idx, r := range ret {
+		if r != opts[idx] {
+			t.Fatalf("get %dth failed, wanted: %s, but get: %s", idx, opts[idx], r)
+		}
+	}
+}
+
 func TestCustomizedSliceFlagSeparator(t *testing.T) {
-	defaultSliceFlagSeparator = ";"
-	defer func() {
-		defaultSliceFlagSeparator = ","
-	}()
+	separator := separatorSpec{
+		customized: true,
+		sep:        ";",
+	}
 	opts := []string{"opt1", "opt2", "opt3,op", "opt4"}
-	ret := flagSplitMultiValues(strings.Join(opts, ";"))
+	ret := separator.flagSplitMultiValues(strings.Join(opts, ";"))
 	if len(ret) != 4 {
 		t.Fatalf("split slice flag failed, want: 4, but get: %d", len(ret))
 	}
@@ -3443,13 +3457,13 @@ func TestCustomizedSliceFlagSeparator(t *testing.T) {
 }
 
 func TestFlagSplitMultiValues_Disabled(t *testing.T) {
-	disableSliceFlagSeparator = true
-	defer func() {
-		disableSliceFlagSeparator = false
-	}()
+	separator := separatorSpec{
+		customized: true,
+		disabled:   true,
+	}
 
 	opts := []string{"opt1", "opt2", "opt3,op", "opt4"}
-	ret := flagSplitMultiValues(strings.Join(opts, defaultSliceFlagSeparator))
+	ret := separator.flagSplitMultiValues(strings.Join(opts, defaultSliceFlagSeparator))
 	if len(ret) != 1 {
 		t.Fatalf("failed to disable split slice flag, want: 1, but got: %d", len(ret))
 	}

--- a/flag_uint64_slice.go
+++ b/flag_uint64_slice.go
@@ -11,6 +11,7 @@ import (
 // Uint64Slice wraps []int64 to satisfy flag.Value
 type Uint64Slice struct {
 	slice      []uint64
+	separator  separatorSpec
 	hasBeenSet bool
 }
 
@@ -43,7 +44,7 @@ func (i *Uint64Slice) Set(value string) error {
 		return nil
 	}
 
-	for _, s := range flagSplitMultiValues(value) {
+	for _, s := range i.separator.flagSplitMultiValues(value) {
 		tmp, err := strconv.ParseUint(strings.TrimSpace(s), 0, 64)
 		if err != nil {
 			return err
@@ -53,6 +54,10 @@ func (i *Uint64Slice) Set(value string) error {
 	}
 
 	return nil
+}
+
+func (i *Uint64Slice) WithSeparatorSpec(spec separatorSpec) {
+	i.separator = spec
 }
 
 // String returns a readable representation of this value (for usage defaults)
@@ -153,10 +158,11 @@ func (f *Uint64SliceFlag) Apply(set *flag.FlagSet) error {
 		setValue = f.Value.clone()
 	default:
 		setValue = new(Uint64Slice)
+		setValue.WithSeparatorSpec(f.separator)
 	}
 
 	if val, source, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok && val != "" {
-		for _, s := range flagSplitMultiValues(val) {
+		for _, s := range f.separator.flagSplitMultiValues(val) {
 			if err := setValue.Set(strings.TrimSpace(s)); err != nil {
 				return fmt.Errorf("could not parse %q as uint64 slice value from %s for flag %s: %s", val, source, f.Name, err)
 			}
@@ -173,6 +179,10 @@ func (f *Uint64SliceFlag) Apply(set *flag.FlagSet) error {
 	}
 
 	return nil
+}
+
+func (f *Uint64SliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
 }
 
 // Get returns the flag’s value in the given Context.

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -1038,6 +1038,8 @@ func (f *Float64Slice) String() string
 func (f *Float64Slice) Value() []float64
     Value returns the slice of float64s set by this flag
 
+func (f *Float64Slice) WithSeparatorSpec(spec separatorSpec)
+
 type Float64SliceFlag struct {
 	Name string
 
@@ -1112,6 +1114,8 @@ func (f *Float64SliceFlag) String() string
 
 func (f *Float64SliceFlag) TakesValue() bool
     TakesValue returns true if the flag takes a value, otherwise false
+
+func (f *Float64SliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type Generic interface {
 	Set(value string) error
@@ -1279,6 +1283,8 @@ func (i *Int64Slice) String() string
 func (i *Int64Slice) Value() []int64
     Value returns the slice of ints set by this flag
 
+func (i *Int64Slice) WithSeparatorSpec(spec separatorSpec)
+
 type Int64SliceFlag struct {
 	Name string
 
@@ -1353,6 +1359,8 @@ func (f *Int64SliceFlag) String() string
 
 func (f *Int64SliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *Int64SliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type IntFlag struct {
 	Name string
@@ -1449,6 +1457,8 @@ func (i *IntSlice) String() string
 func (i *IntSlice) Value() []int
     Value returns the slice of ints set by this flag
 
+func (i *IntSlice) WithSeparatorSpec(spec separatorSpec)
+
 type IntSliceFlag struct {
 	Name string
 
@@ -1523,6 +1533,8 @@ func (f *IntSliceFlag) String() string
 
 func (f *IntSliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *IntSliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type InvalidFlagAccessFunc func(*Context, string)
     InvalidFlagAccessFunc is executed when an invalid flag is accessed from the
@@ -1792,6 +1804,8 @@ func (s *StringSlice) String() string
 func (s *StringSlice) Value() []string
     Value returns the slice of strings set by this flag
 
+func (s *StringSlice) WithSeparatorSpec(spec separatorSpec)
+
 type StringSliceFlag struct {
 	Name string
 
@@ -1868,6 +1882,8 @@ func (f *StringSliceFlag) String() string
 
 func (f *StringSliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *StringSliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type SuggestCommandFunc func(commands []*Command, provided string) string
 
@@ -2063,6 +2079,8 @@ func (i *Uint64Slice) String() string
 func (i *Uint64Slice) Value() []uint64
     Value returns the slice of ints set by this flag
 
+func (i *Uint64Slice) WithSeparatorSpec(spec separatorSpec)
+
 type Uint64SliceFlag struct {
 	Name string
 
@@ -2128,6 +2146,8 @@ func (f *Uint64SliceFlag) String() string
 
 func (f *Uint64SliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *Uint64SliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type UintFlag struct {
 	Name string
@@ -2224,6 +2244,8 @@ func (i *UintSlice) String() string
 func (i *UintSlice) Value() []uint
     Value returns the slice of ints set by this flag
 
+func (i *UintSlice) WithSeparatorSpec(spec separatorSpec)
+
 type UintSliceFlag struct {
 	Name string
 
@@ -2289,6 +2311,8 @@ func (f *UintSliceFlag) String() string
 
 func (f *UintSliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *UintSliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type VisibleFlag interface {
 	Flag

--- a/testdata/godoc-v2.x.txt
+++ b/testdata/godoc-v2.x.txt
@@ -1038,6 +1038,8 @@ func (f *Float64Slice) String() string
 func (f *Float64Slice) Value() []float64
     Value returns the slice of float64s set by this flag
 
+func (f *Float64Slice) WithSeparatorSpec(spec separatorSpec)
+
 type Float64SliceFlag struct {
 	Name string
 
@@ -1112,6 +1114,8 @@ func (f *Float64SliceFlag) String() string
 
 func (f *Float64SliceFlag) TakesValue() bool
     TakesValue returns true if the flag takes a value, otherwise false
+
+func (f *Float64SliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type Generic interface {
 	Set(value string) error
@@ -1279,6 +1283,8 @@ func (i *Int64Slice) String() string
 func (i *Int64Slice) Value() []int64
     Value returns the slice of ints set by this flag
 
+func (i *Int64Slice) WithSeparatorSpec(spec separatorSpec)
+
 type Int64SliceFlag struct {
 	Name string
 
@@ -1353,6 +1359,8 @@ func (f *Int64SliceFlag) String() string
 
 func (f *Int64SliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *Int64SliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type IntFlag struct {
 	Name string
@@ -1449,6 +1457,8 @@ func (i *IntSlice) String() string
 func (i *IntSlice) Value() []int
     Value returns the slice of ints set by this flag
 
+func (i *IntSlice) WithSeparatorSpec(spec separatorSpec)
+
 type IntSliceFlag struct {
 	Name string
 
@@ -1523,6 +1533,8 @@ func (f *IntSliceFlag) String() string
 
 func (f *IntSliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *IntSliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type InvalidFlagAccessFunc func(*Context, string)
     InvalidFlagAccessFunc is executed when an invalid flag is accessed from the
@@ -1792,6 +1804,8 @@ func (s *StringSlice) String() string
 func (s *StringSlice) Value() []string
     Value returns the slice of strings set by this flag
 
+func (s *StringSlice) WithSeparatorSpec(spec separatorSpec)
+
 type StringSliceFlag struct {
 	Name string
 
@@ -1868,6 +1882,8 @@ func (f *StringSliceFlag) String() string
 
 func (f *StringSliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *StringSliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type SuggestCommandFunc func(commands []*Command, provided string) string
 
@@ -2063,6 +2079,8 @@ func (i *Uint64Slice) String() string
 func (i *Uint64Slice) Value() []uint64
     Value returns the slice of ints set by this flag
 
+func (i *Uint64Slice) WithSeparatorSpec(spec separatorSpec)
+
 type Uint64SliceFlag struct {
 	Name string
 
@@ -2128,6 +2146,8 @@ func (f *Uint64SliceFlag) String() string
 
 func (f *Uint64SliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *Uint64SliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type UintFlag struct {
 	Name string
@@ -2224,6 +2244,8 @@ func (i *UintSlice) String() string
 func (i *UintSlice) Value() []uint
     Value returns the slice of ints set by this flag
 
+func (i *UintSlice) WithSeparatorSpec(spec separatorSpec)
+
 type UintSliceFlag struct {
 	Name string
 
@@ -2289,6 +2311,8 @@ func (f *UintSliceFlag) String() string
 
 func (f *UintSliceFlag) TakesValue() bool
     TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *UintSliceFlag) WithSeparatorSpec(spec separatorSpec)
 
 type VisibleFlag interface {
 	Flag

--- a/zz_generated.flags.go
+++ b/zz_generated.flags.go
@@ -25,6 +25,8 @@ type Float64SliceFlag struct {
 
 	defaultValue *Float64Slice
 
+	separator separatorSpec
+
 	Action func(*Context, []float64) error
 }
 
@@ -120,6 +122,8 @@ type Int64SliceFlag struct {
 
 	defaultValue *Int64Slice
 
+	separator separatorSpec
+
 	Action func(*Context, []int64) error
 }
 
@@ -163,6 +167,8 @@ type IntSliceFlag struct {
 	EnvVars []string
 
 	defaultValue *IntSlice
+
+	separator separatorSpec
 
 	Action func(*Context, []int) error
 }
@@ -258,6 +264,8 @@ type StringSliceFlag struct {
 	EnvVars []string
 
 	defaultValue *StringSlice
+
+	separator separatorSpec
 
 	TakesFile bool
 
@@ -358,6 +366,8 @@ type Uint64SliceFlag struct {
 
 	defaultValue *Uint64Slice
 
+	separator separatorSpec
+
 	Action func(*Context, []uint64) error
 }
 
@@ -401,6 +411,8 @@ type UintSliceFlag struct {
 	EnvVars []string
 
 	defaultValue *UintSlice
+
+	separator separatorSpec
 
 	Action func(*Context, []uint) error
 }


### PR DESCRIPTION
## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- bug fix

## What this PR does / why we need it:

Remove the dependencies of shared variable from slice type flags parsing, and instead use a `separatorSpec` for parsing. This should not fail downstream dependencies that may be running multiple `*App` concurrently with race detector on.

## Which issue(s) this PR fixes:

Fixes #1670

## Special notes for your reviewer:

This commit creates a new type separatorSpec that will get passed into flag parser, instead of reading from shared variables. I'm uncertain that if I may have missed some parts of the code to be injected. Please let me know if I overlooked anything.

With `HideVersion` and `HideHelp`, the integration test mentioned in the issue is now passing with race detector on with this patch applied.

## Testing

Should be passing with `separatorSpec`, assuming that the call site has the configured `separatorSpec` from caller.

## Release Notes

```release-note
flag: remove dependencies on shared variables when parsing slices
```
