### PR TITLE
Show non categorized flags with categorized on help

### DIFF
--- a/app.go
+++ b/app.go
@@ -250,14 +250,7 @@ func (a *App) Setup() {
 	}
 	sort.Sort(a.categories.(*commandCategories))
 
-	a.flagCategories = newFlagCategories()
-	for _, fl := range a.Flags {
-		if cf, ok := fl.(CategorizableFlag); ok {
-			if cf.GetCategory() != "" {
-				a.flagCategories.AddFlag(cf.GetCategory(), cf)
-			}
-		}
-	}
+	a.flagCategories = newFlagCategoriesFromFlags(a.Flags)
 
 	if a.Metadata == nil {
 		a.Metadata = make(map[string]interface{})

--- a/app_test.go
+++ b/app_test.go
@@ -2303,37 +2303,6 @@ func TestApp_VisibleCategories(t *testing.T) {
 	expect(t, []CommandCategory{}, app.VisibleCategories())
 }
 
-func TestApp_VisibleFlagCategories(t *testing.T) {
-	app := &App{
-		Flags: []Flag{
-			&StringFlag{
-				Name: "strd", // no category set
-			},
-			&Int64Flag{
-				Name:     "intd",
-				Aliases:  []string{"altd1", "altd2"},
-				Category: "cat1",
-			},
-		},
-	}
-	app.Setup()
-	vfc := app.VisibleFlagCategories()
-	if len(vfc) != 1 {
-		t.Fatalf("unexpected visible flag categories %+v", vfc)
-	}
-	if vfc[0].Name() != "cat1" {
-		t.Errorf("expected category name cat1 got %s", vfc[0].Name())
-	}
-	if len(vfc[0].Flags()) != 1 {
-		t.Fatalf("expected flag category to have just one flag got %+v", vfc[0].Flags())
-	}
-
-	fl := vfc[0].Flags()[0]
-	if !reflect.DeepEqual(fl.Names(), []string{"intd", "altd1", "altd2"}) {
-		t.Errorf("unexpected flag %+v", fl.Names())
-	}
-}
-
 func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 	app := &App{
 		Action: func(c *Context) error { return nil },

--- a/category.go
+++ b/category.go
@@ -100,10 +100,23 @@ func newFlagCategories() FlagCategories {
 
 func newFlagCategoriesFromFlags(fs []Flag) FlagCategories {
 	fc := newFlagCategories()
+
+	var categorized bool
 	for _, fl := range fs {
 		if cf, ok := fl.(CategorizableFlag); ok {
-			if cf.GetCategory() != "" {
-				fc.AddFlag(cf.GetCategory(), cf)
+			if cat := cf.GetCategory(); cat != "" {
+				fc.AddFlag(cat, cf)
+				categorized = true
+			}
+		}
+	}
+
+	if categorized == true {
+		for _, fl := range fs {
+			if cf, ok := fl.(CategorizableFlag); ok {
+				if cf.GetCategory() == "" {
+					fc.AddFlag("", fl)
+				}
 			}
 		}
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -470,17 +470,17 @@ func TestCommand_VisibleFlagCategories(t *testing.T) {
 	}
 
 	vfc := c.VisibleFlagCategories()
-	if len(vfc) != 1 {
+	if len(vfc) != 2 {
 		t.Fatalf("unexpected visible flag categories %+v", vfc)
 	}
-	if vfc[0].Name() != "cat1" {
+	if vfc[1].Name() != "cat1" {
 		t.Errorf("expected category name cat1 got %s", vfc[0].Name())
 	}
-	if len(vfc[0].Flags()) != 1 {
+	if len(vfc[1].Flags()) != 1 {
 		t.Fatalf("expected flag category to have just one flag got %+v", vfc[0].Flags())
 	}
 
-	fl := vfc[0].Flags()[0]
+	fl := vfc[1].Flags()[0]
 	if !reflect.DeepEqual(fl.Names(), []string{"intd", "altd1", "altd2"}) {
 		t.Errorf("unexpected flag %+v", fl.Names())
 	}


### PR DESCRIPTION
## What type of PR is this?

- bug
- feature

## What this PR does / why we need it:

Reverting the removal of visible flags from help if their sibling flags have categories defined.

Example:
```
App:
    Flags:
        Flag1: // non categorized
        Flag2: Category1
        
Help Before PR:
    Options:
      Category1
        Flag2
        
Help After:
    Options:
        Flag1
      
      Category1
        Flag2
```

## Which issue(s) this PR fixes:

fixes #1672 

## Release Notes

```release-note
Reverted removal of non categorized flags alongside categorized flags
```
