### PR TITLE
Fix some issues in bash autocompletion

### DIFF
--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -2,17 +2,31 @@
 
 : ${PROG:=$(basename ${BASH_SOURCE})}
 
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+_cli_init_completion() {
+  COMPREPLY=()
+  _get_comp_words_by_ref "$@" cur prev words cword
+}
+
 _cli_bash_autocomplete() {
   if [[ "${COMP_WORDS[0]}" != "source" ]]; then
-    local cur opts base
+    local cur opts base words
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    if [[ "$cur" == "-"* ]]; then
-      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-shell-completion )
+    if declare -F _init_completion >/dev/null 2>&1; then
+      _init_completion -n "=:" || return
     else
-      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-shell-completion )
+      _cli_init_completion -n "=:" || return
     fi
-    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    words=("${words[@]:0:$cword}")
+    if [[ "$cur" == "-"* ]]; then
+      requestComp="${words[*]} ${cur} --generate-shell-completion"
+    else
+      requestComp="${words[*]} --generate-shell-completion"
+    fi
+    opts=$(eval "${requestComp}" 2>/dev/null)
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
     return 0
   fi
 }

--- a/help_test.go
+++ b/help_test.go
@@ -1242,6 +1242,28 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 			argv:     []string{"cmd", "--generate-shell-completion"},
 			expected: "futz\n",
 		},
+		{
+			name: "autocomplete-with-spaces",
+			c: &Context{App: &App{
+				Name: "cmd",
+				Flags: []Flag{
+					&BoolFlag{Name: "happiness"},
+					&Int64Flag{Name: "everybody-jump-on"},
+				},
+			}},
+			cmd: &Command{
+				Name: "putz",
+				Commands: []*Command{
+					{Name: "help"},
+				},
+				Flags: []Flag{
+					&BoolFlag{Name: "excitement"},
+					&StringFlag{Name: "hat-shape"},
+				},
+			},
+			argv:     []string{"cmd", "--url", "http://localhost:8000", "h", "--generate-shell-completion"},
+			expected: "help\n",
+		},
 	} {
 		t.Run(tc.name, func(ct *testing.T) {
 			writer := &bytes.Buffer{}


### PR DESCRIPTION
## What type of PR is this?
- bug

## What this PR does / why we need it:

With current version of autocomplete script, shell quotes gets expanded incorrectly

Consider the following example:
`my-cli --url http://localhost:8000 he` (pressing tab should auto-complete to help, but it doesn't)
Why doesn't it auto-complete?
Because it calls the following command:
`my-cli --url http : //localhost : 8000 --generate-bash-completion`
And if we put it in quotes my-cli --url "http://localhost:8000" he
It calls:
`my-cli --url '"http://localhost:8000"' --generate-bash-completion`

Both fail, so CLI fails to call correct URL and return a list of completions.
With this PR it sends correct data
Actually I am not sure if that's the best solution, I checked how cobra does this and converted to our use case
It looks like the `_init_completion` function does all the magic and makes it work, I don't understand why unfortunately

P.S. I hope it'll be backported to 2.x series too (:

## Testing

I tested multiple cases, i.e. sending one positional argument, 2 of them, or argument + flag, the CLI receives same arguments as before, but now more cases work

## Release Notes

```release-note
Fixed shell expansion in bash autocompletion scripts
```
