### PR TITLE
Make trim space optional

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -428,7 +428,7 @@ func ExampleApp_Run_sliceValues() {
 	// 0-float64Sclice cli.Float64Slice{slice:[]float64{13.3, 14.4, 15.5, 16.6}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
 	// 1-int64Sclice cli.Int64Slice{slice:[]int64{13, 14, 15, 16}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
 	// 2-intSclice cli.IntSlice{slice:[]int{13, 14, 15, 16}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
-	// 3-stringSclice cli.StringSlice{slice:[]string{"parsed1", "parsed2", "parsed3", "parsed4"}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true, noTrimSpace:false}
+	// 3-stringSclice cli.StringSlice{slice:[]string{"parsed1", "parsed2", "parsed3", "parsed4"}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true, keepSpace:false}
 	// error: <nil>
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -428,7 +428,7 @@ func ExampleApp_Run_sliceValues() {
 	// 0-float64Sclice cli.Float64Slice{slice:[]float64{13.3, 14.4, 15.5, 16.6}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
 	// 1-int64Sclice cli.Int64Slice{slice:[]int64{13, 14, 15, 16}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
 	// 2-intSclice cli.IntSlice{slice:[]int{13, 14, 15, 16}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
-	// 3-stringSclice cli.StringSlice{slice:[]string{"parsed1", "parsed2", "parsed3", "parsed4"}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true}
+	// 3-stringSclice cli.StringSlice{slice:[]string{"parsed1", "parsed2", "parsed3", "parsed4"}, separator:cli.separatorSpec{sep:"", disabled:false, customized:false}, hasBeenSet:true, noTrimSpace:false}
 	// error: <nil>
 }
 

--- a/flag-spec.yaml
+++ b/flag-spec.yaml
@@ -101,6 +101,8 @@ flag_types:
         type: bool
       - name: Action
         type: "func(*Context, []string) error"
+      - name: NoTrimSpace
+        type: bool
   time.Duration:
     struct_fields:
       - name: Action

--- a/flag-spec.yaml
+++ b/flag-spec.yaml
@@ -101,7 +101,7 @@ flag_types:
         type: bool
       - name: Action
         type: "func(*Context, []string) error"
-      - name: NoTrimSpace
+      - name: KeepSpace
         type: bool
   time.Duration:
     struct_fields:

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -10,10 +10,10 @@ import (
 
 // StringSlice wraps a []string to satisfy flag.Value
 type StringSlice struct {
-	slice       []string
-	separator   separatorSpec
-	hasBeenSet  bool
-	noTrimSpace bool
+	slice      []string
+	separator  separatorSpec
+	hasBeenSet bool
+	keepSpace  bool
 }
 
 // NewStringSlice creates a *StringSlice with default values
@@ -46,7 +46,7 @@ func (s *StringSlice) Set(value string) error {
 	}
 
 	for _, t := range s.separator.flagSplitMultiValues(value) {
-		if !s.noTrimSpace {
+		if !s.keepSpace {
 			t = strings.TrimSpace(t)
 		}
 		s.slice = append(s.slice, t)
@@ -153,11 +153,11 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 		setValue.WithSeparatorSpec(f.separator)
 	}
 
-	setValue.noTrimSpace = f.NoTrimSpace
+	setValue.keepSpace = f.KeepSpace
 
 	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		for _, s := range f.separator.flagSplitMultiValues(val) {
-			if !f.NoTrimSpace {
+			if !f.KeepSpace {
 				s = strings.TrimSpace(s)
 			}
 			if err := setValue.Set(s); err != nil {

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -157,7 +157,10 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 
 	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		for _, s := range f.separator.flagSplitMultiValues(val) {
-			if err := setValue.Set(strings.TrimSpace(s)); err != nil {
+			if !f.NoTrimSpace {
+				s = strings.TrimSpace(s)
+			}
+			if err := setValue.Set(s); err != nil {
 				return fmt.Errorf("could not parse %q as string value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 		}

--- a/flag_string_slice.go
+++ b/flag_string_slice.go
@@ -10,9 +10,10 @@ import (
 
 // StringSlice wraps a []string to satisfy flag.Value
 type StringSlice struct {
-	slice      []string
-	separator  separatorSpec
-	hasBeenSet bool
+	slice       []string
+	separator   separatorSpec
+	hasBeenSet  bool
+	noTrimSpace bool
 }
 
 // NewStringSlice creates a *StringSlice with default values
@@ -45,6 +46,9 @@ func (s *StringSlice) Set(value string) error {
 	}
 
 	for _, t := range s.separator.flagSplitMultiValues(value) {
+		if !s.noTrimSpace {
+			t = strings.TrimSpace(t)
+		}
 		s.slice = append(s.slice, t)
 	}
 
@@ -148,6 +152,8 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 		setValue = new(StringSlice)
 		setValue.WithSeparatorSpec(f.separator)
 	}
+
+	setValue.noTrimSpace = f.NoTrimSpace
 
 	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		for _, s := range f.separator.flagSplitMultiValues(val) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -144,6 +144,11 @@ func TestFlagsFromEnv(t *testing.T) {
 		s.hasBeenSet = false
 		return *s
 	}
+	newSetStringSliceNoTrimSpace := func(defaults ...string) StringSlice {
+		s := newSetStringSlice(defaults...)
+		s.noTrimSpace = true
+		return s
+	}
 
 	var flagTests = []struct {
 		input     string
@@ -198,6 +203,8 @@ func TestFlagsFromEnv(t *testing.T) {
 		{"path", "path", &PathFlag{Name: "path", EnvVars: []string{"PATH"}}, ""},
 
 		{"foo,bar", newSetStringSlice("foo", "bar"), &StringSliceFlag{Name: "names", EnvVars: []string{"NAMES"}}, ""},
+		{" space ", newSetStringSliceNoTrimSpace(" space "), &StringSliceFlag{Name: "names", NoTrimSpace: true, EnvVars: []string{"NAMES"}}, ""},
+		{" no space ", newSetStringSlice("no space"), &StringSliceFlag{Name: "names", EnvVars: []string{"NAMES"}}, ""},
 
 		{"1", uint(1), &UintFlag{Name: "seconds", EnvVars: []string{"SECONDS"}}, ""},
 		{"08", uint(8), &UintFlag{Name: "seconds", EnvVars: []string{"SECONDS"}, Base: 10}, ""},

--- a/flag_test.go
+++ b/flag_test.go
@@ -144,9 +144,9 @@ func TestFlagsFromEnv(t *testing.T) {
 		s.hasBeenSet = false
 		return *s
 	}
-	newSetStringSliceNoTrimSpace := func(defaults ...string) StringSlice {
+	newSetStringSliceKeepSpace := func(defaults ...string) StringSlice {
 		s := newSetStringSlice(defaults...)
-		s.noTrimSpace = true
+		s.keepSpace = true
 		return s
 	}
 
@@ -203,7 +203,7 @@ func TestFlagsFromEnv(t *testing.T) {
 		{"path", "path", &PathFlag{Name: "path", EnvVars: []string{"PATH"}}, ""},
 
 		{"foo,bar", newSetStringSlice("foo", "bar"), &StringSliceFlag{Name: "names", EnvVars: []string{"NAMES"}}, ""},
-		{" space ", newSetStringSliceNoTrimSpace(" space "), &StringSliceFlag{Name: "names", NoTrimSpace: true, EnvVars: []string{"NAMES"}}, ""},
+		{" space ", newSetStringSliceKeepSpace(" space "), &StringSliceFlag{Name: "names", KeepSpace: true, EnvVars: []string{"NAMES"}}, ""},
 		{" no space ", newSetStringSlice("no space"), &StringSliceFlag{Name: "names", EnvVars: []string{"NAMES"}}, ""},
 
 		{"1", uint(1), &UintFlag{Name: "seconds", EnvVars: []string{"SECONDS"}}, ""},
@@ -781,7 +781,7 @@ func TestStringSliceFlag_MatchStringFlagBehavior(t *testing.T) {
 			app := App{
 				Flags: []Flag{
 					&StringFlag{Name: "string"},
-					&StringSliceFlag{Name: "slice", NoTrimSpace: true},
+					&StringSliceFlag{Name: "slice", KeepSpace: true},
 				},
 				Action: func(ctx *Context) error {
 					f1, f2 := ctx.String("string"), ctx.StringSlice("slice")
@@ -822,7 +822,7 @@ func TestStringSliceFlag_TrimSpace(t *testing.T) {
 			app := App{
 				Flags: []Flag{
 					&StringSliceFlag{Name: "trim"},
-					&StringSliceFlag{Name: "no-trim", NoTrimSpace: true},
+					&StringSliceFlag{Name: "no-trim", KeepSpace: true},
 				},
 				Action: func(ctx *Context) error {
 					flagTrim, flagNoTrim := ctx.StringSlice("trim"), ctx.StringSlice("no-trim")

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -1828,7 +1828,7 @@ type StringSliceFlag struct {
 
 	Action func(*Context, []string) error
 
-	NoTrimSpace bool
+	KeepSpace bool
 	// Has unexported fields.
 }
     StringSliceFlag is a flag with type *StringSlice

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -1827,6 +1827,8 @@ type StringSliceFlag struct {
 	TakesFile bool
 
 	Action func(*Context, []string) error
+
+	NoTrimSpace bool
 	// Has unexported fields.
 }
     StringSliceFlag is a flag with type *StringSlice

--- a/testdata/godoc-v2.x.txt
+++ b/testdata/godoc-v2.x.txt
@@ -1828,7 +1828,7 @@ type StringSliceFlag struct {
 
 	Action func(*Context, []string) error
 
-	NoTrimSpace bool
+	KeepSpace bool
 	// Has unexported fields.
 }
     StringSliceFlag is a flag with type *StringSlice

--- a/testdata/godoc-v2.x.txt
+++ b/testdata/godoc-v2.x.txt
@@ -1827,6 +1827,8 @@ type StringSliceFlag struct {
 	TakesFile bool
 
 	Action func(*Context, []string) error
+
+	NoTrimSpace bool
 	// Has unexported fields.
 }
     StringSliceFlag is a flag with type *StringSlice

--- a/zz_generated.flags.go
+++ b/zz_generated.flags.go
@@ -270,6 +270,8 @@ type StringSliceFlag struct {
 	TakesFile bool
 
 	Action func(*Context, []string) error
+
+	NoTrimSpace bool
 }
 
 // IsSet returns whether or not the flag has been set through env or file

--- a/zz_generated.flags.go
+++ b/zz_generated.flags.go
@@ -271,7 +271,7 @@ type StringSliceFlag struct {
 
 	Action func(*Context, []string) error
 
-	NoTrimSpace bool
+	KeepSpace bool
 }
 
 // IsSet returns whether or not the flag has been set through env or file


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR makes trimming space from string slice values optional (opt in) to not break backward compatibility.

See discussion from https://github.com/urfave/cli/pull/1649#issuecomment-1407739883 and onwards.

## Which issue(s) this PR fixes:

Fixes #1648

## Testing

* Modified existing test to use new flag.
* Added test that verifies changes only take effect if field is set (opt in), thus avoiding breaking existing code/usage.
* Test the behavior for values from the environment.

## Release Notes

```release-note
Add new field `KeepSpace` to `StringSliceFlag` struct. Setting this field will keep leading and tailing spaces when parsing flags.
```
