### PR TITLE
Deprecation of package ioutil in Go 1.16

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -384,7 +384,7 @@ func flagFromEnvOrFile(envVars []string, filePath string) (value string, fromWhe
 	}
 	for _, fileVar := range strings.Split(filePath, ",") {
 		if fileVar != "" {
-			if data, err := ioutil.ReadFile(fileVar); err == nil {
+			if data, err := os.ReadFile(fileVar); err == nil {
 				return string(data), fmt.Sprintf("file %q", filePath), true
 			}
 		}


### PR DESCRIPTION
ioutil.ReadFile(...) became -> os.ReadFile(...)

https://github.com/go-critic/go-critic/issues/1019
