### PR TITLE
Shift tested Go versions

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.18.x, 1.19.x]
+        go: [1.19.x, 1.20.x]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -25,9 +25,9 @@ jobs:
       - name: Set PATH
         run: echo "${GITHUB_WORKSPACE}/.local/bin" >>"${GITHUB_PATH}"
       - uses: actions/checkout@v3
-      - if: matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
+      - if: matrix.go == '1.20.x' && matrix.os == 'ubuntu-latest'
         run: make ensure-goimports
-      - if: matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
+      - if: matrix.go == '1.20.x' && matrix.os == 'ubuntu-latest'
         run: make lint
       - run: make vet
       - run: make test
@@ -38,12 +38,12 @@ jobs:
         env:
           GFLAGS: -tags urfave_cli_no_docs
       - run: make check-binary-size
-      - if: matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
+      - if: matrix.go == '1.20.x' && matrix.os == 'ubuntu-latest'
         run: make generate
       - run: make diffcheck
-      - if: matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
+      - if: matrix.go == '1.20.x' && matrix.os == 'ubuntu-latest'
         run: make v3diff
-      - if: success() && matrix.go == '1.19.x' && matrix.os == 'ubuntu-latest'
+      - if: success() && matrix.go == '1.20.x' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - uses: actions/setup-node@v3
         with:
           node-version: '16'


### PR DESCRIPTION
## What type of PR is this?

- maintenance

## What this PR does / why we need it:

Bump the tested go versions since the first patch of 1.20.x is available now.

## Which issue(s) this PR fixes:

N/A 😬 