### PR TITLE
Add makezero linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,5 @@
 # https://golangci-lint.run/usage/configuration/
 linters:
   enable:
+    - makezero
     - misspell

--- a/errors.go
+++ b/errors.go
@@ -41,9 +41,7 @@ func (m *multiError) Error() string {
 // Errors returns a copy of the errors slice
 func (m *multiError) Errors() []error {
 	errs := make([]error, len(*m))
-	for _, err := range *m {
-		errs = append(errs, err)
-	}
+	copy(errs, *m)
 	return errs
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -159,3 +159,13 @@ func TestHandleExitCoder_MultiErrorWithFormat(t *testing.T) {
 	expect(t, called, true)
 	expect(t, ErrWriter.(*bytes.Buffer).String(), "This the format: err1\nThis the format: err2\n")
 }
+
+func TestMultiErrorErrorsCopy(t *testing.T) {
+	errList := []error{
+		errors.New("foo"),
+		errors.New("bar"),
+		errors.New("baz"),
+	}
+	me := newMultiError(errList...)
+	expect(t, errList, me.Errors())
+}


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Fixes copying of errors for multiErrors. I already mentioned this in #1697.

I don't think this actually has an impact on users, because the handleMultiError function will just drop nil errors.

I added a regression test, just in case.

## Which issue(s) this PR fixes:

Partially fixes: #1704

## Release Notes

```release-note
NONE
```
