### PR TITLE
Better Generic Support For ISCs

### DIFF
--- a/altsrc/generic_with_import.go
+++ b/altsrc/generic_with_import.go
@@ -1,0 +1,9 @@
+package altsrc
+
+import "github.com/urfave/cli/v2"
+
+type GenericWithImport interface {
+	cli.Generic
+
+	FromJson([]byte) error
+}

--- a/altsrc/input_source_context.go
+++ b/altsrc/input_source_context.go
@@ -30,3 +30,9 @@ type InputSourceContext interface {
 
 	isSet(name string) bool
 }
+
+type InputSourceContextWithExport interface {
+	InputSourceContext
+
+	Json(name string) ([]byte, error)
+}

--- a/altsrc/json_source_context.go
+++ b/altsrc/json_source_context.go
@@ -286,6 +286,14 @@ func (x *jsonSource) Bool(name string) (bool, error) {
 	return v, nil
 }
 
+func (x *jsonSource) Json(name string) ([]byte, error) {
+	i, err := x.getValue(name)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(i)
+}
+
 func (x *jsonSource) isSet(name string) bool {
 	_, err := x.getValue(name)
 	return err == nil

--- a/altsrc/json_source_context_test.go
+++ b/altsrc/json_source_context_test.go
@@ -1,0 +1,12 @@
+package altsrc
+
+import "testing"
+
+func TestJsonSourceContext_Json(t *testing.T) {
+	ctx, err := NewJSONSource([]byte(`{"test":{"key":"value"}}`))
+	expect(t, nil, err)
+
+	export, err := ctx.(*jsonSource).Json("test")
+	expect(t, []byte(`{"key":"value"}`), export)
+	expect(t, nil, err)
+}

--- a/altsrc/map_input_source_test.go
+++ b/altsrc/map_input_source_test.go
@@ -33,3 +33,99 @@ func TestMapInputSource_Int64Slice(t *testing.T) {
 	expect(t, []int64{1, 2, 3}, d)
 	expect(t, nil, err)
 }
+
+func TestMapInputSource_mapToJsonable(t *testing.T) {
+	testMap := map[interface{}]interface{}{
+		"test_map": map[interface{}]interface{}{
+			"key1":                 "value",
+			&stringGeneric{"key2"}: 2,
+			"key3": map[interface{}]interface{}{
+				"subkey1": []interface{}{"subvalue"},
+			},
+		},
+	}
+	expectMap := map[string]interface{}{
+		"test_map": map[string]interface{}{
+			"key1": "value",
+			"key2": 2,
+			"key3": map[string]interface{}{
+				"subkey1": []interface{}{"subvalue"},
+			},
+		},
+	}
+
+	d, err := mapToJsonable(testMap)
+	expect(t, expectMap, d)
+	expect(t, nil, err)
+}
+
+func TestMapInputSource_sliceToJsonable(t *testing.T) {
+	testSlice := []interface{}{
+		map[interface{}]interface{}{
+			"key1":                 "value",
+			&stringGeneric{"key2"}: 2,
+			"key3": map[interface{}]interface{}{
+				"subkey1": []interface{}{"subvalue"},
+			},
+		},
+		"value",
+		2,
+	}
+	expectSlice := []interface{}{
+		map[string]interface{}{
+			"key1": "value",
+			"key2": 2,
+			"key3": map[string]interface{}{
+				"subkey1": []interface{}{"subvalue"},
+			},
+		},
+		"value",
+		2,
+	}
+
+	d, err := sliceToJsonable(testSlice)
+	expect(t, expectSlice, d)
+	expect(t, nil, err)
+}
+
+func TestMapInputSource_Json(t *testing.T) {
+	inputSource := NewMapInputSource(
+		"test",
+		map[interface{}]interface{}{
+			"test_map": map[interface{}]interface{}{
+				"key1":                 "value",
+				&stringGeneric{"key2"}: 2,
+				"key3": []interface{}{map[interface{}]interface{}{
+					"subkey1": []interface{}{"subvalue"},
+				}},
+			},
+			"test_slice": []interface{}{
+				"value",
+				2,
+				map[interface{}]interface{}{
+					"key1":                 "value",
+					&stringGeneric{"key2"}: 2,
+					"key3": []interface{}{map[interface{}]interface{}{
+						"subkey1": []interface{}{"subvalue"},
+					}},
+					"key4": []interface{}{
+						[]interface{}{1, 4, 7},
+						[]interface{}{2, 5, 8},
+						[]interface{}{3, 6, 9},
+					},
+				},
+			},
+		})
+
+	d, err := inputSource.Json("test_map")
+	expect(t, []byte(`{"key1":"value","key2":2,"key3":[{"subkey1":["subvalue"]}]}`), d)
+	expect(t, nil, err)
+
+	d, err = inputSource.Json("test_map.key3")
+	expect(t, []byte(`[{"subkey1":["subvalue"]}]`), d)
+	expect(t, nil, err)
+
+	d, err = inputSource.Json("test_slice")
+	expect(t, []byte(`["value",2,{"key1":"value","key2":2,"key3":[{"subkey1":["subvalue"]}],"key4":[[1,4,7],[2,5,8],[3,6,9]]}]`), d)
+	expect(t, nil, err)
+}

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -2463,6 +2463,12 @@ func (f *GenericFlag) Apply(set *flag.FlagSet) error
 func (f *GenericFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
     ApplyInputSourceValue applies a generic value to the flagSet if required
 
+type GenericWithImport interface {
+	cli.Generic
+
+	FromJson([]byte) error
+}
+
 type InputSourceContext interface {
 	Source() string
 
@@ -2505,6 +2511,12 @@ func NewTomlSourceFromFile(file string) (InputSourceContext, error)
 
 func NewYamlSourceFromFile(file string) (InputSourceContext, error)
     NewYamlSourceFromFile creates a new Yaml InputSourceContext from a filepath.
+
+type InputSourceContextWithExport interface {
+	InputSourceContext
+
+	Json(name string) ([]byte, error)
+}
 
 type Int64Flag struct {
 	*cli.Int64Flag
@@ -2612,6 +2624,8 @@ func (fsm *MapInputSource) Int64Slice(name string) ([]int64, error)
 
 func (fsm *MapInputSource) IntSlice(name string) ([]int, error)
     IntSlice returns an []int from the map if it exists otherwise returns nil
+
+func (fsm *MapInputSource) Json(name string) ([]byte, error)
 
 func (fsm *MapInputSource) Source() string
     Source returns the path of the source file

--- a/testdata/godoc-v2.x.txt
+++ b/testdata/godoc-v2.x.txt
@@ -2463,6 +2463,12 @@ func (f *GenericFlag) Apply(set *flag.FlagSet) error
 func (f *GenericFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
     ApplyInputSourceValue applies a generic value to the flagSet if required
 
+type GenericWithImport interface {
+	cli.Generic
+
+	FromJson([]byte) error
+}
+
 type InputSourceContext interface {
 	Source() string
 
@@ -2505,6 +2511,12 @@ func NewTomlSourceFromFile(file string) (InputSourceContext, error)
 
 func NewYamlSourceFromFile(file string) (InputSourceContext, error)
     NewYamlSourceFromFile creates a new Yaml InputSourceContext from a filepath.
+
+type InputSourceContextWithExport interface {
+	InputSourceContext
+
+	Json(name string) ([]byte, error)
+}
 
 type Int64Flag struct {
 	*cli.Int64Flag
@@ -2612,6 +2624,8 @@ func (fsm *MapInputSource) Int64Slice(name string) ([]int64, error)
 
 func (fsm *MapInputSource) IntSlice(name string) ([]int, error)
     IntSlice returns an []int from the map if it exists otherwise returns nil
+
+func (fsm *MapInputSource) Json(name string) ([]byte, error)
 
 func (fsm *MapInputSource) Source() string
     Source returns the path of the source file


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

- Allow generics to be set as their Set() string in the config
- Allow converting internal ISC (InputSourceContext) types to Generics when:
  - The data used to define the Generic can be expressed in JSON
  - The target Generic implements `FromJson([]byte) error`
  - The source ISC implements `Json(name string) ([]byte, error)`
- Update existing ISC implementations to also implement `Json(name string) ([]byte, error)`

And of course, there are tests for the new features.

As to why, the internal ISCs don't actually support Generics, as they don't know about these types to be able to deserialize into them directly. Proper support requires the ability to coerce the intermediate types into a Generic type. This can be done one of two ways - by using a string equivalent as you would on the CLI, or by implementing methods that can handle a JSON intermediate version on the Generic itself. 

Given:

```go
	app.Flags = []cli.Flag{
		altsrc.NewGenericFlag(&cli.GenericFlag{
			Name:   "location",
			Usage:  "where to connect",
			Value:  HostPort{},
		}),
		// ...
	}
```

The following examples are equivalent for the sample `HostPort` type added in this PR to the `altsrc` tests:

```yaml
location: localhost:33
```

```yaml
location:
  host: localhost
  port: 33
```

Third-party code that implements its own InputSourceContext may already support storing Generics in its internal structure, in which case the new code paths won't be hit, rendering full BC.

## Testing

Tests were updated in the code to cover the new scenarios.

## Release Notes

```release-note
Better Generic support when using an InputSourceContext
```