### PR TITLE
v2 - Fix `incorrectTypeForFlagError` for pointers

### DIFF
--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -475,6 +475,9 @@ func incorrectTypeForFlagError(name, expectedTypeName string, value interface{})
 	valueTypeName := ""
 	if valueType != nil {
 		valueTypeName = valueType.Name()
+		if valueTypeName == "" && valueType.Kind() == reflect.Pointer {
+			valueTypeName = "*" + valueType.Elem().Name()
+		}
 	}
 
 	return fmt.Errorf("Mismatched type for flag '%s'. Expected '%s' but actual is '%s'", name, expectedTypeName, valueTypeName)

--- a/altsrc/map_input_source_test.go
+++ b/altsrc/map_input_source_test.go
@@ -1,6 +1,7 @@
 package altsrc
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -32,4 +33,9 @@ func TestMapInputSource_Int64Slice(t *testing.T) {
 	d, err := inputSource.Int64Slice("test_num")
 	expect(t, []int64{1, 2, 3}, d)
 	expect(t, nil, err)
+}
+
+func TestMapInputSource_IncorrectFlagTypeError(t *testing.T) {
+	var testVal *bool
+	expect(t, incorrectTypeForFlagError("test", "bool", testVal), fmt.Errorf("Mismatched type for flag 'test'. Expected 'bool' but actual is '*bool'"))
 }


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

When configs parsed into `MapInputSource` are looked up, they report type mismatch errors, as expected. However, if the type is mismatched because it somehow ended up becoming a pointer, the error message doesn't actually indicate this. Instead, it reports an "actual type" of `''` - the empty string. This is a known limitation of the way `reflect` works, and is used elsewhere in the code to dereference the pointer to get the actual type. So I'm not sure why it was overlooked in this case.

## Testing

A test was added to ensure this change works as expected. 

## Release Notes

```release-note
NONE
```