### PR TITLE
v2 - Fix: missing required flag error uses flag name and not alias

### DIFF
--- a/context.go
+++ b/context.go
@@ -204,9 +204,10 @@ func (cCtx *Context) checkRequiredFlags(flags []Flag) requiredFlagsErr {
 			var flagPresent bool
 			var flagName string
 
-			for _, key := range f.Names() {
-				flagName = key
+			flagNames := f.Names()
+			flagName = flagNames[0]
 
+			for _, key := range flagNames {
 				if cCtx.IsSet(strings.TrimSpace(key)) {
 					flagPresent = true
 				}

--- a/context_test.go
+++ b/context_test.go
@@ -602,6 +602,14 @@ func TestCheckRequiredFlags(t *testing.T) {
 				&StringFlag{Name: "n", Required: true},
 			},
 		},
+		{
+			testCase:              "required_flag_with_alias_errors_with_actual_name",
+			expectedAnError:       true,
+			expectedErrorContents: []string{"Required flag \"collection\" not set"},
+			flags: []Flag{
+				&StringFlag{Name: "collection", Required: true, Aliases: []string{"c"}},
+			},
+		},
 	}
 
 	for _, test := range tdata {


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

Up until now, the missing required flag error showed the last alias of a flag, instead of the actual flag name. This results in a relatively unclear error messages:
```
Required flag "c" not set
```

Instead of 
```
Required flag "collection" not set
```

## Which issue(s) this PR fixes:

Fixes #1701 

## Testing

Added test case to ensure this change works as expected.

## Release Notes

```release-note
NONE
```
