### PR TITLE
Preserve separator spec on subcommands

### DIFF
--- a/command.go
+++ b/command.go
@@ -135,6 +135,7 @@ func (c *Command) setup(ctx *Context) {
 		if scmd.HelpName == "" {
 			scmd.HelpName = fmt.Sprintf("%s %s", c.HelpName, scmd.Name)
 		}
+		scmd.separator = c.separator
 		newCmds = append(newCmds, scmd)
 	}
 	c.Subcommands = newCmds

--- a/command_test.go
+++ b/command_test.go
@@ -515,3 +515,30 @@ func TestCommand_RunSubcommandWithDefault(t *testing.T) {
 	err = app.Run([]string{"app"})
 	expect(t, err, errors.New("should not run this subcommand"))
 }
+
+func TestCommand_PreservesSeparatorOnSubcommands(t *testing.T) {
+	var values []string
+	subcommand := &Command{
+		Name: "bar",
+		Flags: []Flag{
+			&StringSliceFlag{Name: "my-flag"},
+		},
+		Action: func(c *Context) error {
+			values = c.StringSlice("my-flag")
+			return nil
+		},
+	}
+	app := &App{
+		Commands: []*Command{
+			{
+				Name:        "foo",
+				Subcommands: []*Command{subcommand},
+			},
+		},
+		SliceFlagSeparator: ";",
+	}
+
+	app.Run([]string{"app", "foo", "bar", "--my-flag", "1;2;3"})
+
+	expect(t, values, []string{"1", "2", "3"})
+}


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The separatorSpec is not passed along to the subcommands which means that SliceFlags on subcommands will not use the global separator settings. Extended the command to pass the separatorSpec along.

## Which issue(s) this PR fixes:

SliceFlags on sub commands will not use the global separator settings.

## Testing

Added test case to ensure this  change works as expected.

## Release Notes

```release-note
NONE
```
