### PR TITLE
Remove redundant variable declarations

### DIFF
--- a/flag_generic.go
+++ b/flag_generic.go
@@ -117,13 +117,8 @@ func (cCtx *Context) Generic(name string) interface{} {
 }
 
 func lookupGeneric(name string, set *flag.FlagSet) interface{} {
-	f := set.Lookup(name)
-	if f != nil {
-		parsed, err := f.Value, error(nil)
-		if err != nil {
-			return nil
-		}
-		return parsed
+	if f := set.Lookup(name); f != nil {
+		return f.Value
 	}
 	return nil
 }

--- a/flag_path.go
+++ b/flag_path.go
@@ -90,13 +90,8 @@ func (cCtx *Context) Path(name string) string {
 }
 
 func lookupPath(name string, set *flag.FlagSet) string {
-	f := set.Lookup(name)
-	if f != nil {
-		parsed, err := f.Value.String(), error(nil)
-		if err != nil {
-			return ""
-		}
-		return parsed
+	if f := set.Lookup(name); f != nil {
+		return f.Value.String()
 	}
 	return ""
 }

--- a/flag_string.go
+++ b/flag_string.go
@@ -87,10 +87,8 @@ func (cCtx *Context) String(name string) string {
 }
 
 func lookupString(name string, set *flag.FlagSet) string {
-	f := set.Lookup(name)
-	if f != nil {
-		parsed := f.Value.String()
-		return parsed
+	if f := set.Lookup(name); f != nil {
+		return f.Value.String()
 	}
 	return ""
 }


### PR DESCRIPTION
## What type of PR is this?
- cleanup

## What this PR does / why we need it:

- `err` variable is useless.
- Reduce redundant `parsed` variable declaration.
