### PR TITLE
Remove redundant variable declarations

### DIFF
--- a/flag_generic.go
+++ b/flag_generic.go
@@ -98,13 +98,8 @@ func (c *Context) GlobalGeneric(name string) interface{} {
 }
 
 func lookupGeneric(name string, set *flag.FlagSet) interface{} {
-	f := set.Lookup(name)
-	if f != nil {
-		parsed, err := f.Value, error(nil)
-		if err != nil {
-			return nil
-		}
-		return parsed
+	if f := set.Lookup(name); f != nil {
+		return f.Value
 	}
 	return nil
 }

--- a/flag_string.go
+++ b/flag_string.go
@@ -86,13 +86,8 @@ func (c *Context) GlobalString(name string) string {
 }
 
 func lookupString(name string, set *flag.FlagSet) string {
-	f := set.Lookup(name)
-	if f != nil {
-		parsed, err := f.Value.String(), error(nil)
-		if err != nil {
-			return ""
-		}
-		return parsed
+	if f := set.Lookup(name); f != nil {
+		return f.Value.String()
 	}
 	return ""
 }


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

- `err` variable is useless.
- Reduce redundant `parsed` variable declaration.

> same as #1714, but for `v1`.