### PR TITLE
Add Frogbot workflows to this repository

### DIFF
--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -1,0 +1,40 @@
+name: "Frogbot Scan and Fix"
+on:
+  push:
+    # Creating fix pull requests will be triggered by any push to one of the these branches.
+    # You can add or replace to any branch you want to open fix pull requests for.
+    branches:
+      - "main"
+permissions:
+  contents: write
+  pull-requests: write
+  security-events: write
+jobs:
+  create-fix-pull-requests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # Install prerequisites
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+
+      - uses: jfrog/frogbot@v2
+        env:
+          # [Mandatory]
+          # JFrog platform URL
+          JF_URL: ${{ secrets.JF_URL }}
+
+          # [Mandatory if JF_ACCESS_TOKEN is not provided]
+          # JFrog username with 'read' permissions for Xray. Must be provided with JF_PASSWORD
+          JF_USER: ${{ secrets.JF_USER }}
+
+          # [Mandatory if JF_ACCESS_TOKEN is not provided]
+          # JFrog password. Must be provided with JF_USER
+          JF_PASSWORD: ${{ secrets.JF_PASSWORD }}
+
+          # [Manadatory]
+          # The GitHub token automatically generated for the job
+          JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -5,6 +5,9 @@ on:
     # You can add or replace to any branch you want to open fix pull requests for.
     branches:
       - "main"
+  schedule:
+    # The job will run once a day at 00:00 GMT.
+    - cron: "0 0 * * *"
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/frogbot-scan-pr.yml
+++ b/.github/workflows/frogbot-scan-pr.yml
@@ -1,0 +1,41 @@
+name: "Frogbot Scan Pull Request"
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+permissions:
+  pull-requests: write
+  contents: read
+jobs:
+  scan-pull-request:
+    runs-on: ubuntu-latest
+    # A pull request needs to be approved, before Frogbot scans it. Any GitHub user who is associated with the
+    # "frogbot" GitHub environment can approve the pull request to be scanned.
+    environment: frogbot
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      # Install prerequisites
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+
+      - uses: jfrog/frogbot@v2
+        env:
+          # [Mandatory]
+          # JFrog platform URL
+          JF_URL: ${{ secrets.JF_URL }}
+
+          # [Mandatory if JF_ACCESS_TOKEN is not provided]
+          # JFrog username with 'read' permissions for Xray. Must be provided with JF_PASSWORD
+          JF_USER: ${{ secrets.JF_USER }}
+
+          # [Mandatory if JF_ACCESS_TOKEN is not provided]
+          # JFrog password. Must be provided with JF_USER
+          JF_PASSWORD: ${{ secrets.JF_PASSWORD }}
+
+          # [Manadatory]
+          # The GitHub token automatically generated for the job
+          JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


## What type of PR is this?

- feature

## What this PR does / why we need it:

I'm opeening this PR following the discussion here - https://github.com/urfave/cli/discussions/1716 - about adding [Frogbot](https://github.com/jfrog/frogbot#readme) to this repository.

This PR includes two GitHub workflow files.
`frogbot-scan-and-fix.yml` - to allow scanning PRs.
`frogbot-scan-pr.yml` - to scan the repository following new commits.

## Special notes for your reviewer:

This PR should be merged after the steps discussed in https://github.com/urfave/cli/discussions/1716 are implemeneted.

## Testing

After the merge, we can test this by opening a test pull request and allow Frogbot to scan it. Then, following a merge of a pull request, we can look at the logs of workflow run added by `frogbot-scan-pr.yml`, to see it includes no errors.

## Release Notes

```release-note
Frogbot added to this repository
```
