### PR TITLE
Bug/fix issue 1703

### DIFF
--- a/help.go
+++ b/help.go
@@ -84,19 +84,6 @@ var helpCommand = &Command{
 	},
 }
 
-func anyFlag(candidates []string, flags []Flag) bool {
-	for _, flag := range flags {
-		for _, alias := range flag.Names() {
-			for _, c := range candidates {
-				if c == alias {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
 // Prints help for the App or Command
 type helpPrinter func(w io.Writer, templ string, data interface{})
 

--- a/help.go
+++ b/help.go
@@ -42,6 +42,7 @@ var helpCommand = &Command{
 		// 3 $ app foo
 		// 4 $ app help foo
 		// 5 $ app foo help
+		// 6 $ app foo -h (with no other sub-commands nor flags defined)
 
 		// Case 4. when executing a help command set the context to parent
 		// to allow resolution of subsequent args. This will transform
@@ -77,8 +78,23 @@ var helpCommand = &Command{
 			HelpPrinter(cCtx.App.Writer, templ, cCtx.Command)
 			return nil
 		}
+
+		// Case 6, handling incorporated in the callee itself
 		return ShowSubcommandHelp(cCtx)
 	},
+}
+
+func anyFlag(candidates []string, flags []Flag) bool {
+	for _, flag := range flags {
+		for _, alias := range flag.Names() {
+			for _, c := range candidates {
+				if c == alias {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // Prints help for the App or Command
@@ -292,8 +308,12 @@ func ShowSubcommandHelp(cCtx *Context) error {
 	if cCtx == nil {
 		return nil
 	}
-
-	HelpPrinter(cCtx.App.Writer, SubcommandHelpTemplate, cCtx.Command)
+	// use custom template when provided (fixes #1703)
+	templ := SubcommandHelpTemplate
+	if cCtx.Command != nil && cCtx.Command.CustomHelpTemplate != "" {
+		templ = cCtx.Command.CustomHelpTemplate
+	}
+	HelpPrinter(cCtx.App.Writer, templ, cCtx.Command)
 	return nil
 }
 

--- a/help_test.go
+++ b/help_test.go
@@ -1126,38 +1126,6 @@ func TestHideHelpCommand_WithSubcommands(t *testing.T) {
 	}
 }
 
-func TestHideHelpCommand_RunAsSubcommand_False_CustomTemplate(t *testing.T) {
-	var buf bytes.Buffer
-
-	app := &App{
-		Writer: &buf,
-		Commands: []*Command{
-			{
-				Name:               "dummy",
-				CustomHelpTemplate: "TEMPLATE",
-				HideHelpCommand:    false,
-			},
-		},
-	}
-
-	err := app.RunAsSubcommand(newContextFromStringSlice([]string{"", "dummy", "help"}))
-	if err != nil {
-		t.Errorf("Run returned unexpected error: %v", err)
-	}
-	if !strings.Contains(buf.String(), "TEMPLATE") {
-		t.Errorf("Custom Help template ignored")
-	}
-	buf.Reset()
-
-	err = app.RunAsSubcommand(newContextFromStringSlice([]string{"", "dummy", "-h"}))
-	if err != nil {
-		t.Errorf("Run returned unexpected error: %v", err)
-	}
-	if !strings.Contains(buf.String(), "TEMPLATE") {
-		t.Errorf("Custom Help template ignored")
-	}
-}
-
 func TestHideHelpCommand_RunAsSubcommand_True_CustomTemplate(t *testing.T) {
 	var buf bytes.Buffer
 

--- a/help_test.go
+++ b/help_test.go
@@ -1126,6 +1126,61 @@ func TestHideHelpCommand_WithSubcommands(t *testing.T) {
 	}
 }
 
+func TestHideHelpCommand_RunAsSubcommand_False_CustomTemplate(t *testing.T) {
+	var buf bytes.Buffer
+
+	app := &App{
+		Writer: &buf,
+		Commands: []*Command{
+			{
+				Name:               "dummy",
+				CustomHelpTemplate: "TEMPLATE",
+				HideHelpCommand:    false,
+			},
+		},
+	}
+
+	err := app.RunAsSubcommand(newContextFromStringSlice([]string{"", "dummy", "help"}))
+	if err != nil {
+		t.Errorf("Run returned unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "TEMPLATE") {
+		t.Errorf("Custom Help template ignored")
+	}
+	buf.Reset()
+
+	err = app.RunAsSubcommand(newContextFromStringSlice([]string{"", "dummy", "-h"}))
+	if err != nil {
+		t.Errorf("Run returned unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "TEMPLATE") {
+		t.Errorf("Custom Help template ignored")
+	}
+}
+
+func TestHideHelpCommand_RunAsSubcommand_True_CustomTemplate(t *testing.T) {
+	var buf bytes.Buffer
+
+	app := &App{
+		Writer: &buf,
+		Commands: []*Command{
+			{
+				Name:               "dummy",
+				CustomHelpTemplate: "TEMPLATE",
+				HideHelpCommand:    true,
+			},
+		},
+	}
+
+	err := app.RunAsSubcommand(newContextFromStringSlice([]string{"", "dummy", "-h"}))
+	if err != nil {
+		t.Errorf("Run returned unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "TEMPLATE") {
+		t.Errorf("Custom Help template ignored")
+	}
+}
+
 func TestDefaultCompleteWithFlags(t *testing.T) {
 	origEnv := os.Environ()
 	origArgv := os.Args


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?



<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

fixes #1703

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

Let me know if you want the solution somewhere else in the code-base.

I noticed that you try to contain corner case handling to the `helpCommand.Action` callback. However I'm not familiar enough with the code-base to fully understand what the right set of conditions would be by comparing various disparate but seemingly interconnected objects and fields/attributes.

Instead I went for the most intuitive solution of simply ensuring that whenever the help command is about to be rendered, instead of assuming that the caller has populated the cCtx correctly, I used _defensive programming_ to ensure honoring the intent of using a custom template for given command, at the closest location to the template use, if the command happens to have one defined.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

Two unit tests added. One for the happy path to ensure the behavior didn't change in that regard. The other for the error path which triggers the bug and which this fix addresses.

tests were performed by running `make test`

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
* Custom help templates are now used when -h[elp] flag is given, even when no sub-commands are defined. 
```
