### PR TITLE
Fix func name referenced in doc comment

### DIFF
--- a/app.go
+++ b/app.go
@@ -333,7 +333,7 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 }
 
 // RunAsSubcommand is for legacy/compatibility purposes only. New code should only
-// use App.RunContextMost. This function is slated to be removed in v3
+// use App.RunContext. This function is slated to be removed in v3.
 func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	a.Setup()
 

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -358,7 +358,7 @@ func (a *App) RunAndExitOnError()
 
 func (a *App) RunAsSubcommand(ctx *Context) (err error)
     RunAsSubcommand is for legacy/compatibility purposes only. New code should
-    only use App.RunContextMost. This function is slated to be removed in v3
+    only use App.RunContext. This function is slated to be removed in v3.
 
 func (a *App) RunContext(ctx context.Context, arguments []string) (err error)
     RunContext is like Run except it takes a Context that will be passed to

--- a/testdata/godoc-v2.x.txt
+++ b/testdata/godoc-v2.x.txt
@@ -358,7 +358,7 @@ func (a *App) RunAndExitOnError()
 
 func (a *App) RunAsSubcommand(ctx *Context) (err error)
     RunAsSubcommand is for legacy/compatibility purposes only. New code should
-    only use App.RunContextMost. This function is slated to be removed in v3
+    only use App.RunContext. This function is slated to be removed in v3.
 
 func (a *App) RunContext(ctx context.Context, arguments []string) (err error)
     RunContext is like Run except it takes a Context that will be passed to


### PR DESCRIPTION
## What type of PR is this?

- cleanup
- documentation

## What this PR does / why we need it:

Reference a function/method that exists instead of one that does not exist 😁 

## Which issue(s) this PR fixes:

N/A 😬 