### PR TITLE
Output usage errors to ErrWriter

### DIFF
--- a/command.go
+++ b/command.go
@@ -368,10 +368,10 @@ func (cmd *Command) Run(ctx context.Context, arguments []string) (deferErr error
 			err = cCtx.Command.handleExitCoder(cCtx, err)
 			return err
 		}
-		_, _ = fmt.Fprintf(cCtx.Command.Root().Writer, "%s %s\n\n", "Incorrect Usage:", err.Error())
+		_, _ = fmt.Fprintf(cCtx.Command.Root().ErrWriter, "%s %s\n\n", "Incorrect Usage:", err.Error())
 		if cCtx.Command.Suggest {
 			if suggestion, err := cmd.suggestFlagFromError(err, ""); err == nil {
-				fmt.Fprintf(cCtx.Command.Root().Writer, "%s", suggestion)
+				fmt.Fprintf(cCtx.Command.Root().ErrWriter, "%s", suggestion)
 			}
 		}
 		if !cmd.HideHelp {

--- a/examples_test.go
+++ b/examples_test.go
@@ -547,7 +547,8 @@ func ExampleCommand_Suggest() {
 
 func ExampleCommand_Suggest_command() {
 	cmd := &cli.Command{
-		Name: "greet",
+		ErrWriter: os.Stdout,
+		Name:      "greet",
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "name", Value: "squirrel", Usage: "a name to say"},
 		},
@@ -558,7 +559,6 @@ func ExampleCommand_Suggest_command() {
 		Commands: []*cli.Command{
 			{
 				Name:               "neighbors",
-				ErrWriter:          os.Stdout,
 				HideHelp:           true,
 				HideHelpCommand:    true,
 				Suggest:            true,


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

Usage errors were being output to stdout (command.Writer) instead of stderr (command.ErrWriter).

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Usage errors now go to the stderr stream. To capture them, use `command 2>&1 > foo.txt`.
If you have used something like `Writer: io.Discard` to suppress errors, you now need to suppress
them also for `ErrWriter`.
```
