### PR TITLE
Replace fmt.Sprintf's with strconv.Format's

### DIFF
--- a/flag_bool.go
+++ b/flag_bool.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -48,7 +47,7 @@ func (i boolValue) Create(val bool, p *bool, c BoolConfig) Value {
 
 // ToString formats the bool value
 func (i boolValue) ToString(b bool) string {
-	return fmt.Sprintf("%v", b)
+	return strconv.FormatBool(b)
 }
 
 // Below functions are to satisfy the flag.Value interface

--- a/flag_float.go
+++ b/flag_float.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"strconv"
 )
 
@@ -18,7 +17,7 @@ func (f floatValue) Create(val float64, p *float64, c NoConfig) Value {
 }
 
 func (f floatValue) ToString(b float64) string {
-	return fmt.Sprintf("%v", b)
+	return strconv.FormatFloat(b, 'g', -1, 64)
 }
 
 // Below functions are to satisfy the flag.Value interface

--- a/flag_int.go
+++ b/flag_int.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"strconv"
 )
 
@@ -29,7 +28,7 @@ func (i intValue) Create(val int64, p *int64, c IntegerConfig) Value {
 }
 
 func (i intValue) ToString(b int64) string {
-	return fmt.Sprintf("%d", b)
+	return strconv.FormatInt(b, 10)
 }
 
 // Below functions are to satisfy the flag.Value interface

--- a/flag_uint.go
+++ b/flag_uint.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"strconv"
 )
 
@@ -24,7 +23,7 @@ func (i uintValue) Create(val uint64, p *uint64, c IntegerConfig) Value {
 }
 
 func (i uintValue) ToString(b uint64) string {
-	return fmt.Sprintf("%d", b)
+	return strconv.FormatUint(b, 10)
 }
 
 // Below functions are to satisfy the flag.Value interface


### PR DESCRIPTION
## What type of PR is this?

- Non-functional (performance)

## What this PR does / why we need it:

This change swaps the `ToString` implementation under the hood of flag_[bool|float|int|uint].go to use `strconv` package instead of `fmt` package.

This is a non-functional change to optimize the `ToString` operation for [bool|float|int|uint] flags.

## Which issue(s) this PR fixes:

None

## Testing

```
var numToConvert uint64 = 100000000

func BenchmarkFmt(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = fmt.Sprintf("%d", numToConvert)
	}
}

func BenchmarkStrconv(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = strconv.FormatUint(numToConvert, 10)
	}
}
```

```
BenchmarkFmt-8           7687989               154.1 ns/op
BenchmarkStrconv-8      21892513                52.77 ns/op
```

## Release Notes

No user facing changes.
