### PR TITLE
Always get 0 for a nested int64 value in v2.25.7

### DIFF
--- a/altsrc/map_input_source.go
+++ b/altsrc/map_input_source.go
@@ -159,7 +159,7 @@ func (fsm *MapInputSource) Int64(name string) (int64, error) {
 	}
 	nestedGenericValue, exists := nestedVal(name, fsm.valueMap)
 	if exists {
-		otherValue, isType := castToInt64(otherGenericValue)
+		otherValue, isType := castToInt64(nestedGenericValue)
 		if !isType {
 			return 0, incorrectTypeForFlagError(name, "int64", nestedGenericValue)
 		}


### PR DESCRIPTION
## bug fix

- always get 0 for a nested int64 value in v2.25.7

