### PR TITLE
Helper messages for documenting build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .*envrc
 .envrc
 .idea
+# goimports is installed here if not available
 /.local/
 /site/
 coverage.txt

--- a/cmd/urfave-cli-genflags/generated.gotmpl
+++ b/cmd/urfave-cli-genflags/generated.gotmpl
@@ -5,46 +5,46 @@ package {{.PackageName}}
 {{range .SortedFlagTypes}}
 // {{.TypeName}} is a flag with type {{if .ValuePointer}}*{{end}}{{.GoType}}
 type {{.TypeName}} struct {
-  Name string
+	Name string
 
-  Category string
-  DefaultText string
-  FilePath string
-  Usage string
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
 
-  Required bool
-  Hidden bool
-  HasBeenSet bool
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
 
-  Value {{if .ValuePointer}}*{{end}}{{.GoType}}
-  Destination {{if .NoDestinationPointer}}{{else}}*{{end}}{{.GoType}}
+	Value       {{if .ValuePointer}}*{{end}}{{.GoType}}
+	Destination {{if .NoDestinationPointer}}{{else}}*{{end}}{{.GoType}}
 
-  Aliases []string
-  EnvVars []string
+	Aliases []string
+	EnvVars []string
 
-  defaultValue {{if .ValuePointer}}*{{end}}{{.GoType}}
+	defaultValue {{if .ValuePointer}}*{{end}}{{.GoType}}
   
-  {{range .StructFields}}
-  {{.Name}} {{if .Pointer}}*{{end}}{{.Type}}
-  {{end}}
+	{{range .StructFields}}
+	{{.Name}} {{if .Pointer}}*{{end}}{{.Type}}
+	{{end}}
 }
 
 {{if .GenerateFmtStringerInterface}}
 // String returns a readable representation of this value (for usage defaults)
 func (f *{{.TypeName}}) String() string {
-  return {{$.UrfaveCLINamespace}}FlagStringer(f)
+	return {{$.UrfaveCLINamespace}}FlagStringer(f)
 }
 {{end}}{{/* /if .GenerateFmtStringerInterface */}}
 
 {{if .GenerateFlagInterface}}
 // IsSet returns whether or not the flag has been set through env or file
 func (f *{{.TypeName}}) IsSet() bool {
-  return f.HasBeenSet
+	return f.HasBeenSet
 }
 
 // Names returns the names of the flag
 func (f *{{.TypeName}}) Names() []string {
-  return {{$.UrfaveCLINamespace}}FlagNames(f.Name, f.Aliases)
+	return {{$.UrfaveCLINamespace}}FlagNames(f.Name, f.Aliases)
 }
 
 {{end}}{{/* /if .GenerateFlagInterface */}}
@@ -52,7 +52,7 @@ func (f *{{.TypeName}}) Names() []string {
 {{if .GenerateRequiredFlagInterface}}
 // IsRequired returns whether or not the flag is required
 func (f *{{.TypeName}}) IsRequired() bool {
-  return f.Required
+	return f.Required
 }
 {{end}}{{/* /if .GenerateRequiredFlagInterface */}}
 

--- a/cmd/urfave-cli-genflags/generated.gotmpl
+++ b/cmd/urfave-cli-genflags/generated.gotmpl
@@ -1,4 +1,4 @@
-// WARNING: this file is generated. DO NOT EDIT
+{{.HeaderWarning}}
 
 package {{.PackageName}}
 

--- a/cmd/urfave-cli-genflags/generated.gotmpl
+++ b/cmd/urfave-cli-genflags/generated.gotmpl
@@ -2,7 +2,7 @@
 
 package {{.PackageName}}
 
-{{range .SortedFlagTypes}}
+{{range .SortedFlagTypes -}}
 // {{.TypeName}} is a flag with type {{if .ValuePointer}}*{{end}}{{.GoType}}
 type {{.TypeName}} struct {
 	Name string
@@ -23,20 +23,20 @@ type {{.TypeName}} struct {
 	EnvVars []string
 
 	defaultValue {{if .ValuePointer}}*{{end}}{{.GoType}}
-  
-	{{range .StructFields}}
+{{ range .StructFields}}
 	{{.Name}} {{if .Pointer}}*{{end}}{{.Type}}
-	{{end}}
+{{end -}}
 }
 
-{{if .GenerateFmtStringerInterface}}
+{{if .GenerateFmtStringerInterface -}}
 // String returns a readable representation of this value (for usage defaults)
 func (f *{{.TypeName}}) String() string {
 	return {{$.UrfaveCLINamespace}}FlagStringer(f)
 }
+
 {{end}}{{/* /if .GenerateFmtStringerInterface */}}
 
-{{if .GenerateFlagInterface}}
+{{- if .GenerateFlagInterface -}}
 // IsSet returns whether or not the flag has been set through env or file
 func (f *{{.TypeName}}) IsSet() bool {
 	return f.HasBeenSet
@@ -49,14 +49,15 @@ func (f *{{.TypeName}}) Names() []string {
 
 {{end}}{{/* /if .GenerateFlagInterface */}}
 
-{{if .GenerateRequiredFlagInterface}}
+{{- if .GenerateRequiredFlagInterface -}}
 // IsRequired returns whether or not the flag is required
 func (f *{{.TypeName}}) IsRequired() bool {
 	return f.Required
 }
+
 {{end}}{{/* /if .GenerateRequiredFlagInterface */}}
 
-{{if .GenerateVisibleFlagInterface}}
+{{- if .GenerateVisibleFlagInterface -}}
 // IsVisible returns true if the flag is not hidden, otherwise false
 func (f *{{.TypeName}}) IsVisible() bool {
 	return !f.Hidden
@@ -64,7 +65,7 @@ func (f *{{.TypeName}}) IsVisible() bool {
 {{end}}{{/* /if .GenerateVisibleFlagInterface */}}
 {{end}}{{/* /range .SortedFlagTypes */}}
 
-// vim{{/* 👻 */}}:ro
-{{/*
+{{- "// vim"}}:ro
+{{- /* 👻
 vim:filetype=gotexttmpl
 */}}

--- a/cmd/urfave-cli-genflags/main.go
+++ b/cmd/urfave-cli-genflags/main.go
@@ -225,6 +225,10 @@ type Spec struct {
 	UrfaveCLITestNamespace string                     `yaml:"urfave_cli_test_namespace"`
 }
 
+func (Spec) HeaderWarning() string {
+	return "// WARNING: this file is generated. DO NOT EDIT"
+}
+
 func (gfs *Spec) SortedFlagTypes() []*FlagType {
 	typeNames := []string{}
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -82,6 +82,7 @@ func main() {
 			{
 				Name:   "generate",
 				Action: GenerateActionFunc,
+				Usage:  "generate API docs",
 			},
 			{
 				Name: "yamlfmt",
@@ -496,6 +497,7 @@ func checkBinarySizeActionFunc(c *cli.Context) (err error) {
 func GenerateActionFunc(cCtx *cli.Context) error {
 	top := cCtx.Path("top")
 
+	log.Println("--- generating godoc-current.txt API reference ---")
 	cliDocs, err := sh("go", "doc", "-all", top)
 	if err != nil {
 		return err
@@ -514,6 +516,7 @@ func GenerateActionFunc(cCtx *cli.Context) error {
 		return err
 	}
 
+	log.Println("--- generating Go source files ---")
 	return runCmd("go", "generate", cCtx.Path("top")+"/...")
 }
 


### PR DESCRIPTION
I don't have `goimports` installed, and running `make` as described in https://cli.urfave.org/CONTRIBUTING/#development-workflow fails.

```
./urfave-cli-genflags	
which: no goimports in ...
```

Took this opportunity to enhance the process a bit.

I see that `zz_generated.flags.go` is invalid without `goimports` (for whatever reason it is needed). And I need to check why `goimports` is not installed into `./.local/bin` automatically.

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Create valid output from `make` call even if `goimports` is not installed.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note

```
