### PR TITLE
fix: check duplicated sub command name and alias

### DIFF
--- a/app.go
+++ b/app.go
@@ -329,6 +329,9 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 	a.rootCommand = a.newRootCommand()
 	cCtx.Command = a.rootCommand
 
+	if err := checkDuplicatedCmds(a.rootCommand); err != nil {
+		return err
+	}
 	return a.rootCommand.Run(cCtx, arguments...)
 }
 

--- a/command.go
+++ b/command.go
@@ -149,6 +149,9 @@ func (c *Command) Run(cCtx *Context, arguments ...string) (err error) {
 
 	if !c.isRoot {
 		c.setup(cCtx)
+		if err := checkDuplicatedCmds(c); err != nil {
+			return err
+		}
 	}
 
 	a := args(arguments)
@@ -403,4 +406,17 @@ func hasCommand(commands []*Command, command *Command) bool {
 	}
 
 	return false
+}
+
+func checkDuplicatedCmds(parent *Command) error {
+	seen := make(map[string]struct{})
+	for _, c := range parent.Subcommands {
+		for _, name := range c.Names() {
+			if _, exists := seen[name]; exists {
+				return fmt.Errorf("parent command [%s] has duplicated subcommand name or alias: %s", parent.Name, name)
+			}
+			seen[name] = struct{}{}
+		}
+	}
+	return nil
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -17,3 +17,11 @@ func expect(t *testing.T, a interface{}, b interface{}) {
 		t.Errorf("Expected %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
 	}
 }
+
+func expectNotEqual(t *testing.T, a interface{}, b interface{}) {
+	t.Helper()
+
+	if reflect.DeepEqual(a, b) {
+		t.Errorf("Expected not equal, but got: %v (type %v), %v (type %v) ", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	}
+}


### PR DESCRIPTION

## What type of PR is this?
- bug

## What this PR does / why we need it:

Fix https://github.com/urfave/cli/issues/785.

## Which issue(s) this PR fixes:

Fix https://github.com/urfave/cli/issues/785


## Special notes for your reviewer:

This fix is only for v2. Do we need to fix it in other versions?

## Testing

- I test it in unit test.
- Also, I write a dummy program and see the output:

```golang
package main

import (
	"fmt"

	"github.com/urfave/cli/v2"
)

func main() {
	app := &cli.App{
		Name: "linrl3",
		Commands: []*cli.Command{
			{Name: "sub1"},
			{Name: "sub1"},
		},
	}
	if err := app.Run([]string{"linrl3", "sub1"}); err != nil {
		fmt.Println(err)
	}
}
```
result: 
```
result:
➜  cli git:(fix/v2_duplicate_subcommand) ✗ go run cmd/dummyrun/main.go
parent command [linrl3] has duplicated subcommand name or alias: sub1
```
<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
- fix: if sub-commands in the same level have same name or alias, an error would return
```
