### PR TITLE
Make v3 examples runnable on pkg.go.dev

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -7,7 +7,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/urfave/cli/v3"
+	// Alias the package import to make the examples runnable on pkg.go.dev.
+	//
+	// See issue #1811.
+	cli "github.com/urfave/cli/v3"
 )
 
 func ExampleCommand_Run() {


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- documentation

## What this PR does / why we need it:

Makes the examples rendered on pkg.go.dev runnable for v3.

## Which issue(s) this PR fixes:
Fixes https://github.com/urfave/cli/issues/1811.

## Testing
1. Install [pkgsite](https://pkg.go.dev/golang.org/x/pkgsite).
```
go install golang.org/x/pkgsite/cmd/pkgsite@latest
```
2. Browse to the `cli` repository root.
3. Run `pkgsite`
```
pkgsite
```
4. Browse to http://localhost:8080/github.com/urfave/cli/v3#example-Command.Run-NoAction

The existing examples have no `main` function and are not runnable:
<img width="1155" alt="Screenshot 2023-09-02 at 2 57 17 PM" src="https://github.com/urfave/cli/assets/9760375/beb37ef4-f355-4e6f-b8c1-1f30cce688cb">

The fixed examples have a `main` and a "Run" button:
<img width="1165" alt="Screenshot 2023-09-02 at 2 56 48 PM" src="https://github.com/urfave/cli/assets/9760375/0b35cc6d-b1bc-4efc-bb56-e003ae3cc718">

## Release Notes

```release-note
Make v3 examples runnable on pkg.go.dev.
```
