### PR TITLE
Remove redundant nil check in `LocalFlagNames`

### DIFF
--- a/command.go
+++ b/command.go
@@ -922,11 +922,9 @@ func (cmd *Command) LocalFlagNames() []string {
 	cmd.flagSet.Visit(makeFlagNameVisitor(&names))
 
 	// Check the flags which have been set via env or file
-	if cmd.Flags != nil {
-		for _, f := range cmd.Flags {
-			if f.IsSet() {
-				names = append(names, f.Names()...)
-			}
+	for _, f := range cmd.Flags {
+		if f.IsSet() {
+			names = append(names, f.Names()...)
 		}
 	}
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- cleanup

## What this PR does / why we need it:

From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/_cXfzMOvMm3

## Testing

```
go test ./...
?   	github.com/urfave/cli/v3/internal/build	[no test files]
?   	github.com/urfave/cli/v3/internal/example-cli	[no test files]
?   	github.com/urfave/cli/v3/internal/example-hello-world	[no test files]
ok  	github.com/urfave/cli/v3	0.101s
```

## Release Notes

```release-note
NONE
```
