### PR TITLE
Fix:(issue_1720) Add support for reading args from stdin

### DIFF
--- a/command.go
+++ b/command.go
@@ -408,9 +408,10 @@ outer:
 				if token != "" {
 					args = append(args, token)
 					token = ""
-				} else {
-					//TODO. Should we pass in empty strings ?
 				}
+				/*else {
+					//TODO. Should we pass in empty strings ?
+				}*/
 				st = STATE_SEARCH_FOR_TOKEN
 			}
 		}

--- a/command.go
+++ b/command.go
@@ -344,7 +344,7 @@ func (cmd *Command) ensureHelp() {
 }
 
 func (cmd *Command) parseArgsFromStdin() ([]string, error) {
-	b, err := io.ReadAll(os.Stdin)
+	b, err := io.ReadAll(cmd.Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -3883,16 +3883,10 @@ bar2
 `)
 	fp.Close()
 
-	oldIn := os.Stdin
-	defer func() {
-		os.Remove(fp.Name())
-		os.Stdin = oldIn
-	}()
-	os.Stdin, err = os.Open(fp.Name())
-	r.NoError(err)
-
 	cmd := buildMinimalTestCommand()
 	cmd.ReadArgsFromStdin = true
+	cmd.Reader, err = os.Open(fp.Name())
+	r.NoError(err)
 	cmd.Flags = []Flag{
 		&IntFlag{
 			Name: "if",

--- a/command_test.go
+++ b/command_test.go
@@ -3969,6 +3969,16 @@ func TestCommandReadArgsFromStdIn(t *testing.T) {
 			args:        []string{"foo"},
 			expectError: true,
 		},
+		{
+			name: "incomplete string",
+			input: `
+			--ssf
+			"
+			hello
+			`,
+			args:          []string{"foo"},
+			expectedSlice: []string{"hello"},
+		},
 	}
 
 	for _, tst := range tests {

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -394,6 +394,9 @@ type Command struct {
 	MutuallyExclusiveFlags []MutuallyExclusiveFlags
 	// Arguments to parse for this command
 	Arguments []Argument
+	// Whether to read arguments from stdin
+	// applicable to root command only
+	ReadArgsFromStdin bool
 
 	// Has unexported fields.
 }

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -394,6 +394,9 @@ type Command struct {
 	MutuallyExclusiveFlags []MutuallyExclusiveFlags
 	// Arguments to parse for this command
 	Arguments []Argument
+	// Whether to read arguments from stdin
+	// applicable to root command only
+	ReadArgsFromStdin bool
 
 	// Has unexported fields.
 }


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

Fixes #1720 

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

go test -run=TestCommandReadArgsFromStdIn

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

A new field 'ReadArgsFromStdin' has been added to Command. This flag will be applicable to root command only and will allow the root command to process arguments from cmdline as well as from standard input. 

```release-note

```
