### PR TITLE
v2: Add build tag urfave_cli_no_suggest

### DIFF
--- a/app.go
+++ b/app.go
@@ -23,8 +23,8 @@ var (
 		fmt.Sprintf("See %s", appActionDeprecationURL), 2)
 	ignoreFlagPrefix = "test." // this is to ignore test flags when adding flags from other packages
 
-	SuggestFlag               SuggestFlagFunc    = suggestFlag
-	SuggestCommand            SuggestCommandFunc = suggestCommand
+	SuggestFlag               SuggestFlagFunc    = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestCommand            SuggestCommandFunc = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
 	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
 )
 
@@ -366,6 +366,9 @@ func (a *App) suggestFlagFromError(err error, command string) (string, error) {
 		hideHelp = hideHelp || cmd.HideHelp
 	}
 
+	if SuggestFlag == nil {
+		return "", err
+	}
 	suggestion := SuggestFlag(flags, flag, hideHelp)
 	if len(suggestion) == 0 {
 		return "", err

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -27,8 +27,8 @@ application:
 VARIABLES
 
 var (
-	SuggestFlag               SuggestFlagFunc    = suggestFlag
-	SuggestCommand            SuggestCommandFunc = suggestCommand
+	SuggestFlag               SuggestFlagFunc    = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestCommand            SuggestCommandFunc = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
 	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
 )
 var AppHelpTemplate = `NAME:

--- a/help.go
+++ b/help.go
@@ -278,7 +278,7 @@ func ShowCommandHelp(ctx *Context, command string) error {
 
 	if ctx.App.CommandNotFound == nil {
 		errMsg := fmt.Sprintf("No help topic for '%v'", command)
-		if ctx.App.Suggest {
+		if ctx.App.Suggest && SuggestCommand != nil {
 			if suggestion := SuggestCommand(ctx.Command.Subcommands, command); suggestion != "" {
 				errMsg += ". " + suggestion
 			}

--- a/suggestions.go
+++ b/suggestions.go
@@ -1,3 +1,6 @@
+//go:build !urfave_cli_no_suggest
+// +build !urfave_cli_no_suggest
+
 package cli
 
 import (
@@ -5,6 +8,11 @@ import (
 
 	"github.com/xrash/smetrics"
 )
+
+func init() {
+	SuggestFlag = suggestFlag
+	SuggestCommand = suggestCommand
+}
 
 func jaroWinkler(a, b string) float64 {
 	// magic values are from https://github.com/xrash/smetrics/blob/039620a656736e6ad994090895784a7af15e0b80/jaro-winkler.go#L8

--- a/suggestions_test.go
+++ b/suggestions_test.go
@@ -1,3 +1,6 @@
+//go:build !urfave_cli_no_suggest
+// +build !urfave_cli_no_suggest
+
 package cli
 
 import (

--- a/testdata/godoc-v2.x.txt
+++ b/testdata/godoc-v2.x.txt
@@ -27,8 +27,8 @@ application:
 VARIABLES
 
 var (
-	SuggestFlag               SuggestFlagFunc    = suggestFlag
-	SuggestCommand            SuggestCommandFunc = suggestCommand
+	SuggestFlag               SuggestFlagFunc    = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestCommand            SuggestCommandFunc = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
 	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
 )
 var AppHelpTemplate = `NAME:


### PR DESCRIPTION
## What type of PR is this?

- cleanup
- feature

## What this PR does / why we need it:

Like `urfave_cli_no_docs` (in docs.go), allow to disable flag and command suggestions at build time (and drop dependency on module [`github.com/xrash/smetrics`](https://pkg.go.dev/github.com/xrash/smetrics)) with a new `urfave_cli_no_suggest` build tag:

```console
$ go build -tags urfave_cli_no_suggest,urfave_cli_no_docs
```


## Release Notes

```release-note
Add `urfave_cli_no_suggest` build tag to disable suggestions and drop dependency on module [`github.com/xrash/smetrics`](https://pkg.go.dev/github.com/xrash/smetrics) for smaller binaries.
```
