### PR TITLE
Backport Show non categorized flags with categorized on help

### DIFF
--- a/category.go
+++ b/category.go
@@ -100,10 +100,24 @@ func newFlagCategories() FlagCategories {
 
 func newFlagCategoriesFromFlags(fs []Flag) FlagCategories {
 	fc := newFlagCategories()
+
+	var categorized bool
+
 	for _, fl := range fs {
 		if cf, ok := fl.(CategorizableFlag); ok {
-			if cf.GetCategory() != "" {
-				fc.AddFlag(cf.GetCategory(), fl)
+			if cat := cf.GetCategory(); cat != "" {
+				fc.AddFlag(cat, fl)
+				categorized = true
+			}
+		}
+	}
+
+	if categorized {
+		for _, fl := range fs {
+			if cf, ok := fl.(CategorizableFlag); ok {
+				if cf.GetCategory() == "" {
+					fc.AddFlag("", fl)
+				}
 			}
 		}
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -526,12 +526,15 @@ func TestCommand_VisibleFlagCategories(t *testing.T) {
 	}
 
 	vfc := cmd.VisibleFlagCategories()
-	require.NotEmpty(t, vfc)
-	assert.Equal(t, vfc[0].Name(), "cat1", "expected category name cat1")
+	require.Len(t, vfc, 2)
 
-	require.Len(t, vfc[0].Flags(), 1, "expected flag category to have just one flag")
+	assert.Equal(t, vfc[0].Name(), "", "expected category name to be empty")
 
-	fl := vfc[0].Flags()[0]
+	assert.Equal(t, vfc[1].Name(), "cat1", "expected category name cat1")
+
+	require.Len(t, vfc[1].Flags(), 1, "expected flag category to have just one flag")
+
+	fl := vfc[1].Flags()[0]
 	assert.Equal(t, fl.Names(), []string{"intd", "altd1", "altd2"})
 }
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug
- feature

## What this PR does / why we need it:

Reverting the removal of visible flags from help if their sibling flags have categories defined.

Example:

```
App:
    Flags:
        Flag1: // non categorized
        Flag2: Category1
        
Help Before PR:
    Options:
      Category1
        Flag2
        
Help After:
    Options:
        Flag1
      
      Category1
        Flag2
```

## Which issue(s) this PR fixes:

fixes #1672 for version 3

## Special notes for your reviewer:

This is a backport  (or forwardport in our case) of #1673

## Testing

- Unit tests added
- Example application tryed

## Release Notes

```release-note
Reverted removal of non categorized flags alongside categorized flags
```
