### PR TITLE
Cleanup: Remove unnecessary intermediate variables

### DIFF
--- a/app.go
+++ b/app.go
@@ -229,8 +229,6 @@ func (a *App) Setup() {
 		a.separator.disabled = true
 	}
 
-	var newCommands []*Command
-
 	for _, c := range a.Commands {
 		cname := c.Name
 		if c.HelpName != "" {
@@ -239,9 +237,7 @@ func (a *App) Setup() {
 		c.separator = a.separator
 		c.HelpName = fmt.Sprintf("%s %s", a.HelpName, cname)
 		c.flagCategories = newFlagCategoriesFromFlags(c.Flags)
-		newCommands = append(newCommands, c)
 	}
-	a.Commands = newCommands
 
 	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
 		if !a.HideHelpCommand {

--- a/command.go
+++ b/command.go
@@ -132,15 +132,12 @@ func (c *Command) setup(ctx *Context) {
 	}
 	sort.Sort(c.categories.(*commandCategories))
 
-	var newCmds []*Command
 	for _, scmd := range c.Subcommands {
 		if scmd.HelpName == "" {
 			scmd.HelpName = fmt.Sprintf("%s %s", c.HelpName, scmd.Name)
 		}
 		scmd.separator = c.separator
-		newCmds = append(newCmds, scmd)
 	}
-	c.Subcommands = newCmds
 
 	if c.BashComplete == nil {
 		c.BashComplete = DefaultCompleteWithFlags(c)


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

In the initial version of the code, `Commands` is of type `[]Command`.

https://github.com/urfave/cli/blob/aced6e8739166ac46d05f741f60891d3cf2331e9/app.go#L25

In this case iterating over Commands using range will generate intermediate variables, so it needs to be written as follows

https://github.com/urfave/cli/blob/aced6e8739166ac46d05f741f60891d3cf2331e9/app.go#L90-L95

But this part of the code has changed in the last decade. Now, `Commands` is of type `[]*Command` and, in my opinion, there is no need to manipulate intermediate variables.

https://github.com/urfave/cli/blob/7656c5fb838ca8a6febca43100147d317b544fd3/app.go#L54

https://github.com/urfave/cli/blob/7656c5fb838ca8a6febca43100147d317b544fd3/app.go#L232-L244

The same reason is true for the removal of code in cli/command.go.

https://github.com/urfave/cli/blob/aced6e8739166ac46d05f741f60891d3cf2331e9/command.go#L34

https://github.com/urfave/cli/blob/aced6e8739166ac46d05f741f60891d3cf2331e9/command.go#L197-L202

https://github.com/urfave/cli/blob/7656c5fb838ca8a6febca43100147d317b544fd3/command.go#L42

https://github.com/urfave/cli/blob/7656c5fb838ca8a6febca43100147d317b544fd3/command.go#L135-L143


## Special notes for your reviewer:

I'm not familiar with the Go language, so please point out any errors in my understanding, and thanks for reviewing.

## Release Notes

```release-note
NONE
```
