### PR TITLE
Adjust code style

### DIFF
--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	bothEnvFlagsAreSetError = fmt.Errorf("cannot set both flags `--env` and `--no-env`")
+	errBothEnvFlagsAreSet = fmt.Errorf("cannot set both flags `--env` and `--no-env`")
 )
 
 type boolWithInverseTestCase struct {
@@ -98,7 +98,7 @@ func TestBoolWithInverseBasic(t *testing.T) {
 		},
 		{
 			args: []string{"--env", "--no-env"},
-			err:  bothEnvFlagsAreSetError,
+			err:  errBothEnvFlagsAreSet,
 		},
 	}
 
@@ -146,7 +146,7 @@ func TestBoolWithInverseAction(t *testing.T) {
 		},
 		{
 			args: []string{"--env", "--no-env"},
-			err:  bothEnvFlagsAreSetError,
+			err:  errBothEnvFlagsAreSet,
 		},
 	}
 
@@ -184,7 +184,7 @@ func TestBoolWithInverseAlias(t *testing.T) {
 		},
 		{
 			args: []string{"--do-env", "--no-do-env"},
-			err:  bothEnvFlagsAreSetError,
+			err:  errBothEnvFlagsAreSet,
 		},
 	}
 
@@ -232,7 +232,7 @@ func TestBoolWithInverseEnvVars(t *testing.T) {
 			value:   false,
 		},
 		{
-			err: bothEnvFlagsAreSetError,
+			err: errBothEnvFlagsAreSet,
 			envVars: map[string]string{
 				"ENV":    "true",
 				"NO-ENV": "true",
@@ -313,7 +313,7 @@ func TestBoolWithInverseRequired(t *testing.T) {
 		},
 		{
 			args: []string{"--env", "--no-env"},
-			err:  bothEnvFlagsAreSetError,
+			err:  errBothEnvFlagsAreSet,
 		},
 	}
 

--- a/flag_mutex_test.go
+++ b/flag_mutex_test.go
@@ -12,7 +12,7 @@ func TestFlagMutuallyExclusiveFlags(t *testing.T) {
 		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
 			{
 				Flags: [][]Flag{
-					[]Flag{
+					{
 						&IntFlag{
 							Name: "i",
 						},
@@ -20,7 +20,7 @@ func TestFlagMutuallyExclusiveFlags(t *testing.T) {
 							Name: "s",
 						},
 					},
-					[]Flag{
+					{
 						&IntFlag{
 							Name:    "t",
 							Aliases: []string{"ai"},


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

- Cleans up some of the type redundancy 
-  change the name of a variable  as recommended by [staticcheck](https://staticcheck.dev/) :
```bash
error var bothEnvFlagsAreSetError should have name of the form errFoo (ST1012)go-staticcheck
```
 

## Which issue(s) this PR fixes:
 N/A
 
## Special notes for your reviewer:

appreciate your greate work.

## Testing
Its just a code style issue. you can run `staticcheck` and `go test ./...` .

## Release Notes

```release-note
clean up type redundancy and fix code style
```
