### PR TITLE
Include mutually exclusive flags in help text

### DIFF
--- a/command.go
+++ b/command.go
@@ -855,7 +855,7 @@ func (cmd *Command) VisibleFlagCategories() []VisibleFlagCategory {
 
 // VisibleFlags returns a slice of the Flags with Hidden=false
 func (cmd *Command) VisibleFlags() []Flag {
-	return visibleFlags(cmd.Flags)
+	return visibleFlags(cmd.allFlags())
 }
 
 func (cmd *Command) appendFlag(fl Flag) {

--- a/command.go
+++ b/command.go
@@ -283,7 +283,7 @@ func (cmd *Command) setupDefaults(osArgs []string) {
 	sort.Sort(cmd.categories.(*commandCategories))
 
 	tracef("setting flag categories (cmd=%[1]q)", cmd.Name)
-	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.Flags)
+	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags())
 
 	if cmd.Metadata == nil {
 		tracef("setting default Metadata (cmd=%[1]q)", cmd.Name)
@@ -325,7 +325,7 @@ func (cmd *Command) setupSubcommand() {
 	sort.Sort(cmd.categories.(*commandCategories))
 
 	tracef("setting flag categories (cmd=%[1]q)", cmd.Name)
-	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.Flags)
+	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags())
 }
 
 func (cmd *Command) ensureHelp() {
@@ -848,7 +848,7 @@ func (cmd *Command) VisibleCommands() []*Command {
 // VisibleFlagCategories returns a slice containing all the visible flag categories with the flags they contain
 func (cmd *Command) VisibleFlagCategories() []VisibleFlagCategory {
 	if cmd.flagCategories == nil {
-		cmd.flagCategories = newFlagCategoriesFromFlags(cmd.Flags)
+		cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags())
 	}
 	return cmd.flagCategories.VisibleCategories()
 }

--- a/command.go
+++ b/command.go
@@ -282,6 +282,11 @@ func (cmd *Command) setupDefaults(osArgs []string) {
 	tracef("sorting command categories (cmd=%[1]q)", cmd.Name)
 	sort.Sort(cmd.categories.(*commandCategories))
 
+	tracef("setting category on mutually exclusive flags (cmd=%[1]q)", cmd.Name)
+	for _, grp := range cmd.MutuallyExclusiveFlags {
+		grp.propagateCategory()
+	}
+
 	tracef("setting flag categories (cmd=%[1]q)", cmd.Name)
 	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags())
 
@@ -323,6 +328,11 @@ func (cmd *Command) setupSubcommand() {
 
 	tracef("sorting command categories (cmd=%[1]q)", cmd.Name)
 	sort.Sort(cmd.categories.(*commandCategories))
+
+	tracef("setting category on mutually exclusive flags (cmd=%[1]q)", cmd.Name)
+	for _, grp := range cmd.MutuallyExclusiveFlags {
+		grp.propagateCategory()
+	}
 
 	tracef("setting flag categories (cmd=%[1]q)", cmd.Name)
 	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags())

--- a/command_test.go
+++ b/command_test.go
@@ -525,38 +525,32 @@ func TestCommand_VisibleFlagCategories(t *testing.T) {
 			},
 		},
 		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{{
+			Category: "cat2",
 			Flags: [][]Flag{
 				{
-					&BoolFlag{
-						Name: "mutexStrd",
-					},
-					&BoolFlag{
-						Name:     "mutexCat1",
-						Category: "cat1",
-					},
-					&BoolFlag{
-						Name:     "mutexCat2",
-						Category: "cat2",
+					&StringFlag{
+						Name: "mutex",
 					},
 				},
 			},
 		}},
 	}
 
+	cmd.MutuallyExclusiveFlags[0].propagateCategory()
+
 	vfc := cmd.VisibleFlagCategories()
 	require.Len(t, vfc, 3)
 
 	assert.Equal(t, vfc[0].Name(), "", "expected category name to be empty")
-	assert.Equal(t, vfc[0].Flags()[0].Names(), []string{"mutexStrd"})
+	assert.Equal(t, vfc[0].Flags()[0].Names(), []string{"strd"})
 
 	assert.Equal(t, vfc[1].Name(), "cat1", "expected category name cat1")
-	require.Len(t, vfc[1].Flags(), 2, "expected flag category to have two flags")
+	require.Len(t, vfc[1].Flags(), 1, "expected flag category to have one flag")
 	assert.Equal(t, vfc[1].Flags()[0].Names(), []string{"intd", "altd1", "altd2"})
-	assert.Equal(t, vfc[1].Flags()[1].Names(), []string{"mutexCat1"})
 
 	assert.Equal(t, vfc[2].Name(), "cat2", "expected category name cat2")
 	require.Len(t, vfc[2].Flags(), 1, "expected flag category to have one flag")
-	assert.Equal(t, vfc[2].Flags()[0].Names(), []string{"mutexCat2"})
+	assert.Equal(t, vfc[2].Flags()[0].Names(), []string{"mutex"})
 }
 
 func TestCommand_RunSubcommandWithDefault(t *testing.T) {

--- a/command_test.go
+++ b/command_test.go
@@ -524,19 +524,39 @@ func TestCommand_VisibleFlagCategories(t *testing.T) {
 				Category: "cat1",
 			},
 		},
+		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{{
+			Flags: [][]Flag{
+				{
+					&BoolFlag{
+						Name: "mutexStrd",
+					},
+					&BoolFlag{
+						Name:     "mutexCat1",
+						Category: "cat1",
+					},
+					&BoolFlag{
+						Name:     "mutexCat2",
+						Category: "cat2",
+					},
+				},
+			},
+		}},
 	}
 
 	vfc := cmd.VisibleFlagCategories()
-	require.Len(t, vfc, 2)
+	require.Len(t, vfc, 3)
 
 	assert.Equal(t, vfc[0].Name(), "", "expected category name to be empty")
+	assert.Equal(t, vfc[0].Flags()[0].Names(), []string{"mutexStrd"})
 
 	assert.Equal(t, vfc[1].Name(), "cat1", "expected category name cat1")
+	require.Len(t, vfc[1].Flags(), 2, "expected flag category to have two flags")
+	assert.Equal(t, vfc[1].Flags()[0].Names(), []string{"intd", "altd1", "altd2"})
+	assert.Equal(t, vfc[1].Flags()[1].Names(), []string{"mutexCat1"})
 
-	require.Len(t, vfc[1].Flags(), 1, "expected flag category to have just one flag")
-
-	fl := vfc[1].Flags()[0]
-	assert.Equal(t, fl.Names(), []string{"intd", "altd1", "altd2"})
+	assert.Equal(t, vfc[2].Name(), "cat2", "expected category name cat2")
+	require.Len(t, vfc[2].Flags(), 1, "expected flag category to have one flag")
+	assert.Equal(t, vfc[2].Flags()[0].Names(), []string{"mutexCat2"})
 }
 
 func TestCommand_RunSubcommandWithDefault(t *testing.T) {

--- a/flag.go
+++ b/flag.go
@@ -162,6 +162,9 @@ type VisibleFlag interface {
 type CategorizableFlag interface {
 	// Returns the category of the flag
 	GetCategory() string
+
+	// Sets the category of the flag
+	SetCategory(string)
 }
 
 // PersistentFlag is an interface to enable detection of flags which are persistent

--- a/flag_impl.go
+++ b/flag_impl.go
@@ -221,6 +221,10 @@ func (f *FlagBase[T, C, V]) GetCategory() string {
 	return f.Category
 }
 
+func (f *FlagBase[T, C, V]) SetCategory(c string) {
+	f.Category = c
+}
+
 // GetUsage returns the usage string for the flag
 func (f *FlagBase[T, C, V]) GetUsage() string {
 	return f.Usage

--- a/flag_mutex.go
+++ b/flag_mutex.go
@@ -11,6 +11,9 @@ type MutuallyExclusiveFlags struct {
 
 	// whether this group is required
 	Required bool
+
+	// Category to apply to all flags within group
+	Category string
 }
 
 func (grp MutuallyExclusiveFlags) check(cmd *Command) error {
@@ -40,4 +43,14 @@ func (grp MutuallyExclusiveFlags) check(cmd *Command) error {
 		return &mutuallyExclusiveGroupRequiredFlag{flags: &grp}
 	}
 	return nil
+}
+
+func (grp MutuallyExclusiveFlags) propagateCategory() {
+	for _, grpf := range grp.Flags {
+		for _, f := range grpf {
+			if cf, ok := f.(CategorizableFlag); ok {
+				cf.SetCategory(grp.Category)
+			}
+		}
+	}
 }

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -289,6 +289,9 @@ func (s *BoolWithInverseFlag) Value() bool
 type CategorizableFlag interface {
 	// Returns the category of the flag
 	GetCategory() string
+
+	// Sets the category of the flag
+	SetCategory(string)
 }
     CategorizableFlag is an interface that allows us to potentially use a flag
     in a categorized representation.
@@ -702,6 +705,8 @@ func (f *FlagBase[T, C, V]) Names() []string
 func (f *FlagBase[T, C, V]) RunAction(ctx context.Context, cmd *Command) error
     RunAction executes flag action if set
 
+func (f *FlagBase[T, C, V]) SetCategory(c string)
+
 func (f *FlagBase[T, C, V]) String() string
     String returns a readable representation of this value (for usage defaults)
 
@@ -821,6 +826,9 @@ type MutuallyExclusiveFlags struct {
 
 	// whether this group is required
 	Required bool
+
+	// Category to apply to all flags within group
+	Category string
 }
     MutuallyExclusiveFlags defines a mutually exclusive flag group Multiple
     option paths can be provided out of which only one can be defined on cmdline

--- a/help_test.go
+++ b/help_test.go
@@ -1528,20 +1528,22 @@ func TestCategorizedHelp(t *testing.T) {
 		},
 		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
 			{
+				Category: "cat1",
 				Flags: [][]Flag{
 					{
 						&StringFlag{
-							Name: "mutexstd",
-						},
-						&IntFlag{
-							Name:     "mutexcat1",
-							Category: "cat1",
+							Name:     "m1",
+							Category: "overridden",
 						},
 					},
+				},
+			},
+			{
+				Flags: [][]Flag{
 					{
-						&IntFlag{
-							Name:     "mutexcat2",
-							Category: "cat2",
+						&StringFlag{
+							Name:     "m2",
+							Category: "ignored",
 						},
 					},
 				},
@@ -1575,18 +1577,14 @@ COMMANDS:
             for one command
 
 GLOBAL OPTIONS:
-   --help, -h        show help (default: false)
-   --mutexstd value  
-   --strd value      
+   --help, -h    show help (default: false)
+   --m2 value    
+   --strd value  
 
    cat1
 
    --intd value, --altd1 value, --altd2 value  (default: 0)
-   --mutexcat1 value                           (default: 0)
-
-   cat2
-
-   --mutexcat2 value  (default: 0)
+   --m1 value                                  
 
 `, output.String())
 }

--- a/help_test.go
+++ b/help_test.go
@@ -1526,6 +1526,27 @@ func TestCategorizedHelp(t *testing.T) {
 				Category: "cat1",
 			},
 		},
+		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
+			{
+				Flags: [][]Flag{
+					{
+						&StringFlag{
+							Name: "mutexstd",
+						},
+						&IntFlag{
+							Name:     "mutexcat1",
+							Category: "cat1",
+						},
+					},
+					{
+						&IntFlag{
+							Name:     "mutexcat2",
+							Category: "cat2",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	HelpPrinter = func(w io.Writer, templ string, data interface{}) {
@@ -1554,12 +1575,18 @@ COMMANDS:
             for one command
 
 GLOBAL OPTIONS:
-   --help, -h    show help (default: false)
-   --strd value  
+   --help, -h        show help (default: false)
+   --mutexstd value  
+   --strd value      
 
    cat1
 
    --intd value, --altd1 value, --altd2 value  (default: 0)
+   --mutexcat1 value                           (default: 0)
+
+   cat2
+
+   --mutexcat2 value  (default: 0)
 
 `, output.String())
 }

--- a/help_test.go
+++ b/help_test.go
@@ -1176,6 +1176,28 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 	}
 }
 
+func TestMutuallyExclusiveFlags(t *testing.T) {
+	writer := &bytes.Buffer{}
+	cmd := &Command{
+		Name:   "cmd",
+		Writer: writer,
+		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
+			{
+				Flags: [][]Flag{
+					{
+						&StringFlag{
+							Name: "s1",
+						},
+					},
+				}},
+		},
+	}
+
+	ShowAppHelp(cmd)
+
+	assert.Contains(t, writer.String(), "--s1", "written help does not include mutex flag")
+}
+
 func TestWrap(t *testing.T) {
 	emptywrap := wrap("", 4, 16)
 	assert.Empty(t, emptywrap, "Wrapping empty line should return empty line")

--- a/help_test.go
+++ b/help_test.go
@@ -1193,7 +1193,7 @@ func TestMutuallyExclusiveFlags(t *testing.T) {
 		},
 	}
 
-	ShowAppHelp(cmd)
+	_ = ShowAppHelp(cmd)
 
 	assert.Contains(t, writer.String(), "--s1", "written help does not include mutex flag")
 }

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -289,6 +289,9 @@ func (s *BoolWithInverseFlag) Value() bool
 type CategorizableFlag interface {
 	// Returns the category of the flag
 	GetCategory() string
+
+	// Sets the category of the flag
+	SetCategory(string)
 }
     CategorizableFlag is an interface that allows us to potentially use a flag
     in a categorized representation.
@@ -702,6 +705,8 @@ func (f *FlagBase[T, C, V]) Names() []string
 func (f *FlagBase[T, C, V]) RunAction(ctx context.Context, cmd *Command) error
     RunAction executes flag action if set
 
+func (f *FlagBase[T, C, V]) SetCategory(c string)
+
 func (f *FlagBase[T, C, V]) String() string
     String returns a readable representation of this value (for usage defaults)
 
@@ -821,6 +826,9 @@ type MutuallyExclusiveFlags struct {
 
 	// whether this group is required
 	Required bool
+
+	// Category to apply to all flags within group
+	Category string
 }
     MutuallyExclusiveFlags defines a mutually exclusive flag group Multiple
     option paths can be provided out of which only one can be defined on cmdline


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

The default help text did not include mutually exclusive flags; now it does:

```
cmd := &cli.Command{
		MutuallyExclusiveFlags: []cli.MutuallyExclusiveFlags{{
			Flags: [][]cli.Flag{
				{
					&cli.StringFlag{
						Name: "foo",
					},
				},
				{
					&cli.BoolFlag{
						Name:     "bar",
						Category: "Category",
					},
				},
				{
					&cli.BoolFlag{
						Name:     "baz",
						Category: "Category",
					},
				},
			},
		}},
	}
```
```
GLOBAL OPTIONS:
   --foo value
   --help, -h   show help (default: false)

   Category

   --bar  (default: false)
   --baz  (default: false)
```

Changes:
- `SetCategory` method added to Flag interface.
- `Category` field and `propagateCategory` method added to `MutuallyExclusiveFlags`, allowing mutex group to set a category and propagate it downward to all flags within.
- Mutex group category downward-propagation added to command and subcommand setup, prior to computing visible categories. This implies that any category set on a mutex flag itself will be ignored if no group category is set, or overridden if one is.
- Replaced `cmd.Flags` with `cmd.allFlags()` when calculating visible flags and visible flag categories, to ensure downward-propagated group categories are included in help text.

## Which issue(s) this PR fixes:

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
-->
Fixes #1858 

## Special notes for your reviewer:

I considered two approaches, described in #1858 . This is the simpler of the two, where no attempt is made to display or categorize mutually exclusive flags in any special way. Under this approach the changes are minimal and ~users don't need to consider any special cases when using mutually exclusive flags.~ Flags within a mutex group now ignore their own `Category` and inherit it from the group instead, but there's precedent with the mutex group's `Required` field so it's not an entirely new concept.

## Testing

Unit tests are updated to reflect both uncategorized and categorized output.

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Mutually exclusive flags are now included in the default help text.
```
