### PR TITLE
Fix variadic args

### DIFF
--- a/args.go
+++ b/args.go
@@ -128,7 +128,7 @@ func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error) {
 
 	if a.Values == nil {
 		a.Values = &values
-	} else {
+	} else if count > 0 {
 		*a.Values = values
 	}
 
@@ -139,6 +139,7 @@ func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error) {
 			*a.Destination = t
 		}
 	}
+
 	return s[count:], nil
 }
 

--- a/args.go
+++ b/args.go
@@ -118,7 +118,7 @@ func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error) {
 		}
 		values = append(values, value.Get().(T))
 		count++
-		if count >= a.Max && a.Max != -1 {
+		if count >= a.Max && a.Max > -1 {
 			break
 		}
 	}

--- a/args.go
+++ b/args.go
@@ -118,7 +118,7 @@ func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error) {
 		}
 		values = append(values, value.Get().(T))
 		count++
-		if count >= a.Max {
+		if count >= a.Max && a.Max != -1 {
 			break
 		}
 	}

--- a/args_test.go
+++ b/args_test.go
@@ -216,7 +216,7 @@ func TestUnboundedArgs(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			arg.Values = &test.values
 			require.NoError(t, cmd.Run(context.Background(), test.args))
-			require.Equal(t, test.expected, test.values)
+			require.Equal(t, test.expected, *arg.Values)
 		})
 	}
 }

--- a/args_test.go
+++ b/args_test.go
@@ -189,7 +189,7 @@ func TestUnboundedArgs(t *testing.T) {
 		{
 			name:     "cmd accepts no args",
 			args:     []string{"foo"},
-			expected: []string{},
+			expected: nil,
 		},
 		{
 			name:     "cmd uses given args",
@@ -197,16 +197,16 @@ func TestUnboundedArgs(t *testing.T) {
 			expected: []string{"bar", "baz"},
 		},
 		{
-			name:     "given args override default values",
-			args:     []string{"foo", "bar", "baz"},
-			values:   []string{"zbar", "zbaz"},
-			expected: []string{"bar", "baz"},
-		},
-		{
 			name:     "cmd uses default values",
 			args:     []string{"foo"},
 			values:   []string{"zbar", "zbaz"},
 			expected: []string{"zbar", "zbaz"},
+		},
+		{
+			name:     "given args override default values",
+			args:     []string{"foo", "bar", "baz"},
+			values:   []string{"zbar", "zbaz"},
+			expected: []string{"bar", "baz"},
 		},
 	}
 

--- a/args_test.go
+++ b/args_test.go
@@ -174,3 +174,49 @@ func TestSingleOptionalArg(t *testing.T) {
 	require.NoError(t, cmd.Run(context.Background(), []string{"foo", "zbar"}))
 	require.Equal(t, "zbar", s1)
 }
+
+func TestUnboundedArgs(t *testing.T) {
+	arg := &StringArg{
+		Min: 0,
+		Max: -1,
+	}
+	tests := []struct {
+		name     string
+		args     []string
+		values   []string
+		expected []string
+	}{
+		{
+			name:     "cmd accepts no args",
+			args:     []string{"foo"},
+			expected: []string{},
+		},
+		{
+			name:     "cmd uses given args",
+			args:     []string{"foo", "bar", "baz"},
+			expected: []string{"bar", "baz"},
+		},
+		{
+			name:     "given args override default values",
+			args:     []string{"foo", "bar", "baz"},
+			values:   []string{"zbar", "zbaz"},
+			expected: []string{"bar", "baz"},
+		},
+		{
+			name:     "cmd uses default values",
+			args:     []string{"foo"},
+			values:   []string{"zbar", "zbaz"},
+			expected: []string{"zbar", "zbaz"},
+		},
+	}
+
+	cmd := buildMinimalTestCommand()
+	cmd.Arguments = []Argument{arg}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			arg.Values = &test.values
+			require.NoError(t, cmd.Run(context.Background(), test.args))
+			require.Equal(t, test.expected, test.values)
+		})
+	}
+}


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?
- bug

## What this PR does / why we need it:
<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
Fixes the following:
- If variadic args are passed, only the first is captured because `Parse` exits early when comparing `count >= -1`.
- If no args are passed, default values are clobbered by the empty set.

## Special notes for your reviewer:

If more arguments are defined after an unbounded argument, the end user may experience an error:
```
Arguments: []cli.Argument{
    &cli.StringArg{
        Name: "First",
        Max: -1,
    },
    &cli.StringArg{
        Name: "Second,
    },
}
```
After `First` is parsed, there will be no remaining args. If `Second.Min` == 0, it will just use its default/zero value. If `Second.Min` > 0, this will result in an insufficient arg count error. Both of those behaviors seem intuitive to me, but we could also add a runtime check and proactively error if an unbounded arg is defined as anything other than the last argument.

## Testing

Unit tests updated with cases for variadic args.

## Release Notes
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Variadic args are now parsed correctly.
```
