### PR TITLE
Fix repeated [arguments...] in usage template in v2

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -167,6 +167,7 @@ func ExampleApp_Run_commandHelp() {
 				Aliases:     []string{"d"},
 				Usage:       "use it to see a description",
 				Description: "This is how we describe describeit the function",
+				Args:        true,
 				Action: func(c *Context) error {
 					fmt.Printf("i like to describe things")
 					return nil
@@ -227,7 +228,7 @@ func ExampleApp_Run_subcommandNoAction() {
 	//    greet describeit - use it to see a description
 	//
 	// USAGE:
-	//    greet describeit [command options] [arguments...]
+	//    greet describeit [command options]
 	//
 	// DESCRIPTION:
 	//    This is how we describe describeit the function
@@ -1912,6 +1913,7 @@ func TestApp_Run_SubcommandFullPath(t *testing.T) {
 	subCmd := &Command{
 		Name:  "bar",
 		Usage: "does bar things",
+		Args:  true,
 	}
 	cmd := &Command{
 		Name:        "foo",
@@ -1946,6 +1948,7 @@ func TestApp_Run_SubcommandHelpName(t *testing.T) {
 		Name:     "bar",
 		HelpName: "custom",
 		Usage:    "does bar things",
+		Args:     true,
 	}
 	cmd := &Command{
 		Name:        "foo",
@@ -1980,6 +1983,7 @@ func TestApp_Run_CommandHelpName(t *testing.T) {
 	subCmd := &Command{
 		Name:  "bar",
 		Usage: "does bar things",
+		Args:  true,
 	}
 	cmd := &Command{
 		Name:        "foo",

--- a/template.go
+++ b/template.go
@@ -1,7 +1,7 @@
 package cli
 
 var helpNameTemplate = `{{$v := offset .HelpName 6}}{{wrap .HelpName 3}}{{if .Usage}} - {{wrap .Usage $v}}{{end}}`
-var usageTemplate = `{{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}}[arguments...]{{end}}[arguments...]{{end}}{{end}}`
+var usageTemplate = `{{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}}[arguments...]{{end}}{{end}}{{end}}`
 var descriptionTemplate = `{{wrap .Description 3}}`
 var authorsTemplate = `{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
    {{range $index, $author := .Authors}}{{if $index}}

--- a/template.go
+++ b/template.go
@@ -1,7 +1,7 @@
 package cli
 
 var helpNameTemplate = `{{$v := offset .HelpName 6}}{{wrap .HelpName 3}}{{if .Usage}} - {{wrap .Usage $v}}{{end}}`
-var usageTemplate = `{{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}}[arguments...]{{end}}{{end}}{{end}}`
+var usageTemplate = `{{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}}{{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}} [arguments...]{{end}}{{end}}{{end}}`
 var descriptionTemplate = `{{wrap .Description 3}}`
 var authorsTemplate = `{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
    {{range $index, $author := .Authors}}{{if $index}}


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

This PR fixes a small bug in the `usageTemplate` template, where `[arguments ...]` would
be printed even if `command.Args == false` and would be printed twice otherwise.

## Which issue(s) this PR fixes:

None yet. I can create one.

## Special notes for your reviewer:

Very simple thing. No need for much.

## Testing

Visually. It is only a rendering issue.

## Release Notes`

```release-note
Fixes a repeating [arguments...] string in the usageTemplate
```
