### PR TITLE
Stop command aliases and flag aliases from being suggested in shell completion

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -259,11 +259,8 @@ func ExampleApp_Run_bashComplete_withShortFlag() {
 	_ = app.Run(os.Args)
 	// Output:
 	// --other
-	// -o
 	// --xyz
-	// -x
 	// --help
-	// -h
 }
 
 func ExampleApp_Run_bashComplete_withLongFlag() {
@@ -360,10 +357,8 @@ func ExampleApp_Run_bashComplete() {
 	_ = app.Run(os.Args)
 	// Output:
 	// describeit
-	// d
 	// next
 	// help
-	// h
 }
 
 func ExampleApp_Run_zshComplete() {
@@ -398,10 +393,8 @@ func ExampleApp_Run_zshComplete() {
 	_ = app.Run(os.Args)
 	// Output:
 	// describeit:use it to see a description
-	// d:use it to see a description
 	// next:next example
 	// help:Shows a list of commands or help for one command
-	// h:Shows a list of commands or help for one command
 }
 
 func ExampleApp_Run_sliceValues() {

--- a/docs/v2/examples/bash-completions.md
+++ b/docs/v2/examples/bash-completions.md
@@ -190,7 +190,7 @@ The default shell completion flag (`--generate-bash-completion`) is defined as
 
 <!-- {
   "args": ["&#45;&#45;generate&#45;bash&#45;completion"],
-  "output": "wat\nhelp\nh"
+  "output": "wat\nhelp\n"
 } -->
 ```go
 package main

--- a/help.go
+++ b/help.go
@@ -151,13 +151,9 @@ func printCommandSuggestions(commands []*Command, writer io.Writer) {
 			continue
 		}
 		if strings.HasSuffix(os.Getenv("SHELL"), "zsh") {
-			for _, name := range command.Names() {
-				_, _ = fmt.Fprintf(writer, "%s:%s\n", name, command.Usage)
-			}
+			_, _ = fmt.Fprintf(writer, "%s:%s\n", command.Name, command.Usage)
 		} else {
-			for _, name := range command.Names() {
-				_, _ = fmt.Fprintf(writer, "%s\n", name)
-			}
+			_, _ = fmt.Fprintf(writer, "%s\n", command.Name)
 		}
 	}
 }
@@ -186,23 +182,21 @@ func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
 		if bflag, ok := flag.(*BoolFlag); ok && bflag.Hidden {
 			continue
 		}
-		for _, name := range flag.Names() {
-			name = strings.TrimSpace(name)
-			// this will get total count utf8 letters in flag name
-			count := utf8.RuneCountInString(name)
-			if count > 2 {
-				count = 2 // reuse this count to generate single - or -- in flag completion
-			}
-			// if flag name has more than one utf8 letter and last argument in cli has -- prefix then
-			// skip flag completion for short flags example -v or -x
-			if strings.HasPrefix(lastArg, "--") && count == 1 {
-				continue
-			}
-			// match if last argument matches this flag and it is not repeated
-			if strings.HasPrefix(name, cur) && cur != name && !cliArgContains(name) {
-				flagCompletion := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
-				_, _ = fmt.Fprintln(writer, flagCompletion)
-			}
+		name := strings.TrimSpace(flag.Names()[0])
+		// this will get total count utf8 letters in flag name
+		count := utf8.RuneCountInString(name)
+		if count > 2 {
+			count = 2 // reuse this count to generate single - or -- in flag completion
+		}
+		// if flag name has more than one utf8 letter and last argument in cli has -- prefix then
+		// skip flag completion for short flags example -v or -x
+		if strings.HasPrefix(lastArg, "--") && count == 1 {
+			continue
+		}
+		// match if last argument matches this flag and it is not repeated
+		if strings.HasPrefix(name, cur) && cur != name && !cliArgContains(name) {
+			flagCompletion := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
+			_, _ = fmt.Fprintln(writer, flagCompletion)
 		}
 	}
 }

--- a/help_test.go
+++ b/help_test.go
@@ -1270,7 +1270,7 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 				},
 			},
 			argv:     []string{"cmd", "--happiness", "putz", "--generate-bash-completion"},
-			expected: "futz\nhelp\nh\n",
+			expected: "futz\nhelp\n",
 		},
 		{
 			name: "typical-subcommand-subcommand-suggestion",


### PR DESCRIPTION
## What type of PR is this?

- bug fix

## Which issue(s) this PR fixes:

This PR fixes #1875

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
- Command aliases and flag aliases are no longer included in shell completions (#1876)
```
