### PR TITLE
Stop command aliases and flag aliases from being suggested in shell completion

### DIFF
--- a/docs/v3/examples/bash-completions.md
+++ b/docs/v3/examples/bash-completions.md
@@ -188,7 +188,7 @@ The default shell completion flag (`--generate-bash-completion`) is defined as
 
 <!-- {
   "args": ["&#45;&#45;generate&#45;shell&#45;completion"],
-  "output": "wat\nhelp\nh"
+  "output": "wat\nhelp\n"
 } -->
 ```go
 package main

--- a/examples_test.go
+++ b/examples_test.go
@@ -269,11 +269,8 @@ func ExampleCommand_Run_shellComplete_bash_withShortFlag() {
 	_ = cmd.Run(context.Background(), os.Args)
 	// Output:
 	// --other
-	// -o
 	// --xyz
-	// -x
 	// --help
-	// -h
 }
 
 func ExampleCommand_Run_shellComplete_bash_withLongFlag() {
@@ -376,10 +373,8 @@ func ExampleCommand_Run_shellComplete_bash() {
 	_ = cmd.Run(context.Background(), os.Args)
 	// Output:
 	// describeit
-	// d
 	// next
 	// help
-	// h
 }
 
 func ExampleCommand_Run_shellComplete_zsh() {
@@ -415,10 +410,8 @@ func ExampleCommand_Run_shellComplete_zsh() {
 	_ = cmd.Run(context.Background(), os.Args)
 	// Output:
 	// describeit:use it to see a description
-	// d:use it to see a description
 	// next:next example
 	// help:Shows a list of commands or help for one command
-	// h:Shows a list of commands or help for one command
 }
 
 func ExampleCommand_Run_sliceValues() {

--- a/help.go
+++ b/help.go
@@ -160,13 +160,9 @@ func printCommandSuggestions(commands []*Command, writer io.Writer) {
 			continue
 		}
 		if strings.HasSuffix(os.Getenv("SHELL"), "zsh") {
-			for _, name := range command.Names() {
-				_, _ = fmt.Fprintf(writer, "%s:%s\n", name, command.Usage)
-			}
+			_, _ = fmt.Fprintf(writer, "%s:%s\n", command.Name, command.Usage)
 		} else {
-			for _, name := range command.Names() {
-				_, _ = fmt.Fprintf(writer, "%s\n", name)
-			}
+			_, _ = fmt.Fprintf(writer, "%s\n", command.Name)
 		}
 	}
 }
@@ -195,23 +191,23 @@ func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
 		if bflag, ok := flag.(*BoolFlag); ok && bflag.Hidden {
 			continue
 		}
-		for _, name := range flag.Names() {
-			name = strings.TrimSpace(name)
-			// this will get total count utf8 letters in flag name
-			count := utf8.RuneCountInString(name)
-			if count > 2 {
-				count = 2 // reuse this count to generate single - or -- in flag completion
-			}
-			// if flag name has more than one utf8 letter and last argument in cli has -- prefix then
-			// skip flag completion for short flags example -v or -x
-			if strings.HasPrefix(lastArg, "--") && count == 1 {
-				continue
-			}
-			// match if last argument matches this flag and it is not repeated
-			if strings.HasPrefix(name, cur) && cur != name && !cliArgContains(name) {
-				flagCompletion := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
-				fmt.Fprintln(writer, flagCompletion)
-			}
+
+		name := strings.TrimSpace(flag.Names()[0])
+		// this will get total count utf8 letters in flag name
+		count := utf8.RuneCountInString(name)
+		if count > 2 {
+			count = 2 // reuse this count to generate single - or -- in flag completion
+		}
+		// if flag name has more than one utf8 letter and last argument in cli has -- prefix then
+		// skip flag completion for short flags example -v or -x
+		if strings.HasPrefix(lastArg, "--") && count == 1 {
+			continue
+		}
+		// match if last argument matches this flag and it is not repeated
+		if strings.HasPrefix(name, cur) && cur != name && !cliArgContains(name) {
+			flagCompletion := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
+			fmt.Fprintln(writer, flagCompletion)
+
 		}
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- bug fix

## Which issue(s) this PR fixes:

This PR fixes #1875. It is the second try, now targeting v3. The first try, targeting v2, was in #1876.

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
- Command aliases and flag aliases are no longer included in shell completions (#1882)
```
