### PR TITLE
Bump Go versions and reorder steps as with v2-maint

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -15,17 +15,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.21.x, 1.22.x]
+        go: [stable, oldstable]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-
-      - name: Checkout Code
-        uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: npm install markdown-toc


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Eliminates the need for updating these values, as with `v2-maint`.

## Which issue(s) this PR fixes:

N/A