### PR TITLE
Replace Jaro-Winkler algorithm usage with an internal function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/urfave/cli/v3
 
 go 1.18
 
-require (
-	github.com/stretchr/testify v1.8.4
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673
-)
+require github.com/stretchr/testify v1.8.4
 
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/urfave/cli-altsrc/v3 v3.0.0-alpha2 h1:j4SaBpPB8++L0c0KuTnz/Yus3UQoWJ54hQjhIMW8rCM=
 github.com/urfave/cli-altsrc/v3 v3.0.0-alpha2/go.mod h1:Q79oyIY/z4jtzIrKEK6MUeWC7/szGr46x4QdOaOAIWc=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/suggestions.go
+++ b/suggestions.go
@@ -16,8 +16,11 @@ type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
 
 type SuggestCommandFunc func(commands []*Command, provided string) string
 
-// Jaro is the measure of similarity between two strings.
-// The result is 1 for equal strings, and 0 for completely different strings.
+// jaroDistance is the measure of similarity between two strings. It returns a
+// value between 0 and 1, where 1 indicates identical strings and 0 indicates
+// completely different strings.
+//
+// Adapted from https://github.com/xrash/smetrics/blob/5f08fbb34913bc8ab95bb4f2a89a0637ca922666/jaro.go.
 func jaroDistance(a, b string) float64 {
 	if len(a) == 0 && len(b) == 0 {
 		return 1
@@ -72,7 +75,10 @@ func jaroDistance(a, b string) float64 {
 	return ((matches / lenA) + (matches / lenB) + ((matches - transpositions) / matches)) / 3.0
 }
 
-// jaroWinkler is more accurate when strings have a common prefix up to a defined maximum length.
+// jaroWinkler is more accurate when strings have a common prefix up to a
+// defined maximum length.
+//
+// Adapted from https://github.com/xrash/smetrics/blob/5f08fbb34913bc8ab95bb4f2a89a0637ca922666/jaro-winkler.go.
 func jaroWinkler(a, b string) float64 {
 	const (
 		boostThreshold = 0.7

--- a/suggestions_test.go
+++ b/suggestions_test.go
@@ -8,6 +8,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestJaroWinkler(t *testing.T) {
+	// Given
+	for _, testCase := range []struct {
+		a, b     string
+		expected float64
+	}{
+		{"", "", 1},
+		{"a", "", 0},
+		{"", "a", 0},
+		{"a", "a", 1},
+		{"a", "b", 0},
+		{"aa", "aa", 1},
+		{"aa", "bb", 0},
+		{"aaa", "aaa", 1},
+		{"aa", "ab", 0.6666666666666666},
+		{"aa", "ba", 0.6666666666666666},
+		{"ba", "aa", 0.6666666666666666},
+		{"ab", "aa", 0.6666666666666666},
+	} {
+		// When
+		res := jaroWinkler(testCase.a, testCase.b)
+
+		// Then
+		assert.Equal(t, testCase.expected, res)
+	}
+}
+
 func TestSuggestFlag(t *testing.T) {
 	// Given
 	app := buildExtendedTestCommand()


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

To support the goal of only requiring the Go standard library. We were using the Jaro-Winkler algorithm for the suggestion from the "xrash/smetrics" package. This function was rewritten to be faithful to stdlib.

## Which issue(s) this PR fixes:

Fixes #1892 

## Testing

go test -run=TestJaroWinkler

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note

```
