### PR TITLE
Make it possible to `source` the Zsh autocomplete script

### DIFF
--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,20 +1,29 @@
-#compdef $PROG
+#compdef program
+compdef _program program
 
-_cli_zsh_autocomplete() {
-  local -a opts
-  local cur
-  cur=${words[-1]}
-  if [[ "$cur" == "-"* ]]; then
-    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-shell-completion)}")
-  else
-    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-shell-completion)}")
-  fi
+# Replace "program" with the actual name of your CLI program. Let's say your CLI
+# program is called "acme", then replace like so:
+# * program => acme
+# * _program => _acme
 
-  if [[ "${opts[1]}" != "" ]]; then
-    _describe 'values' opts
-  else
-    _files
-  fi
+_program() {
+	local -a opts
+	local cur
+	cur=${words[-1]}
+	if [[ "$cur" == "-"* ]]; then
+		opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-shell-completion)}")
+	else
+		opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-shell-completion)}")
+	fi
+
+	if [[ "${opts[1]}" != "" ]]; then
+		_describe 'values' opts
+	else
+		_files
+	fi
 }
 
-compdef _cli_zsh_autocomplete $PROG
+# don't run the completion function when being source-ed or eval-ed
+if [ "$funcstack[1]" = "_program" ]; then
+	_program
+fi

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,8 +1,9 @@
 #compdef program
 compdef _program program
 
-# Replace "program" with the actual name of your CLI program. Let's say your CLI
-# program is called "acme", then replace like so:
+# Replace all occurences of "program" in this file with the actual name of your
+# CLI program. We recommend using Find+Replace feature of your editor. Let's say
+# your CLI program is called "acme", then replace like so:
 # * program => acme
 # * _program => _acme
 


### PR DESCRIPTION
## What type of PR is this?

- bug
- documentation

## What this PR does / why we need it:

This PR updates the default Zsh autcompletion script so it can be `source`d. This makes debugging/testing autocompletion easier, because there's no need to copy this file to `zsh/site-functions` dir and rename it.

I first described this problem in https://github.com/urfave/cli/issues/1874

I also formatted this file with [`shfmt`](https://github.com/mvdan/sh).

## Which issue(s) this PR fixes:

Related to #1874.

I'm not sure if the same problem occurs in Bash. I'll check when I have more free time and possibly fix it in another PR.

## Special notes for your reviewer:

None.


## Testing

Tested locally.

I use this version of the `zsh_autocomplete` script in my own CLI programs, and it works as intended. Example: [`bartekpacia/emu`](https://github.com/bartekpacia/emu).

## Release Notes

```release-note

```
