### PR TITLE
reorder flags so they can come after arguments

### DIFF
--- a/command.go
+++ b/command.go
@@ -112,7 +112,7 @@ type Command struct {
 	// Boolean to enable reordering flags before passing them to the parser
 	// such that `cli -f <val> <arg>` behaves the same as `cli <arg> -f <val>`.
 	// This only has effect when set at the top-level command.
-	AllowFlagsAfterArguments bool `json:"allowFlagsAfterArguments"`
+	AllowFlagsAfterArguments bool `json:"allowFlagsAfterArguments,omitempty"`
 	// Enable suggestions for commands and flags
 	Suggest bool `json:"suggest"`
 	// Allows global flags set by libraries which use flag.XXXVar(...) directly

--- a/command_test.go
+++ b/command_test.go
@@ -60,6 +60,7 @@ func buildExtendedTestCommand() *Command {
 			Hidden: true,
 		},
 	}
+	cmd.AllowFlagsAfterArguments = true
 	cmd.Commands = []*Command{{
 		Aliases: []string{"c"},
 		Flags: []Flag{
@@ -4385,6 +4386,7 @@ func TestJSONExportCommand(t *testing.T) {
 		"sliceFlagSeparator": "",
 		"disableSliceFlagSeparator": false,
 		"useShortOptionHandling": false,
+		"allowFlagsAfterArguments": true,
 		"suggest": false,
 		"allowExtFlags": false,
 		"skipFlagParsing": false,


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This brings back (and improves) the `reorderFlags` function from v1 that allows flags to be specified after arguments and still work. It's a very much requested feature, see https://github.com/urfave/cli/issues/1733 and https://github.com/urfave/cli/issues/976.

## Which issue(s) this PR fixes:

Fixes #976

## Testing

I've done some manual testing.