### PR TITLE
Fix:(issue_1930) Fix for invalid bool counts

### DIFF
--- a/command.go
+++ b/command.go
@@ -800,12 +800,6 @@ func (cmd *Command) parseFlags(args Args) (Args, error) {
 		return cmd.Args(), err
 	}
 
-	tracef("normalizing flags (cmd=%[1]q)", cmd.Name)
-
-	if err := normalizeFlags(cmd.Flags, cmd.flagSet); err != nil {
-		return cmd.Args(), err
-	}
-
 	tracef("done parsing flags (cmd=%[1]q)", cmd.Name)
 
 	return cmd.Args(), nil

--- a/command_test.go
+++ b/command_test.go
@@ -3230,30 +3230,34 @@ func TestCommand_Value(t *testing.T) {
 			subCmd,
 		},
 	}
-	err := cmd.Run(buildTestContext(t), []string{"main", "--top-flag", "13", "test", "--myflag", "14"})
-	assert.NoError(t, err)
+	t.Run("flag name", func(t *testing.T) {
+		r := require.New(t)
+		err := cmd.Run(buildTestContext(t), []string{"main", "--top-flag", "13", "test", "--myflag", "14"})
 
-	r := require.New(t)
-	r.Equal(int64(13), cmd.Value("top-flag"))
-	r.Equal(int64(13), cmd.Value("t"))
-	r.Equal(int64(13), cmd.Value("tf"))
+		r.NoError(err)
+		r.Equal(int64(13), cmd.Value("top-flag"))
+		r.Equal(int64(13), cmd.Value("t"))
+		r.Equal(int64(13), cmd.Value("tf"))
 
-	r.Equal(int64(14), subCmd.Value("myflag"))
-	r.Equal(int64(14), subCmd.Value("m"))
-	r.Equal(int64(14), subCmd.Value("mf"))
+		r.Equal(int64(14), subCmd.Value("myflag"))
+		r.Equal(int64(14), subCmd.Value("m"))
+		r.Equal(int64(14), subCmd.Value("mf"))
+	})
 
-	// use only aliases here
-	err = cmd.Run(buildTestContext(t), []string{"main", "-tf", "15", "test", "-m", "16"})
-	assert.NoError(t, err)
+	t.Run("flag aliases", func(t *testing.T) {
+		r := require.New(t)
+		err := cmd.Run(buildTestContext(t), []string{"main", "-tf", "15", "test", "-m", "16"})
 
-	r.Equal(int64(15), cmd.Value("top-flag"))
-	r.Equal(int64(15), cmd.Value("t"))
-	r.Equal(int64(15), cmd.Value("tf"))
+		r.NoError(err)
+		r.Equal(int64(15), cmd.Value("top-flag"))
+		r.Equal(int64(15), cmd.Value("t"))
+		r.Equal(int64(15), cmd.Value("tf"))
 
-	r.Equal(int64(16), subCmd.Value("myflag"))
-	r.Equal(int64(16), subCmd.Value("m"))
-	r.Equal(int64(16), subCmd.Value("mf"))
-	r.Nil(cmd.Value("unknown-flag"))
+		r.Equal(int64(16), subCmd.Value("myflag"))
+		r.Equal(int64(16), subCmd.Value("m"))
+		r.Equal(int64(16), subCmd.Value("mf"))
+		r.Nil(cmd.Value("unknown-flag"))
+	})
 }
 
 func TestCommand_Value_InvalidFlagAccessHandler(t *testing.T) {

--- a/flag.go
+++ b/flag.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -196,48 +195,6 @@ func newFlagSet(name string, flags []Flag) (*flag.FlagSet, error) {
 	set.SetOutput(io.Discard)
 
 	return set, nil
-}
-
-func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {
-	switch ff.Value.(type) {
-	case Serializer:
-		_ = set.Set(name, ff.Value.(Serializer).Serialize())
-	default:
-		_ = set.Set(name, ff.Value.String())
-	}
-}
-
-func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
-	visited := make(map[string]bool)
-	set.Visit(func(f *flag.Flag) {
-		visited[f.Name] = true
-	})
-	for _, f := range flags {
-		parts := f.Names()
-		if len(parts) == 1 {
-			continue
-		}
-		var ff *flag.Flag
-		for _, name := range parts {
-			name = strings.Trim(name, " ")
-			if visited[name] {
-				if ff != nil {
-					return errors.New("Cannot use two forms of the same flag: " + name + " " + ff.Name)
-				}
-				ff = set.Lookup(name)
-			}
-		}
-		if ff == nil {
-			continue
-		}
-		for _, name := range parts {
-			name = strings.Trim(name, " ")
-			if !visited[name] {
-				copyFlag(name, ff, set)
-			}
-		}
-	}
-	return nil
 }
 
 func visibleFlags(fl []Flag) []Flag {


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug
- cleanup

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

Fixes #1930 
Fixes #1929 
## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing
_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

go test -run=TestCommand_Value
go test -run=TestBoolFlagCountFromCommand

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
The normalizeFlags function is redundant and causes the value.Set to be triggered for every alias which in turn increments count for flag unnecessarily. This function is a holdover from very very old code and has been removed. This fixes the count issue and also allows multiple aliases of same flag to be used without any errors. 
```
