### PR TITLE
docs(flag): add `UseShortOptionHandling` description

### DIFF
--- a/docs/v2/examples/flags.md
+++ b/docs/v2/examples/flags.md
@@ -107,8 +107,8 @@ For bool flags you can specify the flag multiple times to get a count(e.g -v -v 
 > If you want to support the `-vvv` flag, you need to set `App.UseShortOptionHandling`.
 
 <!-- {
-  "args": ["&#45;&#45;foo", "&#45;&#45;foo"],
-  "output": "count 2"
+  "args": ["&#45;&#45;foo", "&#45;&#45;foo", "&#45;fff",  "&#45;f"],
+  "output": "count 6"  
 } -->
 ```go
 package main

--- a/docs/v2/examples/flags.md
+++ b/docs/v2/examples/flags.md
@@ -104,6 +104,8 @@ See full list of flags at https://pkg.go.dev/github.com/urfave/cli/v2
 
 For bool flags you can specify the flag multiple times to get a count(e.g -v -v -v or -vvv)
 
+> If you want to support the `-vvv` flag, you need to set `App.UseShortOptionHandling`.
+
 <!-- {
   "args": ["&#45;&#45;foo", "&#45;&#45;foo"],
   "output": "count 2"
@@ -123,10 +125,12 @@ func main() {
 	var count int
 
 	app := &cli.App{
+		UseShortOptionHandling: true,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:        "foo",
 				Usage:       "foo greeting",
+				Aliases:     []string{"f"},
 				Count: &count,
 			},
 		},

--- a/docs/v3/examples/flags.md
+++ b/docs/v3/examples/flags.md
@@ -106,6 +106,8 @@ See full list of flags at https://pkg.go.dev/github.com/urfave/cli/v3
 
 For bool flags you can specify the flag multiple times to get a count(e.g -v -v -v or -vvv)
 
+> If you want to support the `-vvv` flag, you need to set `Command.UseShortOptionHandling`.
+
 <!-- {
   "args": ["&#45;&#45;foo", "&#45;&#45;foo"],
   "output": "count 2"
@@ -126,10 +128,12 @@ func main() {
 	var count int
 
 	cmd := &cli.Command{
+		UseShortOptionHandling: true,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:        "foo",
 				Usage:       "foo greeting",
+				Aliases:     []string{"f"},
 				Config: cli.BoolConfig{
 					Count: &count,
 				},

--- a/docs/v3/examples/flags.md
+++ b/docs/v3/examples/flags.md
@@ -109,8 +109,8 @@ For bool flags you can specify the flag multiple times to get a count(e.g -v -v 
 > If you want to support the `-vvv` flag, you need to set `Command.UseShortOptionHandling`.
 
 <!-- {
-  "args": ["&#45;&#45;foo", "&#45;&#45;foo"],
-  "output": "count 2"
+  "args": ["&#45;&#45;foo", "&#45;&#45;foo", "&#45;fff"],
+  "output": "count 5"
 } -->
 ```go
 package main


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

Add a description of `UseShortOptionHandling` in the Flag section so that users can clearly understand that to support Flags like `-vvv`, it is necessary to set `UseShortOptionHandling`.

## Which issue(s) this PR fixes:

Close: #1942

## Special notes for your reviewer:

nil

## Testing

nil

## Release Notes

```release-note
NONE
```
