### PR TITLE
docs(flag): add `UseShortOptionHandling` description

### DIFF
--- a/docs/v2/examples/flags.md
+++ b/docs/v2/examples/flags.md
@@ -104,9 +104,11 @@ See full list of flags at https://pkg.go.dev/github.com/urfave/cli/v2
 
 For bool flags you can specify the flag multiple times to get a count(e.g -v -v -v or -vvv)
 
+> If you want to support the `-vvv` flag, you need to set `App.UseShortOptionHandling`.
+
 <!-- {
-  "args": ["&#45;&#45;foo", "&#45;&#45;foo"],
-  "output": "count 2"
+  "args": ["&#45;&#45;foo", "&#45;&#45;foo", "&#45;fff",  "&#45;f"],
+  "output": "count 6"
 } -->
 ```go
 package main
@@ -123,10 +125,12 @@ func main() {
 	var count int
 
 	app := &cli.App{
+		UseShortOptionHandling: true,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:        "foo",
 				Usage:       "foo greeting",
+				Aliases:     []string{"f"},
 				Count: &count,
 			},
 		},

--- a/docs/v2/examples/flags.md
+++ b/docs/v2/examples/flags.md
@@ -107,7 +107,7 @@ For bool flags you can specify the flag multiple times to get a count(e.g -v -v 
 > If you want to support the `-vvv` flag, you need to set `App.UseShortOptionHandling`.
 
 <!-- {
-  "args": ["&#45;&#45;foo", "&#45;&#45;foo", "&#45;fff",  "&#45;f"],
+  "args": ["&#45;&#45;f", "&#45;&#45;f", "&#45;fff",  "&#45;f"],
   "output": "count 6"
 } -->
 ```go


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

Add a description of `UseShortOptionHandling` in the Flag section so that users can clearly understand that to support Flags like `-vvv`, it is necessary to set `UseShortOptionHandling`.

## Which issue(s) this PR fixes:

nil

## Special notes for your reviewer:

Backport of https://github.com/urfave/cli/pull/1953

Ref: https://github.com/urfave/cli/pull/1953#issuecomment-2222281095

## Testing

nil

## Release Notes

```release-note
NONE
```

/cc @Juneezee @dearchap 
