### PR TITLE
fix(bool-with-inverse-flag): fix string printing of bool with inverse flag to properly show inverse prefix

### DIFF
--- a/flag_bool_with_inverse.go
+++ b/flag_bool_with_inverse.go
@@ -183,10 +183,12 @@ func (parent *BoolWithInverseFlag) String() string {
 	out := FlagStringer(parent)
 	i := strings.Index(out, "\t")
 
+	prefix := "--"
+
 	// single character flags are prefixed with `-` instead of `--`
 	if len(parent.Name) == 1 {
-		return fmt.Sprintf("-[%s]%s%s", parent.inversePrefix(), parent.Name, out[i:])
+		prefix = "-"
 	}
 
-	return fmt.Sprintf("--[%s]%s%s", parent.inversePrefix(), parent.Name, out[i:])
+	return fmt.Sprintf("%s[%s]%s%s", prefix, parent.inversePrefix(), parent.Name, out[i:])
 }

--- a/flag_bool_with_inverse.go
+++ b/flag_bool_with_inverse.go
@@ -123,6 +123,14 @@ func (parent *BoolWithInverseFlag) inverseName() string {
 	return parent.InversePrefix + parent.BoolFlag.Name
 }
 
+func (parent *BoolWithInverseFlag) inversePrefix() string {
+	if parent.InversePrefix == "" {
+		return DefaultInverseBoolPrefix
+	}
+
+	return parent.InversePrefix
+}
+
 func (parent *BoolWithInverseFlag) inverseAliases() (aliases []string) {
 	if len(parent.BoolFlag.Aliases) > 0 {
 		aliases = make([]string, len(parent.BoolFlag.Aliases))
@@ -170,11 +178,15 @@ func (parent *BoolWithInverseFlag) Names() []string {
 // String implements the standard Stringer interface.
 //
 // Example for BoolFlag{Name: "env"}
-// --env     (default: false) || --no-env    (default: false)
+// --[no-]env	(default: false)
 func (parent *BoolWithInverseFlag) String() string {
-	if parent.positiveFlag == nil {
-		return fmt.Sprintf("%s || --%s", parent.BoolFlag.String(), parent.inverseName())
+	out := FlagStringer(parent)
+	i := strings.Index(out, "\t")
+
+	// single character flags are prefixed with `-` instead of `--`
+	if len(parent.Name) == 1 {
+		return fmt.Sprintf("-[%s]%s%s", parent.inversePrefix(), parent.Name, out[i:])
 	}
 
-	return fmt.Sprintf("%s || %s", parent.positiveFlag.String(), parent.negativeFlag.String())
+	return fmt.Sprintf("--[%s]%s%s", parent.inversePrefix(), parent.Name, out[i:])
 }

--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -335,9 +335,83 @@ func TestBoolWithInverseNames(t *testing.T) {
 	require.Equal(t, "env", names[0], "expected first name to be `env`")
 	require.Equal(t, "no-env", names[1], "expected first name to be `no-env`")
 
-	flagString := flag.String()
-	require.Contains(t, flagString, "--env")
-	require.Contains(t, flagString, "--no-env")
+	// flagString := flag.String()
+	// require.Contains(t, flagString, "--env")
+	// require.Contains(t, flagString, "--no-env")
+}
+
+func TestBoolWithInverseString(t *testing.T) {
+	tcs := []struct {
+		testName      string
+		flagName      string
+		required      bool
+		usage         string
+		inversePrefix string
+		expected      string
+	}{
+		{
+			testName: "single-char flag name",
+			flagName: "e",
+			required: true,
+			expected: "-[no-]e\t",
+		},
+		{
+			testName: "multi-char flag name",
+			flagName: "env",
+			required: true,
+			expected: "--[no-]env\t",
+		},
+		{
+			testName: "required with usage",
+			flagName: "env",
+			required: true,
+			usage:    "env usage",
+			expected: "--[no-]env\tenv usage",
+		},
+		{
+			testName: "required without usage",
+			flagName: "env",
+			required: true,
+			expected: "--[no-]env\t",
+		},
+		{
+			testName: "not required with default usage",
+			flagName: "env",
+			required: false,
+			expected: "--[no-]env\t(default: false)",
+		},
+		{
+			testName:      "custom inverse prefix",
+			flagName:      "env",
+			required:      true,
+			inversePrefix: "nope-",
+			expected:      "--[nope-]env\t",
+		},
+		{
+			testName: "empty inverse prefix",
+			flagName: "",
+			required: true,
+			expected: "--[no-]\t",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.testName, func(t *testing.T) {
+			flag := &BoolWithInverseFlag{
+				BoolFlag: &BoolFlag{
+					Name:     tc.flagName,
+					Usage:    tc.usage,
+					Required: tc.required,
+				},
+			}
+
+			if tc.inversePrefix != "" {
+				flag.InversePrefix = tc.inversePrefix
+			}
+
+			require.Equal(t, tc.expected, flag.String())
+		})
+	}
 }
 
 func TestBoolWithInverseDestination(t *testing.T) {

--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -406,10 +406,7 @@ func TestBoolWithInverseString(t *testing.T) {
 					Usage:    tc.usage,
 					Required: tc.required,
 				},
-			}
-
-			if tc.inversePrefix != "" {
-				flag.InversePrefix = tc.inversePrefix
+				InversePrefix: tc.inversePrefix,
 			}
 
 			require.Equal(t, tc.expected, flag.String())

--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -346,6 +346,12 @@ func TestBoolWithInverseString(t *testing.T) {
 		expected      string
 	}{
 		{
+			testName: "empty inverse prefix",
+			flagName: "",
+			required: true,
+			expected: "--[no-]\t",
+		},
+		{
 			testName: "single-char flag name",
 			flagName: "e",
 			required: true,
@@ -382,12 +388,6 @@ func TestBoolWithInverseString(t *testing.T) {
 			required:      true,
 			inversePrefix: "nope-",
 			expected:      "--[nope-]env\t",
-		},
-		{
-			testName: "empty inverse prefix",
-			flagName: "",
-			required: true,
-			expected: "--[no-]\t",
 		},
 	}
 

--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -334,10 +334,6 @@ func TestBoolWithInverseNames(t *testing.T) {
 	require.Len(t, names, 2)
 	require.Equal(t, "env", names[0], "expected first name to be `env`")
 	require.Equal(t, "no-env", names[1], "expected first name to be `no-env`")
-
-	// flagString := flag.String()
-	// require.Contains(t, flagString, "--env")
-	// require.Contains(t, flagString, "--no-env")
 }
 
 func TestBoolWithInverseString(t *testing.T) {

--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -389,6 +389,13 @@ func TestBoolWithInverseString(t *testing.T) {
 			inversePrefix: "nope-",
 			expected:      "--[nope-]env\t",
 		},
+		{
+			testName:      "empty inverse prefix",
+			flagName:      "env",
+			required:      true,
+			inversePrefix: "",
+			expected:      "--[no-]env\t",
+		},
 	}
 
 	for _, tc := range tcs {

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -283,8 +283,7 @@ func (parent *BoolWithInverseFlag) RunAction(ctx context.Context, cmd *Command) 
 func (parent *BoolWithInverseFlag) String() string
     String implements the standard Stringer interface.
 
-    Example for BoolFlag{Name: "env"} --env (default: false) || --no-env
-    (default: false)
+	Example for BoolFlag{Name: "env"} --[no-]env (default: false)
 
 func (parent *BoolWithInverseFlag) Value() bool
 

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -283,7 +283,7 @@ func (parent *BoolWithInverseFlag) RunAction(ctx context.Context, cmd *Command) 
 func (parent *BoolWithInverseFlag) String() string
     String implements the standard Stringer interface.
 
-	Example for BoolFlag{Name: "env"} --[no-]env (default: false)
+    Example for BoolFlag{Name: "env"} --[no-]env (default: false)
 
 func (parent *BoolWithInverseFlag) Value() bool
 

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -283,8 +283,7 @@ func (parent *BoolWithInverseFlag) RunAction(ctx context.Context, cmd *Command) 
 func (parent *BoolWithInverseFlag) String() string
     String implements the standard Stringer interface.
 
-    Example for BoolFlag{Name: "env"} --env (default: false) || --no-env
-    (default: false)
+	Example for BoolFlag{Name: "env"} --[no-]env (default: false)
 
 func (parent *BoolWithInverseFlag) Value() bool
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- bug
## What this PR does / why we need it:

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
- The current usage output of the `BoolWithInverseFlag` was confusing as it was outputting the same description for both the positive and negative flags. This PR makes the usage a bit more clear by only printing out one usage description and printing the inverse prefix in brackets. 

## Which issue(s) this PR fixes:

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->
This PR fixes #1883. 

## Special notes for your reviewer:
<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->
- I tried to make the fix using the existing `FlagStringer` and manipulating its output to match what we want. Let me know if you'd like to use a different approach here however!

## Testing

- Added unit tests for changes

<!--
  Describe how you tested this change.
-->

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Fixed the usage description of a `BoolWithInverseFlag` to show the inverse prefix in square brackets. 
For example: --[no-]env	(default: false)
```