### PR TITLE
fix(command): add `SortCategories` field to sort help output for categories and their respective flags

### DIFF
--- a/category.go
+++ b/category.go
@@ -137,7 +137,7 @@ func newFlagCategoriesFromFlags(fs []Flag, sortCategories bool) FlagCategories {
 
 func (f *defaultFlagCategories) AddFlag(category string, fl Flag) {
 	if _, ok := f.m[category]; !ok {
-		f.m[category] = &defaultVisibleFlagCategory{name: category, m: map[string]Flag{}, sortCategories: f.sortCategories}
+		f.m[category] = &defaultVisibleFlagCategory{name: category, m: map[string]Flag{}}
 	}
 
 	f.m[category].m[fl.String()] = fl
@@ -170,9 +170,8 @@ type VisibleFlagCategory interface {
 }
 
 type defaultVisibleFlagCategory struct {
-	name           string
-	m              map[string]Flag
-	sortCategories bool
+	name string
+	m    map[string]Flag
 }
 
 func (fc *defaultVisibleFlagCategory) Name() string {
@@ -189,9 +188,7 @@ func (fc *defaultVisibleFlagCategory) Flags() []Flag {
 		}
 	}
 
-	if fc.sortCategories {
-		sort.Strings(vfNames)
-	}
+	sort.Strings(vfNames)
 
 	ret := make([]Flag, len(vfNames))
 	for i, flName := range vfNames {

--- a/category.go
+++ b/category.go
@@ -89,17 +89,19 @@ type FlagCategories interface {
 }
 
 type defaultFlagCategories struct {
-	m map[string]*defaultVisibleFlagCategory
+	m              map[string]*defaultVisibleFlagCategory
+	sortCategories bool
 }
 
-func newFlagCategories() FlagCategories {
+func newFlagCategories(sortCategories bool) FlagCategories {
 	return &defaultFlagCategories{
-		m: map[string]*defaultVisibleFlagCategory{},
+		m:              map[string]*defaultVisibleFlagCategory{},
+		sortCategories: sortCategories,
 	}
 }
 
-func newFlagCategoriesFromFlags(fs []Flag) FlagCategories {
-	fc := newFlagCategories()
+func newFlagCategoriesFromFlags(fs []Flag, sortCategories bool) FlagCategories {
+	fc := newFlagCategories(sortCategories)
 
 	var categorized bool
 
@@ -135,7 +137,7 @@ func newFlagCategoriesFromFlags(fs []Flag) FlagCategories {
 
 func (f *defaultFlagCategories) AddFlag(category string, fl Flag) {
 	if _, ok := f.m[category]; !ok {
-		f.m[category] = &defaultVisibleFlagCategory{name: category, m: map[string]Flag{}}
+		f.m[category] = &defaultVisibleFlagCategory{name: category, m: map[string]Flag{}, sortCategories: f.sortCategories}
 	}
 
 	f.m[category].m[fl.String()] = fl
@@ -147,7 +149,9 @@ func (f *defaultFlagCategories) VisibleCategories() []VisibleFlagCategory {
 		catNames = append(catNames, name)
 	}
 
-	sort.Strings(catNames)
+	if f.sortCategories {
+		sort.Strings(catNames)
+	}
 
 	ret := make([]VisibleFlagCategory, len(catNames))
 	for i, name := range catNames {
@@ -166,8 +170,9 @@ type VisibleFlagCategory interface {
 }
 
 type defaultVisibleFlagCategory struct {
-	name string
-	m    map[string]Flag
+	name           string
+	m              map[string]Flag
+	sortCategories bool
 }
 
 func (fc *defaultVisibleFlagCategory) Name() string {
@@ -184,7 +189,9 @@ func (fc *defaultVisibleFlagCategory) Flags() []Flag {
 		}
 	}
 
-	sort.Strings(vfNames)
+	if fc.sortCategories {
+		sort.Strings(vfNames)
+	}
 
 	ret := make([]Flag, len(vfNames))
 	for i, flName := range vfNames {

--- a/command.go
+++ b/command.go
@@ -131,6 +131,9 @@ type Command struct {
 	// Whether to read arguments from stdin
 	// applicable to root command only
 	ReadArgsFromStdin bool `json:"readArgsFromStdin"`
+	// If SortCategories is set to true, the categories will be sorted
+	// for the help output in increasing lexicographical order.
+	SortCategories bool
 
 	// categories contains the categorized commands and is populated on app startup
 	categories CommandCategories
@@ -279,8 +282,10 @@ func (cmd *Command) setupDefaults(osArgs []string) {
 		cmd.categories.AddCommand(subCmd.Category, subCmd)
 	}
 
-	tracef("sorting command categories (cmd=%[1]q)", cmd.Name)
-	sort.Sort(cmd.categories.(*commandCategories))
+	if cmd.SortCategories {
+		tracef("sorting command categories (cmd=%[1]q)", cmd.Name)
+		sort.Sort(cmd.categories.(*commandCategories))
+	}
 
 	tracef("setting category on mutually exclusive flags (cmd=%[1]q)", cmd.Name)
 	for _, grp := range cmd.MutuallyExclusiveFlags {
@@ -288,7 +293,7 @@ func (cmd *Command) setupDefaults(osArgs []string) {
 	}
 
 	tracef("setting flag categories (cmd=%[1]q)", cmd.Name)
-	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags())
+	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags(), cmd.SortCategories)
 
 	if cmd.Metadata == nil {
 		tracef("setting default Metadata (cmd=%[1]q)", cmd.Name)
@@ -326,8 +331,10 @@ func (cmd *Command) setupSubcommand() {
 		cmd.categories.AddCommand(subCmd.Category, subCmd)
 	}
 
-	tracef("sorting command categories (cmd=%[1]q)", cmd.Name)
-	sort.Sort(cmd.categories.(*commandCategories))
+	if cmd.SortCategories {
+		tracef("sorting command categories (cmd=%[1]q)", cmd.Name)
+		sort.Sort(cmd.categories.(*commandCategories))
+	}
 
 	tracef("setting category on mutually exclusive flags (cmd=%[1]q)", cmd.Name)
 	for _, grp := range cmd.MutuallyExclusiveFlags {
@@ -335,7 +342,7 @@ func (cmd *Command) setupSubcommand() {
 	}
 
 	tracef("setting flag categories (cmd=%[1]q)", cmd.Name)
-	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags())
+	cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags(), cmd.SortCategories)
 }
 
 func (cmd *Command) ensureHelp() {
@@ -852,7 +859,7 @@ func (cmd *Command) VisibleCommands() []*Command {
 // VisibleFlagCategories returns a slice containing all the visible flag categories with the flags they contain
 func (cmd *Command) VisibleFlagCategories() []VisibleFlagCategory {
 	if cmd.flagCategories == nil {
-		cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags())
+		cmd.flagCategories = newFlagCategoriesFromFlags(cmd.allFlags(), cmd.SortCategories)
 	}
 	return cmd.flagCategories.VisibleCategories()
 }

--- a/command.go
+++ b/command.go
@@ -133,7 +133,7 @@ type Command struct {
 	ReadArgsFromStdin bool `json:"readArgsFromStdin"`
 	// If SortCategories is set to true, the categories will be sorted
 	// for the help output in increasing lexicographical order.
-	SortCategories bool
+	SortCategories bool `json:"sortCategories"`
 
 	// categories contains the categorized commands and is populated on app startup
 	categories CommandCategories

--- a/command_test.go
+++ b/command_test.go
@@ -3921,6 +3921,7 @@ func TestJSONExportCommand(t *testing.T) {
 
 	expected := `{
 		"name": "greet",
+		"sortCategories": false,
 		"aliases": null,
 		"usage": "Some app",
 		"usageText": "app [first_arg] [second_arg]",
@@ -3932,6 +3933,7 @@ func TestJSONExportCommand(t *testing.T) {
 		"commands": [
 		  {
 			"name": "config",
+			"sortCategories": false, 
 			"aliases": [
 			  "c"
 			],
@@ -3945,6 +3947,7 @@ func TestJSONExportCommand(t *testing.T) {
 			"commands": [
 			  {
 				"name": "sub-config",
+				"sortCategories": false,
 				"aliases": [
 				  "s",
 				  "ss"
@@ -4078,6 +4081,7 @@ func TestJSONExportCommand(t *testing.T) {
 		  },
 		  {
 			"name": "info",
+			"sortCategories": false,
 			"aliases": [
 			  "i",
 			  "in"
@@ -4111,6 +4115,7 @@ func TestJSONExportCommand(t *testing.T) {
 		  },
 		  {
 			"name": "some-command",
+			"sortCategories": false,
 			"aliases": null,
 			"usage": "",
 			"usageText": "",
@@ -4141,6 +4146,7 @@ func TestJSONExportCommand(t *testing.T) {
 		  },
 		  {
 			"name": "hidden-command",
+			"sortCategories": false,
 			"aliases": null,
 			"usage": "",
 			"usageText": "",
@@ -4171,6 +4177,7 @@ func TestJSONExportCommand(t *testing.T) {
 		  },
 		  {
 			"name": "usage",
+			"sortCategories": false,
 			"aliases": [
 			  "u"
 			],
@@ -4184,6 +4191,7 @@ func TestJSONExportCommand(t *testing.T) {
 			"commands": [
 			  {
 				"name": "sub-usage",
+				"sortCategories": false,
 				"aliases": [
 				  "su"
 				],

--- a/command_test.go
+++ b/command_test.go
@@ -543,6 +543,7 @@ func TestCommand_VisibleFlagCategories(t *testing.T) {
 				},
 			},
 		}},
+		SortCategories: true,
 	}
 
 	cmd.MutuallyExclusiveFlags[0].propagateCategory()

--- a/help_test.go
+++ b/help_test.go
@@ -1773,7 +1773,8 @@ GLOBAL OPTIONS:
 
    --help, -h  show help
 
-`},
+`,
+		},
 	}
 
 	for _, tc := range tcs {

--- a/help_test.go
+++ b/help_test.go
@@ -1668,6 +1668,7 @@ func TestCategorizedHelp(t *testing.T) {
 				},
 			},
 		},
+		SortCategories: true,
 	}
 
 	HelpPrinter = func(w io.Writer, templ string, data interface{}) {

--- a/help_test.go
+++ b/help_test.go
@@ -1763,8 +1763,8 @@ COMMANDS:
 GLOBAL OPTIONS:
    B
 
-   --B_flag_2 value  
    --B_flag_1 value  
+   --B_flag_2 value  
 
    A
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- bug
- feature

## What this PR does / why we need it:
- Previously, we were sorting the categories in the help output by default. This PR provides a configurable option to sort and does not sort by default. 

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

This PR fixes #1914 
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

- The help command moves to the bottom when `SortCategories` is set to `false` - is this okay? 

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

-  Added unit tests for the `help` command

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Added a field `SortCategories` that will sort the categories and their respective flags in lexicographical order when set to true. 
```
