### PR TITLE
Fix: Use $0 env variable to retrieve current active shell

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -405,7 +405,7 @@ func ExampleCommand_Run_shellComplete_zsh() {
 
 	// Simulate a zsh environment and command line arguments
 	os.Args = []string{"greet", "--generate-shell-completion"}
-	os.Setenv("SHELL", "/usr/bin/zsh")
+	os.Setenv("0", "/usr/bin/zsh")
 
 	_ = cmd.Run(context.Background(), os.Args)
 	// Output:

--- a/help.go
+++ b/help.go
@@ -159,7 +159,7 @@ func printCommandSuggestions(commands []*Command, writer io.Writer) {
 		if command.Hidden {
 			continue
 		}
-		if strings.HasSuffix(os.Getenv("SHELL"), "zsh") {
+		if strings.HasSuffix(os.Getenv("0"), "zsh") {
 			_, _ = fmt.Fprintf(writer, "%s:%s\n", command.Name, command.Usage)
 		} else {
 			_, _ = fmt.Fprintf(writer, "%s\n", command.Name)


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:
This is a fix to [bug- Shell completions are broken when login shell is different than currently active shell #1884
](https://github.com/urfave/cli/issues/1884)
- Using `$0` as an env variable instead of `SHELL` as `$0` gives the currently active shell

## Which issue(s) this PR fixes:
[Fixes the bug- Shell completions are broken when a login shell is different than currently active shell #1884
](https://github.com/urfave/cli/issues/1884)

## Special notes for your reviewer:

## Testing
Updated the existing test case.

## Release Notes
```release-note
Fixed https://github.com/urfave/cli/issues/1884
```
