### PR TITLE
[Backport] Fix: Use $0 env var to correctly retrieve the current active shell

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -369,7 +369,7 @@ func ExampleApp_Run_bashComplete() {
 func ExampleApp_Run_zshComplete() {
 	// set args for examples sake
 	os.Args = []string{"greet", "--generate-bash-completion"}
-	_ = os.Setenv("SHELL", "/usr/bin/zsh")
+	_ = os.Setenv("0", "/usr/bin/zsh")
 
 	app := NewApp()
 	app.Name = "greet"

--- a/help.go
+++ b/help.go
@@ -150,7 +150,7 @@ func printCommandSuggestions(commands []*Command, writer io.Writer) {
 		if command.Hidden {
 			continue
 		}
-		if strings.HasSuffix(os.Getenv("SHELL"), "zsh") {
+		if strings.HasSuffix(os.Getenv("0"), "zsh") {
 			for _, name := range command.Names() {
 				_, _ = fmt.Fprintf(writer, "%s:%s\n", name, command.Usage)
 			}


### PR DESCRIPTION
## What type of PR is this?

This is a backport for #1969 which fixes #1884

## Release Notes

```release-note
Fixes #1884 - Shell completions are broken when the login shell is different than the currently active shell.
```
