### PR TITLE
Update dependencies in v2-maint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/urfave/cli/v2
 go 1.18
 
 require (
-	github.com/BurntSushi/toml v1.3.2
-	github.com/cpuguy83/go-md2man/v2 v2.0.4
+	github.com/BurntSushi/toml v1.4.0
+	github.com/cpuguy83/go-md2man/v2 v2.0.5
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
+github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -2,12 +2,10 @@
 .TH greet 8
 
 .SH NAME
-.PP
-greet - Some app
+greet \- Some app
 
 
 .SH SYNOPSIS
-.PP
 greet
 
 .EX
@@ -18,7 +16,6 @@ greet
 
 
 .SH DESCRIPTION
-.PP
 Description of the application.
 
 .PP
@@ -30,7 +27,6 @@ app [first_arg] [second_arg]
 
 
 .SH GLOBAL OPTIONS
-.PP
 \fB--another-flag, -b\fP: another usage text
 
 .PP
@@ -42,7 +38,6 @@ app [first_arg] [second_arg]
 
 .SH COMMANDS
 .SH config, c
-.PP
 another usage test
 
 .PP
@@ -52,7 +47,6 @@ another usage test
 \fB--flag, --fl, -f\fP="":
 
 .SS sub-config, s, ss
-.PP
 another usage test
 
 .PP
@@ -62,12 +56,10 @@ another usage test
 \fB--sub-flag, --sub-fl, -s\fP="":
 
 .SH info, i, in
-.PP
 retrieve generic information
 
 .SH some-command
 .SH usage, u
-.PP
 standard usage text
 
 .EX
@@ -90,7 +82,6 @@ Should be a part of the same code block
 \fB--flag, --fl, -f\fP="":
 
 .SS sub-usage, su
-.PP
 standard usage text
 
 .PP


### PR DESCRIPTION
## What type of PR is this?

- maintenance

## What this PR does / why we need it:

Update to latest dependency versions and introduce diffing to the file comparison test func, but without bringing in a dependency like the `v1-maint` branch.

## Which issue(s) this PR fixes:

N/A
