### PR TITLE
Revert "fix: /bin/zsh env variable to retrieve current active shell"

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -405,7 +405,7 @@ func ExampleCommand_Run_shellComplete_zsh() {
 
 	// Simulate a zsh environment and command line arguments
 	os.Args = []string{"greet", "--generate-shell-completion"}
-	os.Setenv("0", "/usr/bin/zsh")
+	os.Setenv("SHELL", "/usr/bin/zsh")
 
 	_ = cmd.Run(context.Background(), os.Args)
 	// Output:

--- a/help.go
+++ b/help.go
@@ -164,7 +164,7 @@ func printCommandSuggestions(commands []*Command, writer io.Writer) {
 		if command.Hidden {
 			continue
 		}
-		if strings.HasSuffix(os.Getenv("0"), "zsh") {
+		if strings.HasSuffix(os.Getenv("SHELL"), "zsh") {
 			_, _ = fmt.Fprintf(writer, "%s:%s\n", command.Name, command.Usage)
 		} else {
 			_, _ = fmt.Fprintf(writer, "%s\n", command.Name)


### PR DESCRIPTION
## What type of PR is this?

This is a bug (regression) fix.

This PR reverts what was done in PR #1969, i.e. it broke displaying long descriptions in zsh.

More details can be seen in [this comment](https://github.com/urfave/cli/pull/1969#issuecomment-2440287160).