### PR TITLE
improve output of build.go#downloadFile when download fails

### DIFF
--- a/scripts/build.go
+++ b/scripts/build.go
@@ -208,7 +208,7 @@ func downloadFile(src, dest string, dirPerm, perm os.FileMode) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("download response %[1]v", resp.StatusCode)
+		return fmt.Errorf("download file from %[2]s into %[3]s: response %[1]v", resp.StatusCode, src, dest)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(dest), dirPerm); err != nil {


### PR DESCRIPTION
The current error message left me with nothing to debug.

Turns out there was no executable for my arm64 drawing machine. See https://github.com/urfave/gfmrun/pull/35