### PR TITLE
Use `cmd.Name` when generating completion script

### DIFF
--- a/command.go
+++ b/command.go
@@ -257,7 +257,7 @@ func (cmd *Command) setupDefaults(osArgs []string) {
 	}
 
 	if cmd.EnableShellCompletion || cmd.Root().shellCompletion {
-		completionCommand := buildCompletionCommand(osArgs[0])
+		completionCommand := buildCompletionCommand(cmd.Name)
 
 		if cmd.ShellCompletionCommandName != "" {
 			tracef(


### PR DESCRIPTION
This PR fixes a bug in completion scripts when the binary is called in any other way than by simply typing its name. Examples:

- When installing my program `emu` with Homebrew, `os.Args[0]` is `/opt/homebrew/Cellar/emu/0.2.16/bin/emu`.

- When running my program `emu` like this: `./emu`, then `os.Args[0]` is `./emu`.

This breaks the completion script.
I think using root command's `cmd.Name` is a good way to fix it.


[Also discussed here](https://github.com/urfave/cli/pull/1998#discussion_r1819174294)