### PR TITLE
Use actions/setup-python in publish-docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -58,16 +58,12 @@ jobs:
           cache-dependency-path: mkdocs-reqs.txt
           
       - name: Ensure mkdocs is available
-        run: |
-          pip install -r mkdocs-reqs.txt
-          pip freeze
+        run: make ensure-mkdocs
 
       - name: Set mkdocs remote
-        run: |
-          git remote rm origin
-          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/urfave/cli.git"
+        run: make set-mkdocs-remote
+        env:
+          MKDOCS_REMOTE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy via mkdocs
-        run: |
-          which mkdocs
-          mkdocs gh-deploy --force
+        run: make deploy-mkdocs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -58,23 +58,16 @@ jobs:
           cache-dependency-path: mkdocs-reqs.txt
           
       - name: Ensure mkdocs is available
-        #run: make ensure-mkdocs
-        #env:
-        #  FLAGS: --upgrade-pip
         run: |
           pip install -r mkdocs-reqs.txt
           pip freeze
 
       - name: Set mkdocs remote
-        #run: make set-mkdocs-remote
-        #env:
-        #  MKDOCS_REMOTE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git remote rm origin
           git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/urfave/cli.git"
 
       - name: Deploy via mkdocs
-        #run: make deploy-mkdocs
         run: |
           which mkdocs
           mkdocs gh-deploy --force

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -75,4 +75,6 @@ jobs:
 
       - name: Deploy via mkdocs
         #run: make deploy-mkdocs
-        run: mkdocs gh-deploy --force
+        run: |
+          which mkdocs
+          mkdocs gh-deploy --force

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - publish-docs-python-shuffle
     tags:
       - v3.*
 
@@ -41,7 +42,7 @@ jobs:
   publish:
     permissions:
       contents: write
-    if: startswith(github.ref, 'refs/tags/')
+    #if: startswith(github.ref, 'refs/tags/')
     name: publish
     needs: [test-docs]
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -34,13 +34,13 @@ jobs:
 
       - run: make gfmrun
         env:
-            FLAGS: --walk docs/v3/
+          FLAGS: --walk docs/v3/
 
       - run: make diffcheck
 
   publish:
     permissions:
-        contents: write
+      contents: write
     if: startswith(github.ref, 'refs/tags/')
     name: publish
     needs: [test-docs]
@@ -50,21 +50,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create virtual environment
-        run: |
-          python -m venv venv
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
           
-      - run: |
-          . venv/bin/activate          
-          make ensure-mkdocs
+      - name: Ensure mkdocs is available
+        run: make ensure-mkdocs
         env:
           FLAGS: --upgrade-pip
 
-      - run: make set-mkdocs-remote
+      - name: Set mkdocs remote
+        run: make set-mkdocs-remote
         env:
           MKDOCS_REMOTE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: |
-          . venv/bin/activate          
-          make deploy-mkdocs
-        
+      - name: Deploy via mkdocs
+        run: make deploy-mkdocs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -61,7 +61,9 @@ jobs:
         #run: make ensure-mkdocs
         #env:
         #  FLAGS: --upgrade-pip
-        run: pip install -r mkdocs-reqs.txt
+        run: |
+          pip install -r mkdocs-reqs.txt
+          pip freeze
 
       - name: Set mkdocs remote
         #run: make set-mkdocs-remote

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -58,14 +58,18 @@ jobs:
           cache-dependency-path: mkdocs-reqs.txt
           
       - name: Ensure mkdocs is available
-        run: make ensure-mkdocs
-        env:
-          FLAGS: --upgrade-pip
+        #run: make ensure-mkdocs
+        #env:
+        #  FLAGS: --upgrade-pip
+        run: pip install -r mkdocs-reqs.txt
 
       - name: Set mkdocs remote
-        run: make set-mkdocs-remote
-        env:
-          MKDOCS_REMOTE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #run: make set-mkdocs-remote
+        #env:
+        #  MKDOCS_REMOTE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote rm origin
+          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/urfave/cli.git"
 
       - name: Deploy via mkdocs
         #run: make deploy-mkdocs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           python-version: '3.13'
           cache: pip
+          cache-dependency-path: mkdocs-reqs.txt
           
       - name: Ensure mkdocs is available
         run: make ensure-mkdocs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - publish-docs-python-shuffle
     tags:
       - v3.*
 
@@ -42,7 +41,7 @@ jobs:
   publish:
     permissions:
       contents: write
-    #if: startswith(github.ref, 'refs/tags/')
+    if: startswith(github.ref, 'refs/tags/')
     name: publish
     needs: [test-docs]
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -68,4 +68,5 @@ jobs:
           MKDOCS_REMOTE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy via mkdocs
-        run: make deploy-mkdocs
+        #run: make deploy-mkdocs
+        run: mkdocs gh-deploy --force

--- a/mkdocs-reqs.txt
+++ b/mkdocs-reqs.txt
@@ -1,5 +1,4 @@
 mkdocs-git-revision-date-localized-plugin~=1.2
-mkdocs-material-extensions~=1.3
-mkdocs-material~=8.5
+mkdocs-material~=9.5
 mkdocs~=1.6
 pygments~=2.18


### PR DESCRIPTION
instead of managing a virtualenv directly which hopefully resolves the problem with mkdocs not finding its extensions.

**Update**: bumping the version of `mkdocs-material` seems to have done the trick

## What type of PR is this?

- bug
- cleanup
- documentation

## What this PR does / why we need it:

so that documentation is published from `main` and `v3` tags again

## Which issue(s) this PR fixes:

N/A ; maybe [this comment](https://github.com/urfave/cli/pull/2018#pullrequestreview-2468948364)
