### PR TITLE
Run Before actions after setting up subcommand

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -2649,7 +2649,7 @@ func TestFlagAction(t *testing.T) {
 		{
 			name: "mixture",
 			args: []string{"app", "--f_string=app", "--f_uint=1", "--f_int_slice=1,2,3", "--f_duration=1h30m20s", "c1", "--f_string=c1", "sub1", "--f_string=sub1"},
-			exp:  "app 1h30m20s [1 2 3] 1 c1 sub1 ",
+			exp:  "sub1 1h30m20s [1 2 3] 1 sub1 sub1 ",
 		},
 		{
 			name: "flag_string_map",


### PR DESCRIPTION
I'm posting this to explore a possible resolution for #2027. 

Let me explain the change to `TestFlagAction/mixture`. The test shows a behavior difference introduced by this PR: since flag actions will now run after all flags have been set, the test does not see the 'shadowed' flag `--f_string=app`. I personally think the new behavior is more correct: the flag is shadowed after all.

I can't really think of a scenario in a real app where you would want to set the same flag two times with different values for the root command and the subcommand. So I propose to change the test, locking in the new behavior.

I have also added a test for issue #2027 here.

## What type of PR is this?

- bug
- cleanup

## What this PR does / why we need it:

This fixes an issue where the Before hook of a parent command would not see flag values set in the subcommand context.

## Which issue(s) this PR fixes:

Fixes #2027 
