### PR TITLE
Support root level map keys in map sources

### DIFF
--- a/value_source.go
+++ b/value_source.go
@@ -189,12 +189,19 @@ func (ms *mapSource) GoString() string {
 	return fmt.Sprintf("&mapSource{name:%[1]q}", ms.name)
 }
 
+// Lookup returns a value from the map source. The lookup name may be a dot-separated path into the map.
+// If that is the case, it will recursively traverse the map based on the '.' delimited sections to find
+// a nested value for the key.
 func (ms *mapSource) Lookup(name string) (any, bool) {
-	// nestedVal checks if the name has '.' delimiters.
-	// If so, it tries to traverse the tree by the '.' delimited sections to find
-	// a nested value for the key.
-	if sections := strings.Split(name, "."); len(sections) > 1 {
-		node := ms.m
+	sections := strings.Split(name, ".")
+	if name == "" || len(sections) == 0 {
+		return nil, false
+	}
+
+	node := ms.m
+
+	// traverse into the map based on the dot-separated sections
+	if len(sections) >= 2 { // the last section is the value we want, we will return it directly at the end
 		for _, section := range sections[:len(sections)-1] {
 			child, ok := node[section]
 			if !ok {
@@ -213,11 +220,11 @@ func (ms *mapSource) Lookup(name string) (any, bool) {
 				return nil, false
 			}
 		}
-		if val, ok := node[sections[len(sections)-1]]; ok {
-			return val, true
-		}
 	}
 
+	if val, ok := node[sections[len(sections)-1]]; ok {
+		return val, true
+	}
 	return nil, false
 }
 

--- a/value_source_test.go
+++ b/value_source_test.go
@@ -222,6 +222,15 @@ func TestMapValueSource(t *testing.T) {
 			},
 		},
 		{
+			name: "Level 1",
+			key:  "foobar",
+			m: map[any]any{
+				"foobar": 10,
+			},
+			val:   "10",
+			found: true,
+		},
+		{
 			name: "Level 2",
 			key:  "foo.bar",
 			m: map[any]any{
@@ -237,6 +246,15 @@ func TestMapValueSource(t *testing.T) {
 			key:  "foo.bar1",
 			m: map[any]any{
 				"foo": map[any]any{
+					"bar": "10",
+				},
+			},
+		},
+		{
+			name: "Level 2 string map type",
+			key:  "foo.bar1",
+			m: map[any]any{
+				"foo": map[string]any{
 					"bar": "10",
 				},
 			},


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

It fixes a bug in `MapValueSource` where lookup doesn't work for keys directly in the first level (root) of the map.

## Which issue(s) this PR fixes:

Fixes #2037 

## Special notes for your reviewer:

The issue is related to this one I raised in `cli-altsrc`: https://github.com/urfave/cli-altsrc/issues/14
I'll create a similar PR there as well.

## Testing

I added a test case for this exact issue as well. It will fail without changes from the PR.
I also added another test case for the `map[string]any` special case that was in place in the code, to make sure that works to.

