### PR TITLE
Fix:(issue_2077) Make sure onUsageError is invoked for command when a…

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -94,7 +94,14 @@ func TestArgumentsSubcommand(t *testing.T) {
 		},
 	}
 
+	numUsageErrors := 0
+	cmd.Commands[0].OnUsageError = func(ctx context.Context, cmd *Command, err error, isSubcommand bool) error {
+		numUsageErrors++
+		return err
+	}
+
 	require.Error(t, errors.New("sufficient count of arg sa not provided, given 0 expected 1"), cmd.Run(context.Background(), []string{"foo", "subcmd", "2006-01-02T15:04:05Z"}))
+	require.Equal(t, 1, numUsageErrors)
 
 	require.NoError(t, cmd.Run(context.Background(), []string{"foo", "subcmd", "2006-01-02T15:04:05Z", "fubar"}))
 	require.Equal(t, time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), tval)

--- a/command_run.go
+++ b/command_run.go
@@ -313,6 +313,10 @@ func (cmd *Command) Run(ctx context.Context, osArgs []string) (deferErr error) {
 			rargs, err = arg.Parse(rargs)
 			if err != nil {
 				tracef("calling with %[1]v (cmd=%[2]q)", err, cmd.Name)
+				if cmd.OnUsageError != nil {
+					err = cmd.OnUsageError(ctx, cmd, err, cmd.parent != nil)
+				}
+				err = cmd.handleExitCoder(ctx, err)
 				return err
 			}
 		}


### PR DESCRIPTION
…rgs are in error

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

Fixes #2077 

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

go test -run=TestArgumentsSubcommand

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
OnUsageError() is invoked for errors in arg parsing as well. 
```
