### PR TITLE
Fix:(issue_2056) Add cmd.XXXArgs() functions for retrieving args

### DIFF
--- a/args.go
+++ b/args.go
@@ -64,6 +64,7 @@ func (a *stringSliceArgs) Slice() []string {
 type Argument interface {
 	Parse([]string) ([]string, error)
 	Usage() string
+	Get() any
 }
 
 // AnyArguments to differentiate between no arguments(nil) vs aleast one
@@ -148,6 +149,16 @@ func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error) {
 	}
 
 	return s[count:], nil
+}
+
+func (a *ArgumentBase[T, C, VC]) Get() any {
+	if a.Values == nil {
+		return nil
+	}
+	if a.Max == 1 {
+		return (*a.Values)[0]
+	}
+	return *a.Values
 }
 
 type (

--- a/args.go
+++ b/args.go
@@ -197,6 +197,7 @@ func (c *Command) StringArgs(name string) []string {
 
 func (c *Command) FloatArgs(name string) []float64 {
 	val := c.getArgValue(name)
+	tracef("command %s found args %s %v", c.Name, name, val)
 	if a, ok := val.([]float64); ok {
 		return a
 	}

--- a/args.go
+++ b/args.go
@@ -227,17 +227,33 @@ func (a *ArgumentsBase[T, C, VC]) Get() any {
 
 type (
 	FloatArg      = ArgumentBase[float64, NoConfig, floatValue]
-	IntArg        = ArgumentBase[int64, IntegerConfig, intValue]
+	IntArg        = ArgumentBase[int, IntegerConfig, intValue[int]]
+	Int8Arg       = ArgumentBase[int8, IntegerConfig, intValue[int8]]
+	Int16Arg      = ArgumentBase[int16, IntegerConfig, intValue[int16]]
+	Int32Arg      = ArgumentBase[int32, IntegerConfig, intValue[int32]]
+	Int64Arg      = ArgumentBase[int64, IntegerConfig, intValue[int64]]
 	StringArg     = ArgumentBase[string, StringConfig, stringValue]
 	StringMapArgs = ArgumentBase[map[string]string, StringConfig, StringMap]
 	TimestampArg  = ArgumentBase[time.Time, TimestampConfig, timestampValue]
-	UintArg       = ArgumentBase[uint64, IntegerConfig, uintValue]
+	UintArg       = ArgumentBase[uint, IntegerConfig, uintValue[uint]]
+	Uint8Arg      = ArgumentBase[uint8, IntegerConfig, uintValue[uint8]]
+	Uint16Arg     = ArgumentBase[uint16, IntegerConfig, uintValue[uint16]]
+	Uint32Arg     = ArgumentBase[uint32, IntegerConfig, uintValue[uint32]]
+	Uint64Arg     = ArgumentBase[uint64, IntegerConfig, uintValue[uint64]]
 
 	FloatArgs     = ArgumentsBase[float64, NoConfig, floatValue]
-	IntArgs       = ArgumentsBase[int64, IntegerConfig, intValue]
+	IntArgs       = ArgumentsBase[int, IntegerConfig, intValue[int]]
+	Int8Args      = ArgumentsBase[int8, IntegerConfig, intValue[int8]]
+	Int16Args     = ArgumentsBase[int16, IntegerConfig, intValue[int16]]
+	Int32Args     = ArgumentsBase[int32, IntegerConfig, intValue[int32]]
+	Int64Args     = ArgumentsBase[int64, IntegerConfig, intValue[int64]]
 	StringArgs    = ArgumentsBase[string, StringConfig, stringValue]
 	TimestampArgs = ArgumentsBase[time.Time, TimestampConfig, timestampValue]
-	UintArgs      = ArgumentsBase[uint64, IntegerConfig, uintValue]
+	UintArgs      = ArgumentsBase[uint, IntegerConfig, uintValue[uint]]
+	Uint8Args     = ArgumentsBase[uint8, IntegerConfig, uintValue[uint8]]
+	Uint16Args    = ArgumentsBase[uint16, IntegerConfig, uintValue[uint16]]
+	Uint32Args    = ArgumentsBase[uint32, IntegerConfig, uintValue[uint32]]
+	Uint64Args    = ArgumentsBase[uint64, IntegerConfig, uintValue[uint64]]
 )
 
 func (c *Command) getArgValue(name string) any {
@@ -252,82 +268,115 @@ func (c *Command) getArgValue(name string) any {
 	return nil
 }
 
-func (c *Command) StringArg(name string) string {
+func arg[T any](name string, c *Command) T {
 	val := c.getArgValue(name)
-	if a, ok := val.(string); ok {
+	if a, ok := val.(T); ok {
 		return a
 	}
-	return ""
+	var zero T
+	return zero
+}
+
+func (c *Command) StringArg(name string) string {
+	return arg[string](name, c)
 }
 
 func (c *Command) StringArgs(name string) []string {
-	val := c.getArgValue(name)
-	if a, ok := val.([]string); ok {
-		return a
-	}
-	return nil
+	return arg[[]string](name, c)
 }
 
 func (c *Command) FloatArg(name string) float64 {
-	val := c.getArgValue(name)
-	if a, ok := val.(float64); ok {
-		return a
-	}
-	return 0
+	return arg[float64](name, c)
 }
 
 func (c *Command) FloatArgs(name string) []float64 {
-	val := c.getArgValue(name)
-	if a, ok := val.([]float64); ok {
-		return a
-	}
-	return nil
+	return arg[[]float64](name, c)
 }
 
-func (c *Command) IntArg(name string) int64 {
-	val := c.getArgValue(name)
-	if a, ok := val.(int64); ok {
-		return a
-	}
-	return 0
+func (c *Command) IntArg(name string) int {
+	return arg[int](name, c)
 }
 
-func (c *Command) IntArgs(name string) []int64 {
-	val := c.getArgValue(name)
-	if a, ok := val.([]int64); ok {
-		return a
-	}
-	return nil
+func (c *Command) IntArgs(name string) []int {
+	return arg[[]int](name, c)
 }
 
-func (c *Command) UintArg(name string) uint64 {
-	val := c.getArgValue(name)
-	if a, ok := val.(uint64); ok {
-		return a
-	}
-	return 0
+func (c *Command) Int8Arg(name string) int8 {
+	return arg[int8](name, c)
 }
 
-func (c *Command) UintArgs(name string) []uint64 {
-	val := c.getArgValue(name)
-	if a, ok := val.([]uint64); ok {
-		return a
-	}
-	return nil
+func (c *Command) Int8Args(name string) []int8 {
+	return arg[[]int8](name, c)
+}
+
+func (c *Command) Int16Arg(name string) int16 {
+	return arg[int16](name, c)
+}
+
+func (c *Command) Int16Args(name string) []int16 {
+	return arg[[]int16](name, c)
+}
+
+func (c *Command) Int32Arg(name string) int32 {
+	return arg[int32](name, c)
+}
+
+func (c *Command) Int32Args(name string) []int32 {
+	return arg[[]int32](name, c)
+}
+
+func (c *Command) Int64Arg(name string) int64 {
+	return arg[int64](name, c)
+}
+
+func (c *Command) Int64Args(name string) []int64 {
+	return arg[[]int64](name, c)
+}
+
+func (c *Command) UintArg(name string) uint {
+	return arg[uint](name, c)
+}
+
+func (c *Command) Uint8Arg(name string) uint8 {
+	return arg[uint8](name, c)
+}
+
+func (c *Command) Uint16Arg(name string) uint16 {
+	return arg[uint16](name, c)
+}
+
+func (c *Command) Uint32Arg(name string) uint32 {
+	return arg[uint32](name, c)
+}
+
+func (c *Command) Uint64Arg(name string) uint64 {
+	return arg[uint64](name, c)
+}
+
+func (c *Command) UintArgs(name string) []uint {
+	return arg[[]uint](name, c)
+}
+
+func (c *Command) Uint8Args(name string) []uint8 {
+	return arg[[]uint8](name, c)
+}
+
+func (c *Command) Uint16Args(name string) []uint16 {
+	return arg[[]uint16](name, c)
+}
+
+func (c *Command) Uint32Args(name string) []uint32 {
+	return arg[[]uint32](name, c)
+}
+
+func (c *Command) Uint64Args(name string) []uint64 {
+	return arg[[]uint64](name, c)
 }
 
 func (c *Command) TimestampArg(name string) time.Time {
-	val := c.getArgValue(name)
-	if a, ok := val.(time.Time); ok {
-		return a
-	}
-	return time.Time{}
+	return arg[time.Time](name, c)
 }
 
 func (c *Command) TimestampArgs(name string) []time.Time {
-	val := c.getArgValue(name)
-	if a, ok := val.([]time.Time); ok {
-		return a
-	}
-	return nil
+	return arg[[]time.Time](name, c)
 }

--- a/args.go
+++ b/args.go
@@ -160,7 +160,10 @@ func (a *ArgumentsBase[T, C, VC]) Parse(s []string) ([]string, error) {
 }
 
 func (a *ArgumentsBase[T, C, VC]) Get() any {
-	return a.values
+	if a.values != nil {
+		return a.values
+	}
+	return []T{}
 }
 
 type (
@@ -172,67 +175,54 @@ type (
 	UintArgs      = ArgumentsBase[uint64, IntegerConfig, uintValue]
 )
 
-func (c *Command) StringArgs(name string) []string {
+func (c *Command) getArgValue(name string) any {
+	tracef("command %s looking for args %s", c.Name, name)
 	for _, arg := range c.Arguments {
 		if arg.HasName(name) {
-			if a, ok := arg.Get().([]string); ok {
-				return a
-			} else {
-				return nil
-			}
+			tracef("command %s found args %s", c.Name, name)
+			return arg.Get()
 		}
+	}
+	tracef("command %s did not find args %s", c.Name, name)
+	return nil
+}
+
+func (c *Command) StringArgs(name string) []string {
+	val := c.getArgValue(name)
+	if a, ok := val.([]string); ok {
+		return a
 	}
 	return nil
 }
 
 func (c *Command) FloatArgs(name string) []float64 {
-	for _, arg := range c.Arguments {
-		if arg.HasName(name) {
-			if a, ok := arg.Get().([]float64); ok {
-				return a
-			} else {
-				return nil
-			}
-		}
+	val := c.getArgValue(name)
+	if a, ok := val.([]float64); ok {
+		return a
 	}
 	return nil
 }
 
 func (c *Command) IntArgs(name string) []int64 {
-	for _, arg := range c.Arguments {
-		if arg.HasName(name) {
-			if a, ok := arg.Get().([]int64); ok {
-				return a
-			} else {
-				return nil
-			}
-		}
+	val := c.getArgValue(name)
+	if a, ok := val.([]int64); ok {
+		return a
 	}
 	return nil
 }
 
 func (c *Command) UintArgs(name string) []uint64 {
-	for _, arg := range c.Arguments {
-		if arg.HasName(name) {
-			if a, ok := arg.Get().([]uint64); ok {
-				return a
-			} else {
-				return nil
-			}
-		}
+	val := c.getArgValue(name)
+	if a, ok := val.([]uint64); ok {
+		return a
 	}
 	return nil
 }
 
 func (c *Command) TimestampArgs(name string) []time.Time {
-	for _, arg := range c.Arguments {
-		if arg.HasName(name) {
-			if a, ok := arg.Get().([]time.Time); ok {
-				return a
-			} else {
-				return nil
-			}
-		}
+	val := c.getArgValue(name)
+	if a, ok := val.([]time.Time); ok {
+		return a
 	}
 	return nil
 }

--- a/args.go
+++ b/args.go
@@ -61,10 +61,19 @@ func (a *stringSliceArgs) Slice() []string {
 	return ret
 }
 
+// Argument captures a positional argument that can
+// be parsed
 type Argument interface {
+	// which this argument can be accessed using the given name
 	HasName(string) bool
+
+	// Parse the given args and return unparsed args and/or error
 	Parse([]string) ([]string, error)
+
+	// The usage template for this argument to use in help
 	Usage() string
+
+	// The Value of this Arg
 	Get() any
 }
 
@@ -126,10 +135,12 @@ func (a *ArgumentsBase[T, C, VC]) Parse(s []string) ([]string, error) {
 	value := vc.Create(a.Value, &t, a.Config)
 	a.values = []T{}
 
+	tracef("attempting arg%[1] parse", &a.Name)
 	for _, arg := range s {
 		if err := value.Set(arg); err != nil {
 			return s, err
 		}
+		tracef("set arg%[1] one value", &a.Name, value.Get().(T))
 		a.values = append(a.values, value.Get().(T))
 		count++
 		if count >= a.Max && a.Max > -1 {
@@ -141,7 +152,8 @@ func (a *ArgumentsBase[T, C, VC]) Parse(s []string) ([]string, error) {
 	}
 
 	if a.Destination != nil {
-		*a.Destination = a.values
+		tracef("appending destination")
+		*a.Destination = append(*a.Destination, a.values...)
 	}
 
 	return s[count:], nil
@@ -163,7 +175,11 @@ type (
 func (c *Command) StringArgs(name string) []string {
 	for _, arg := range c.Arguments {
 		if arg.HasName(name) {
-			return arg.Get().([]string)
+			if a, ok := arg.Get().([]string); ok {
+				return a
+			} else {
+				return nil
+			}
 		}
 	}
 	return nil
@@ -172,7 +188,11 @@ func (c *Command) StringArgs(name string) []string {
 func (c *Command) FloatArgs(name string) []float64 {
 	for _, arg := range c.Arguments {
 		if arg.HasName(name) {
-			return arg.Get().([]float64)
+			if a, ok := arg.Get().([]float64); ok {
+				return a
+			} else {
+				return nil
+			}
 		}
 	}
 	return nil
@@ -181,7 +201,11 @@ func (c *Command) FloatArgs(name string) []float64 {
 func (c *Command) IntArgs(name string) []int64 {
 	for _, arg := range c.Arguments {
 		if arg.HasName(name) {
-			return arg.Get().([]int64)
+			if a, ok := arg.Get().([]int64); ok {
+				return a
+			} else {
+				return nil
+			}
 		}
 	}
 	return nil
@@ -190,7 +214,11 @@ func (c *Command) IntArgs(name string) []int64 {
 func (c *Command) UintArgs(name string) []uint64 {
 	for _, arg := range c.Arguments {
 		if arg.HasName(name) {
-			return arg.Get().([]uint64)
+			if a, ok := arg.Get().([]uint64); ok {
+				return a
+			} else {
+				return nil
+			}
 		}
 	}
 	return nil
@@ -199,7 +227,11 @@ func (c *Command) UintArgs(name string) []uint64 {
 func (c *Command) TimestampArgs(name string) []time.Time {
 	for _, arg := range c.Arguments {
 		if arg.HasName(name) {
-			return arg.Get().([]time.Time)
+			if a, ok := arg.Get().([]time.Time); ok {
+				return a
+			} else {
+				return nil
+			}
 		}
 	}
 	return nil

--- a/args.go
+++ b/args.go
@@ -153,7 +153,7 @@ func (a *ArgumentsBase[T, C, VC]) Parse(s []string) ([]string, error) {
 
 	if a.Destination != nil {
 		tracef("appending destination")
-		*a.Destination = append(*a.Destination, a.values...)
+		*a.Destination = a.values // append(*a.Destination, a.values...)
 	}
 
 	return s[count:], nil

--- a/args_test.go
+++ b/args_test.go
@@ -328,6 +328,33 @@ func TestArgumentsSubcommand(t *testing.T) {
 	}
 }
 
+func TestArgUsage(t *testing.T) {
+	arg := &IntArg{
+		Name: "ia",
+	}
+	tests := []struct {
+		name     string
+		usage    string
+		expected string
+	}{
+		{
+			name:     "default",
+			expected: "ia",
+		},
+		{
+			name:     "usage",
+			usage:    "foo-usage",
+			expected: "foo-usage",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			arg.UsageText = test.usage
+			require.Equal(t, test.expected, arg.Usage())
+		})
+	}
+}
+
 func TestArgsUsage(t *testing.T) {
 	arg := &IntArgs{
 		Name: "ia",

--- a/args_test.go
+++ b/args_test.go
@@ -12,52 +12,52 @@ func TestArgumentsRootCommand(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           []string
-		expectedIvals  []int64
-		expectedUivals []uint64
+		expectedIvals  []int
+		expectedUivals []uint
 		expectedFvals  []float64
 		errStr         string
 	}{
 		{
 			name:           "set ival",
 			args:           []string{"foo", "10"},
-			expectedIvals:  []int64{10},
-			expectedUivals: []uint64{},
+			expectedIvals:  []int{10},
+			expectedUivals: []uint{},
 			expectedFvals:  []float64{},
 		},
 		{
 			name:           "set invalid ival",
 			args:           []string{"foo", "10.0"},
-			expectedIvals:  []int64{},
-			expectedUivals: []uint64{},
+			expectedIvals:  []int{},
+			expectedUivals: []uint{},
 			expectedFvals:  []float64{},
 			errStr:         "strconv.ParseInt: parsing \"10.0\": invalid syntax",
 		},
 		{
 			name:           "set ival uival",
 			args:           []string{"foo", "-10", "11"},
-			expectedIvals:  []int64{-10},
-			expectedUivals: []uint64{11},
+			expectedIvals:  []int{-10},
+			expectedUivals: []uint{11},
 			expectedFvals:  []float64{},
 		},
 		{
 			name:           "set ival uival fval",
 			args:           []string{"foo", "-12", "14", "10.1"},
-			expectedIvals:  []int64{-12},
-			expectedUivals: []uint64{14},
+			expectedIvals:  []int{-12},
+			expectedUivals: []uint{14},
 			expectedFvals:  []float64{10.1},
 		},
 		{
 			name:           "set ival uival multu fvals",
 			args:           []string{"foo", "-13", "12", "10.1", "11.09"},
-			expectedIvals:  []int64{-13},
-			expectedUivals: []uint64{12},
+			expectedIvals:  []int{-13},
+			expectedUivals: []uint{12},
 			expectedFvals:  []float64{10.1, 11.09},
 		},
 		{
 			name:           "set fvals beyond max",
 			args:           []string{"foo", "13", "10", "10.1", "11.09", "12.1"},
-			expectedIvals:  []int64{13},
-			expectedUivals: []uint64{10},
+			expectedIvals:  []int{13},
+			expectedUivals: []uint{10},
 			expectedFvals:  []float64{10.1, 11.09},
 			errStr:         "No help topic for '12.1'",
 		},
@@ -66,8 +66,8 @@ func TestArgumentsRootCommand(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := buildMinimalTestCommand()
-			var ivals []int64
-			var uivals []uint64
+			var ivals []int
+			var uivals []uint
 			var fvals []float64
 			cmd.Arguments = []Argument{
 				&IntArgs{
@@ -147,7 +147,7 @@ func TestArgumentsSubcommand(t *testing.T) {
 	tests := []struct {
 		name          string
 		args          []string
-		expectedIval  int64
+		expectedIval  int
 		expectedSvals []string
 		expectedTVals []time.Time
 		errStr        string
@@ -176,7 +176,7 @@ func TestArgumentsSubcommand(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := buildMinimalTestCommand()
-			var ival int64
+			var ival int
 			var svals []string
 			var tvals []time.Time
 			cmd.Commands = []*Command{

--- a/args_test.go
+++ b/args_test.go
@@ -20,6 +20,7 @@ func TestArgumentsRootCommand(t *testing.T) {
 			name:          "set ival",
 			args:          []string{"foo", "10"},
 			expectedIvals: []int64{10},
+			expectedFvals: []float64{},
 		},
 		{
 			name:          "set ival fval",
@@ -265,7 +266,7 @@ func TestSingleOptionalArg(t *testing.T) {
 		{
 			name: "no args",
 			args: []string{"foo"},
-			exp:  nil,
+			exp:  []string{},
 		},
 		/*{
 			name: "no arg with def value",
@@ -307,10 +308,11 @@ func TestUnboundedArgs(t *testing.T) {
 		Max: -1,
 	}
 	tests := []struct {
-		name     string
-		args     []string
-		values   []string
-		expected []string
+		name      string
+		args      []string
+		defValues []string
+		values    []string
+		expected  []string
 	}{
 		{
 			name:     "cmd accepts no args",
@@ -325,8 +327,7 @@ func TestUnboundedArgs(t *testing.T) {
 		{
 			name:     "cmd uses default values",
 			args:     []string{"foo"},
-			values:   []string{"zbar", "zbaz"},
-			expected: []string{"zbar", "zbaz"},
+			expected: []string{},
 		},
 		{
 			name:     "given args override default values",

--- a/args_test.go
+++ b/args_test.go
@@ -25,6 +25,14 @@ func TestArgumentsRootCommand(t *testing.T) {
 			expectedFvals:  []float64{},
 		},
 		{
+			name:           "set invalid ival",
+			args:           []string{"foo", "10.0"},
+			expectedIvals:  []int64{},
+			expectedUivals: []uint64{},
+			expectedFvals:  []float64{},
+			errStr:         "strconv.ParseInt: parsing \"10.0\": invalid syntax",
+		},
+		{
 			name:           "set ival uival",
 			args:           []string{"foo", "-10", "11"},
 			expectedIvals:  []int64{-10},
@@ -88,8 +96,9 @@ func TestArgumentsRootCommand(t *testing.T) {
 
 			if test.errStr != "" {
 				r.ErrorContains(err, test.errStr)
+			} else {
+				r.Equal(test.expectedIvals, ivals)
 			}
-			r.Equal(test.expectedIvals, ivals)
 			r.Equal(test.expectedIvals, cmd.IntArgs("ia"))
 			r.Equal(test.expectedFvals, cmd.FloatArgs("fa"))
 			r.Equal(test.expectedUivals, cmd.UintArgs("uia"))

--- a/args_test.go
+++ b/args_test.go
@@ -206,8 +206,16 @@ func TestArgumentsRootCommand(t *testing.T) {
 				r.Equal(test.expectedIvals, ivals)
 			}
 			r.Equal(test.expectedIvals, cmd.IntArgs("ia"))
+			r.Equal(int8(0), cmd.Int8Arg("ia"))
+			r.Equal(int16(0), cmd.Int16Arg("ia"))
+			r.Equal(int32(0), cmd.Int32Arg("ia"))
+			r.Equal(int64(0), cmd.Int64Arg("ia"))
 			r.Equal(test.expectedFvals, cmd.FloatArgs("fa"))
 			r.Equal(test.expectedUivals, cmd.UintArgs("uia"))
+			r.Equal(uint8(0), cmd.Uint8Arg("uia"))
+			r.Equal(uint16(0), cmd.Uint16Arg("uia"))
+			r.Equal(uint32(0), cmd.Uint32Arg("uia"))
+			r.Equal(uint64(0), cmd.Uint64Arg("uia"))
 			/*if test.expectedFvals != nil {
 				r.Equal(test.expectedFvals, fvals)
 			}*/

--- a/args_test.go
+++ b/args_test.go
@@ -8,19 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type intnum interface {
-	int | int8 | int16 | int32 | int64
-}
-
-type uintnum interface {
-	uint | uint8 | uint16 | uint32 | uint64
-}
-
-func intTypes[T intnum](t *testing.T) {
+func TestArgsIntTypes(t *testing.T) {
 	cmd := buildMinimalTestCommand()
-	var ival T
+	var ival int
 	cmd.Arguments = []Argument{
-		&ArgumentBase[T, IntegerConfig, intValue[T]]{
+		&IntArg{
 			Name:        "ia",
 			Destination: &ival,
 		},
@@ -29,15 +21,19 @@ func intTypes[T intnum](t *testing.T) {
 	err := cmd.Run(buildTestContext(t), []string{"foo", "10"})
 	r := require.New(t)
 	r.NoError(err)
-	r.Equal(T(10), ival)
-	r.Equal(T(10), arg[T]("ia", cmd))
+	r.Equal(10, ival)
+	r.Equal(10, cmd.IntArg("ia"))
+	r.Equal(int8(0), cmd.Int8Arg("ia"))
+	r.Equal(int16(0), cmd.Int16Arg("ia"))
+	r.Equal(int32(0), cmd.Int32Arg("ia"))
+	r.Equal(int64(0), cmd.Int64Arg("ia"))
 }
 
-func intArrTypes[T intnum](t *testing.T) {
+func TestArgsIntSliceTypes(t *testing.T) {
 	cmd := buildMinimalTestCommand()
-	var ival []T
+	var ival []int
 	cmd.Arguments = []Argument{
-		&ArgumentsBase[T, IntegerConfig, intValue[T]]{
+		&IntArgs{
 			Name:        "ia",
 			Min:         1,
 			Max:         -1,
@@ -45,18 +41,22 @@ func intArrTypes[T intnum](t *testing.T) {
 		},
 	}
 
-	err := cmd.Run(buildTestContext(t), []string{"foo", "10", "11", "12"})
+	err := cmd.Run(buildTestContext(t), []string{"foo", "10", "20", "30"})
 	r := require.New(t)
 	r.NoError(err)
-	r.Equal([]T{10, 11, 12}, ival)
-	r.Equal([]T{10, 11, 12}, arg[[]T]("ia", cmd))
+	r.Equal([]int{10, 20, 30}, ival)
+	r.Equal([]int{10, 20, 30}, cmd.IntArgs("ia"))
+	r.Nil(cmd.Int8Args("ia"))
+	r.Nil(cmd.Int16Args("ia"))
+	r.Nil(cmd.Int32Args("ia"))
+	r.Nil(cmd.Int64Args("ia"))
 }
 
-func uintTypes[T uintnum](t *testing.T) {
+func TestArgsUintTypes(t *testing.T) {
 	cmd := buildMinimalTestCommand()
-	var ival T
+	var ival uint
 	cmd.Arguments = []Argument{
-		&ArgumentBase[T, IntegerConfig, uintValue[T]]{
+		&UintArg{
 			Name:        "ia",
 			Destination: &ival,
 		},
@@ -65,15 +65,19 @@ func uintTypes[T uintnum](t *testing.T) {
 	err := cmd.Run(buildTestContext(t), []string{"foo", "10"})
 	r := require.New(t)
 	r.NoError(err)
-	r.Equal(T(10), ival)
-	r.Equal(T(10), arg[T]("ia", cmd))
+	r.Equal(uint(10), ival)
+	r.Equal(uint(10), cmd.UintArg("ia"))
+	r.Equal(uint8(0), cmd.Uint8Arg("ia"))
+	r.Equal(uint16(0), cmd.Uint16Arg("ia"))
+	r.Equal(uint32(0), cmd.Uint32Arg("ia"))
+	r.Equal(uint64(0), cmd.Uint64Arg("ia"))
 }
 
-func uintArrTypes[T uintnum](t *testing.T) {
+func TestArgsUintSliceTypes(t *testing.T) {
 	cmd := buildMinimalTestCommand()
-	var ival []T
+	var ival []uint
 	cmd.Arguments = []Argument{
-		&ArgumentsBase[T, IntegerConfig, uintValue[T]]{
+		&UintArgs{
 			Name:        "ia",
 			Min:         1,
 			Max:         -1,
@@ -81,37 +85,15 @@ func uintArrTypes[T uintnum](t *testing.T) {
 		},
 	}
 
-	err := cmd.Run(buildTestContext(t), []string{"foo", "10", "11", "12"})
+	err := cmd.Run(buildTestContext(t), []string{"foo", "10", "20", "30"})
 	r := require.New(t)
 	r.NoError(err)
-	r.Equal([]T{10, 11, 12}, ival)
-	r.Equal([]T{10, 11, 12}, arg[[]T]("ia", cmd))
-}
-
-func TestArgumentsRootCommandAllTypes(t *testing.T) {
-	intTypes[int](t)
-	intTypes[int8](t)
-	intTypes[int16](t)
-	intTypes[int32](t)
-	intTypes[int64](t)
-
-	uintTypes[uint](t)
-	uintTypes[uint8](t)
-	uintTypes[uint16](t)
-	uintTypes[uint32](t)
-	uintTypes[uint64](t)
-
-	intArrTypes[int](t)
-	intArrTypes[int8](t)
-	intArrTypes[int16](t)
-	intArrTypes[int32](t)
-	intArrTypes[int64](t)
-
-	uintArrTypes[uint](t)
-	uintArrTypes[uint8](t)
-	uintArrTypes[uint16](t)
-	uintArrTypes[uint32](t)
-	uintArrTypes[uint64](t)
+	r.Equal([]uint{10, 20, 30}, ival)
+	r.Equal([]uint{10, 20, 30}, cmd.UintArgs("ia"))
+	r.Nil(cmd.Uint8Args("ia"))
+	r.Nil(cmd.Uint16Args("ia"))
+	r.Nil(cmd.Uint32Args("ia"))
+	r.Nil(cmd.Uint64Args("ia"))
 }
 
 func TestArgumentsRootCommand(t *testing.T) {
@@ -206,16 +188,8 @@ func TestArgumentsRootCommand(t *testing.T) {
 				r.Equal(test.expectedIvals, ivals)
 			}
 			r.Equal(test.expectedIvals, cmd.IntArgs("ia"))
-			r.Equal(int8(0), cmd.Int8Arg("ia"))
-			r.Equal(int16(0), cmd.Int16Arg("ia"))
-			r.Equal(int32(0), cmd.Int32Arg("ia"))
-			r.Equal(int64(0), cmd.Int64Arg("ia"))
 			r.Equal(test.expectedFvals, cmd.FloatArgs("fa"))
 			r.Equal(test.expectedUivals, cmd.UintArgs("uia"))
-			r.Equal(uint8(0), cmd.Uint8Arg("uia"))
-			r.Equal(uint16(0), cmd.Uint16Arg("uia"))
-			r.Equal(uint32(0), cmd.Uint32Arg("uia"))
-			r.Equal(uint64(0), cmd.Uint64Arg("uia"))
 			/*if test.expectedFvals != nil {
 				r.Equal(test.expectedFvals, fvals)
 			}*/
@@ -252,9 +226,16 @@ func TestArgumentsInvalidType(t *testing.T) {
 	r := require.New(t)
 	r.Nil(cmd.StringArgs("ia"))
 	r.Nil(cmd.FloatArgs("ia"))
-	r.Nil(cmd.UintArgs("ia"))
+	r.Nil(cmd.Int8Args("ia"))
+	r.Nil(cmd.Int16Args("ia"))
+	r.Nil(cmd.Int32Args("ia"))
+	r.Nil(cmd.Int64Args("ia"))
 	r.Nil(cmd.TimestampArgs("ia"))
-	r.Nil(cmd.IntArgs("uia"))
+	r.Nil(cmd.UintArgs("ia"))
+	r.Nil(cmd.Uint8Args("ia"))
+	r.Nil(cmd.Uint16Args("ia"))
+	r.Nil(cmd.Uint32Args("ia"))
+	r.Nil(cmd.Uint64Args("ia"))
 }
 
 func TestArgumentsSubcommand(t *testing.T) {

--- a/args_test.go
+++ b/args_test.go
@@ -307,32 +307,31 @@ func TestSingleOptionalArg(t *testing.T) {
 		name     string
 		args     []string
 		argValue string
-		exp      []string
+		exp      string
 	}{
 		{
 			name: "no args",
 			args: []string{"foo"},
-			exp:  []string{},
+			exp:  "",
 		},
-		/*{
-			name: "no arg with def value",
-			args: []string{"foo"},
-			exp:  []string{"bar"},
-		},*/
+		{
+			name:     "no arg with def value",
+			args:     []string{"foo"},
+			argValue: "bar",
+			exp:      "bar",
+		},
 		{
 			name: "one arg",
 			args: []string{"foo", "zbar"},
-			exp:  []string{"zbar"},
+			exp:  "zbar",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := buildMinimalTestCommand()
-			var s1 []string
-			arg := &StringArgs{
-				Min:         0,
-				Max:         1,
+			var s1 string
+			arg := &StringArg{
 				Value:       test.argValue,
 				Destination: &s1,
 			}

--- a/args_test.go
+++ b/args_test.go
@@ -22,6 +22,7 @@ func TestArgumentsRootCommand(t *testing.T) {
 			args:           []string{"foo", "10"},
 			expectedIvals:  []int64{10},
 			expectedUivals: []uint64{},
+			expectedFvals:  []float64{},
 		},
 		{
 			name:           "set ival uival",
@@ -90,12 +91,10 @@ func TestArgumentsRootCommand(t *testing.T) {
 			}
 			r.Equal(test.expectedIvals, ivals)
 			r.Equal(test.expectedIvals, cmd.IntArgs("ia"))
-			if test.expectedFvals != nil {
+			r.Equal(test.expectedFvals, cmd.FloatArgs("fa"))
+			/*if test.expectedFvals != nil {
 				r.Equal(test.expectedFvals, fvals)
-				r.Equal(test.expectedFvals, cmd.FloatArgs("fa"))
-			} else {
-				r.Equal([]float64{}, cmd.FloatArgs("fa"))
-			}
+			}*/
 		})
 	}
 
@@ -115,6 +114,22 @@ func TestArgumentsRootCommand(t *testing.T) {
 
 	   require.NoError(t, cmd.Run(context.Background(), []string{"foo", "10"}))
 	*/
+}
+
+func TestArgumentsInvalidType(t *testing.T) {
+	cmd := buildMinimalTestCommand()
+	cmd.Arguments = []Argument{
+		&IntArgs{
+			Name: "ia",
+			Min:  1,
+			Max:  1,
+		},
+	}
+	r := require.New(t)
+	r.Nil(cmd.StringArgs("ia"))
+	r.Nil(cmd.FloatArgs("ia"))
+	r.Nil(cmd.UintArgs("ia"))
+	r.Nil(cmd.TimestampArgs("ia"))
 }
 
 func TestArgumentsSubcommand(t *testing.T) {

--- a/args_test.go
+++ b/args_test.go
@@ -92,6 +92,7 @@ func TestArgumentsRootCommand(t *testing.T) {
 			r.Equal(test.expectedIvals, ivals)
 			r.Equal(test.expectedIvals, cmd.IntArgs("ia"))
 			r.Equal(test.expectedFvals, cmd.FloatArgs("fa"))
+			r.Equal(test.expectedUivals, cmd.UintArgs("uia"))
 			/*if test.expectedFvals != nil {
 				r.Equal(test.expectedFvals, fvals)
 			}*/
@@ -130,6 +131,7 @@ func TestArgumentsInvalidType(t *testing.T) {
 	r.Nil(cmd.FloatArgs("ia"))
 	r.Nil(cmd.UintArgs("ia"))
 	r.Nil(cmd.TimestampArgs("ia"))
+	r.Nil(cmd.IntArgs("uia"))
 }
 
 func TestArgumentsSubcommand(t *testing.T) {

--- a/args_test.go
+++ b/args_test.go
@@ -8,6 +8,112 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type intnum interface {
+	int | int8 | int16 | int32 | int64
+}
+
+type uintnum interface {
+	uint | uint8 | uint16 | uint32 | uint64
+}
+
+func intTypes[T intnum](t *testing.T) {
+	cmd := buildMinimalTestCommand()
+	var ival T
+	cmd.Arguments = []Argument{
+		&ArgumentBase[T, IntegerConfig, intValue[T]]{
+			Name:        "ia",
+			Destination: &ival,
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"foo", "10"})
+	r := require.New(t)
+	r.NoError(err)
+	r.Equal(T(10), ival)
+	r.Equal(T(10), arg[T]("ia", cmd))
+}
+
+func intArrTypes[T intnum](t *testing.T) {
+	cmd := buildMinimalTestCommand()
+	var ival []T
+	cmd.Arguments = []Argument{
+		&ArgumentsBase[T, IntegerConfig, intValue[T]]{
+			Name:        "ia",
+			Min:         1,
+			Max:         -1,
+			Destination: &ival,
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"foo", "10", "11", "12"})
+	r := require.New(t)
+	r.NoError(err)
+	r.Equal([]T{10, 11, 12}, ival)
+	r.Equal([]T{10, 11, 12}, arg[[]T]("ia", cmd))
+}
+
+func uintTypes[T uintnum](t *testing.T) {
+	cmd := buildMinimalTestCommand()
+	var ival T
+	cmd.Arguments = []Argument{
+		&ArgumentBase[T, IntegerConfig, uintValue[T]]{
+			Name:        "ia",
+			Destination: &ival,
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"foo", "10"})
+	r := require.New(t)
+	r.NoError(err)
+	r.Equal(T(10), ival)
+	r.Equal(T(10), arg[T]("ia", cmd))
+}
+
+func uintArrTypes[T uintnum](t *testing.T) {
+	cmd := buildMinimalTestCommand()
+	var ival []T
+	cmd.Arguments = []Argument{
+		&ArgumentsBase[T, IntegerConfig, uintValue[T]]{
+			Name:        "ia",
+			Min:         1,
+			Max:         -1,
+			Destination: &ival,
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"foo", "10", "11", "12"})
+	r := require.New(t)
+	r.NoError(err)
+	r.Equal([]T{10, 11, 12}, ival)
+	r.Equal([]T{10, 11, 12}, arg[[]T]("ia", cmd))
+}
+
+func TestArgumentsRootCommandAllTypes(t *testing.T) {
+	intTypes[int](t)
+	intTypes[int8](t)
+	intTypes[int16](t)
+	intTypes[int32](t)
+	intTypes[int64](t)
+
+	uintTypes[uint](t)
+	uintTypes[uint8](t)
+	uintTypes[uint16](t)
+	uintTypes[uint32](t)
+	uintTypes[uint64](t)
+
+	intArrTypes[int](t)
+	intArrTypes[int8](t)
+	intArrTypes[int16](t)
+	intArrTypes[int32](t)
+	intArrTypes[int64](t)
+
+	uintArrTypes[uint](t)
+	uintArrTypes[uint8](t)
+	uintArrTypes[uint16](t)
+	uintArrTypes[uint32](t)
+	uintArrTypes[uint64](t)
+}
+
 func TestArgumentsRootCommand(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/args_test.go
+++ b/args_test.go
@@ -23,10 +23,15 @@ func TestArgsIntTypes(t *testing.T) {
 	r.NoError(err)
 	r.Equal(10, ival)
 	r.Equal(10, cmd.IntArg("ia"))
+	r.Equal(0, cmd.IntArg("iab"))
 	r.Equal(int8(0), cmd.Int8Arg("ia"))
 	r.Equal(int16(0), cmd.Int16Arg("ia"))
 	r.Equal(int32(0), cmd.Int32Arg("ia"))
 	r.Equal(int64(0), cmd.Int64Arg("ia"))
+	r.Equal(float64(0), cmd.FloatArg("ia"))
+	r.Empty(cmd.StringArg("ia"))
+
+	r.Error(cmd.Run(buildTestContext(t), []string{"foo", "10.0"}))
 }
 
 func TestArgsIntSliceTypes(t *testing.T) {
@@ -50,6 +55,8 @@ func TestArgsIntSliceTypes(t *testing.T) {
 	r.Nil(cmd.Int16Args("ia"))
 	r.Nil(cmd.Int32Args("ia"))
 	r.Nil(cmd.Int64Args("ia"))
+
+	r.Error(cmd.Run(buildTestContext(t), []string{"foo", "10", "20.0"}))
 }
 
 func TestArgsUintTypes(t *testing.T) {
@@ -67,10 +74,13 @@ func TestArgsUintTypes(t *testing.T) {
 	r.NoError(err)
 	r.Equal(uint(10), ival)
 	r.Equal(uint(10), cmd.UintArg("ia"))
+	r.Equal(uint(0), cmd.UintArg("iab"))
 	r.Equal(uint8(0), cmd.Uint8Arg("ia"))
 	r.Equal(uint16(0), cmd.Uint16Arg("ia"))
 	r.Equal(uint32(0), cmd.Uint32Arg("ia"))
 	r.Equal(uint64(0), cmd.Uint64Arg("ia"))
+
+	r.Error(cmd.Run(buildTestContext(t), []string{"foo", "10.0"}))
 }
 
 func TestArgsUintSliceTypes(t *testing.T) {
@@ -94,6 +104,8 @@ func TestArgsUintSliceTypes(t *testing.T) {
 	r.Nil(cmd.Uint16Args("ia"))
 	r.Nil(cmd.Uint32Args("ia"))
 	r.Nil(cmd.Uint64Args("ia"))
+
+	r.Error(cmd.Run(buildTestContext(t), []string{"foo", "10", "20.0"}))
 }
 
 func TestArgumentsRootCommand(t *testing.T) {
@@ -195,23 +207,6 @@ func TestArgumentsRootCommand(t *testing.T) {
 			}*/
 		})
 	}
-
-	/*
-	   cmd.Arguments = append(cmd.Arguments,
-
-	   	&StringArgs{
-	   		Name: "sa",
-	   	},
-	   	&UintArgs{
-	   		Name: "ua",
-	   		Min:  2,
-	   		Max:  1, // max is less than min
-	   	},
-
-	   )
-
-	   require.NoError(t, cmd.Run(context.Background(), []string{"foo", "10"}))
-	*/
 }
 
 func TestArgumentsInvalidType(t *testing.T) {
@@ -230,6 +225,7 @@ func TestArgumentsInvalidType(t *testing.T) {
 	r.Nil(cmd.Int16Args("ia"))
 	r.Nil(cmd.Int32Args("ia"))
 	r.Nil(cmd.Int64Args("ia"))
+	r.Equal(time.Time{}, cmd.TimestampArg("ia"))
 	r.Nil(cmd.TimestampArgs("ia"))
 	r.Nil(cmd.UintArgs("ia"))
 	r.Nil(cmd.Uint8Args("ia"))

--- a/args_test.go
+++ b/args_test.go
@@ -10,36 +10,47 @@ import (
 
 func TestArgumentsRootCommand(t *testing.T) {
 	tests := []struct {
-		name          string
-		args          []string
-		expectedIvals []int64
-		expectedFvals []float64
-		errStr        string
+		name           string
+		args           []string
+		expectedIvals  []int64
+		expectedUivals []uint64
+		expectedFvals  []float64
+		errStr         string
 	}{
 		{
-			name:          "set ival",
-			args:          []string{"foo", "10"},
-			expectedIvals: []int64{10},
-			expectedFvals: []float64{},
+			name:           "set ival",
+			args:           []string{"foo", "10"},
+			expectedIvals:  []int64{10},
+			expectedUivals: []uint64{},
 		},
 		{
-			name:          "set ival fval",
-			args:          []string{"foo", "12", "10.1"},
-			expectedIvals: []int64{12},
-			expectedFvals: []float64{10.1},
+			name:           "set ival uival",
+			args:           []string{"foo", "-10", "11"},
+			expectedIvals:  []int64{-10},
+			expectedUivals: []uint64{11},
+			expectedFvals:  []float64{},
 		},
 		{
-			name:          "set ival multu fvals",
-			args:          []string{"foo", "13", "10.1", "11.09"},
-			expectedIvals: []int64{13},
-			expectedFvals: []float64{10.1, 11.09},
+			name:           "set ival uival fval",
+			args:           []string{"foo", "-12", "14", "10.1"},
+			expectedIvals:  []int64{-12},
+			expectedUivals: []uint64{14},
+			expectedFvals:  []float64{10.1},
 		},
 		{
-			name:          "set fvals beyond max",
-			args:          []string{"foo", "13", "10.1", "11.09", "12.1"},
-			expectedIvals: []int64{13},
-			expectedFvals: []float64{10.1, 11.09},
-			errStr:        "No help topic for '12.1'",
+			name:           "set ival uival multu fvals",
+			args:           []string{"foo", "-13", "12", "10.1", "11.09"},
+			expectedIvals:  []int64{-13},
+			expectedUivals: []uint64{12},
+			expectedFvals:  []float64{10.1, 11.09},
+		},
+		{
+			name:           "set fvals beyond max",
+			args:           []string{"foo", "13", "10", "10.1", "11.09", "12.1"},
+			expectedIvals:  []int64{13},
+			expectedUivals: []uint64{10},
+			expectedFvals:  []float64{10.1, 11.09},
+			errStr:         "No help topic for '12.1'",
 		},
 	}
 
@@ -47,6 +58,7 @@ func TestArgumentsRootCommand(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := buildMinimalTestCommand()
 			var ivals []int64
+			var uivals []uint64
 			var fvals []float64
 			cmd.Arguments = []Argument{
 				&IntArgs{
@@ -54,6 +66,12 @@ func TestArgumentsRootCommand(t *testing.T) {
 					Min:         1,
 					Max:         1,
 					Destination: &ivals,
+				},
+				&UintArgs{
+					Name:        "uia",
+					Min:         1,
+					Max:         1,
+					Destination: &uivals,
 				},
 				&FloatArgs{
 					Name:        "fa",
@@ -72,8 +90,8 @@ func TestArgumentsRootCommand(t *testing.T) {
 			}
 			r.Equal(test.expectedIvals, ivals)
 			r.Equal(test.expectedIvals, cmd.IntArgs("ia"))
-			r.Equal(test.expectedFvals, fvals)
 			if test.expectedFvals != nil {
+				r.Equal(test.expectedFvals, fvals)
 				r.Equal(test.expectedFvals, cmd.FloatArgs("fa"))
 			} else {
 				r.Equal([]float64{}, cmd.FloatArgs("fa"))
@@ -181,9 +199,11 @@ func TestArgumentsSubcommand(t *testing.T) {
 			} else {
 				if test.expectedSvals != nil {
 					r.Equal(test.expectedSvals, svals)
+					r.Equal(test.expectedSvals, cmd.Commands[0].StringArgs("sa"))
 				}
 				if test.expectedTVals != nil {
 					r.Equal(test.expectedTVals, tvals)
+					r.Equal(test.expectedTVals, cmd.Commands[0].TimestampArgs("ta"))
 				}
 				r.Equal(test.expectedIval, ival)
 			}

--- a/command_parse.go
+++ b/command_parse.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 const (
@@ -117,6 +118,11 @@ func (cmd *Command) parseFlags(args Args) (Args, error) {
 		if firstArg[1] == '-' {
 			numMinuses++
 			shortOptionHandling = false
+		} else if !unicode.IsLetter(rune(firstArg[1])) {
+			// this is not a flag
+			tracef("parseFlags not a unicode letter. Stop parsing")
+			posArgs = append(posArgs, rargs...)
+			return &stringSliceArgs{posArgs}, nil
 		}
 
 		tracef("parseFlags (shortOptionHandling=%[1]q)", shortOptionHandling)

--- a/command_test.go
+++ b/command_test.go
@@ -4501,7 +4501,7 @@ func TestSliceStringFlagParsing(t *testing.T) {
 func TestJSONExportCommand(t *testing.T) {
 	cmd := buildExtendedTestCommand()
 	cmd.Arguments = []Argument{
-		&Int64Arg{
+		&IntArgs{
 			Name: "fooi",
 		},
 	}

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -46,7 +46,7 @@ var (
 	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
 )
 var AnyArguments = []Argument{
-	&StringArg{
+	&StringArgs{
 		Max: -1,
 	},
 }
@@ -247,27 +247,31 @@ type Args interface {
 }
 
 type Argument interface {
+	HasName(string) bool
 	Parse([]string) ([]string, error)
 	Usage() string
 	Get() any
 }
 
-type ArgumentBase[T any, C any, VC ValueCreator[T, C]] struct {
+type ArgumentsBase[T any, C any, VC ValueCreator[T, C]] struct {
 	Name        string `json:"name"`      // the name of this argument
 	Value       T      `json:"value"`     // the default value of this argument
-	Destination *T     `json:"-"`         // the destination point for this argument
-	Values      *[]T   `json:"-"`         // all the values of this argument, only if multiple are supported
+	Destination *[]T   `json:"-"`         // the destination point for this argument
 	UsageText   string `json:"usageText"` // the usage text to show
 	Min         int    `json:"minTimes"`  // the min num of occurrences of this argument
 	Max         int    `json:"maxTimes"`  // the max num of occurrences of this argument, set to -1 for unlimited
 	Config      C      `json:"config"`    // config for this argument similar to Flag Config
+
+	// Has unexported fields.
 }
 
-func (a *ArgumentBase[T, C, VC]) Get() any
+func (a *ArgumentsBase[T, C, VC]) Get() any
 
-func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error)
+func (a *ArgumentsBase[T, C, VC]) HasName(s string) bool
 
-func (a *ArgumentBase[T, C, VC]) Usage() string
+func (a *ArgumentsBase[T, C, VC]) Parse(s []string) ([]string, error)
+
+func (a *ArgumentsBase[T, C, VC]) Usage() string
 
 type BeforeFunc func(context.Context, *Command) (context.Context, error)
     BeforeFunc is an action that executes prior to any subcommands being run
@@ -497,6 +501,8 @@ func (cmd *Command) FlagNames() []string
 func (cmd *Command) Float(name string) float64
     Float looks up the value of a local FloatFlag, returns 0 if not found
 
+func (c *Command) FloatArgs(name string) []float64
+
 func (cmd *Command) FloatSlice(name string) []float64
     FloatSlice looks up the value of a local FloatSliceFlag, returns nil if not
     found
@@ -514,35 +520,9 @@ func (cmd *Command) HasName(name string) bool
 func (cmd *Command) Int(name string) int
     Int looks up the value of a local Int64Flag, returns 0 if not found
 
-func (cmd *Command) Int16(name string) int16
-    Int16 looks up the value of a local Int16Flag, returns 0 if not found
+func (c *Command) IntArgs(name string) []int64
 
-func (cmd *Command) Int16Slice(name string) []int16
-    Int16Slice looks up the value of a local Int16SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) Int32(name string) int32
-    Int32 looks up the value of a local Int32Flag, returns 0 if not found
-
-func (cmd *Command) Int32Slice(name string) []int32
-    Int32Slice looks up the value of a local Int32SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) Int64(name string) int64
-    Int64 looks up the value of a local Int64Flag, returns 0 if not found
-
-func (cmd *Command) Int64Slice(name string) []int64
-    Int64Slice looks up the value of a local Int64SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) Int8(name string) int8
-    Int8 looks up the value of a local Int8Flag, returns 0 if not found
-
-func (cmd *Command) Int8Slice(name string) []int8
-    Int8Slice looks up the value of a local Int8SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) IntSlice(name string) []int
+func (cmd *Command) IntSlice(name string) []int64
     IntSlice looks up the value of a local IntSliceFlag, returns nil if not
     found
 
@@ -578,6 +558,8 @@ func (cmd *Command) Set(name, value string) error
 
 func (cmd *Command) String(name string) string
 
+func (c *Command) StringArgs(name string) []string
+
 func (cmd *Command) StringMap(name string) map[string]string
     StringMap looks up the value of a local StringMapFlag, returns nil if not
     found
@@ -589,6 +571,8 @@ func (cmd *Command) StringSlice(name string) []string
 func (cmd *Command) Timestamp(name string) time.Time
     Timestamp gets the timestamp from a flag name
 
+func (c *Command) TimestampArgs(name string) []time.Time
+
 func (cmd *Command) ToFishCompletion() (string, error)
     ToFishCompletion creates a fish completion string for the `*App` The
     function errors if either parsing or writing of the string fails.
@@ -596,35 +580,9 @@ func (cmd *Command) ToFishCompletion() (string, error)
 func (cmd *Command) Uint(name string) uint
     Uint looks up the value of a local Uint64Flag, returns 0 if not found
 
-func (cmd *Command) Uint16(name string) uint16
-    Uint16 looks up the value of a local Uint16Flag, returns 0 if not found
+func (c *Command) UintArgs(name string) []uint64
 
-func (cmd *Command) Uint16Slice(name string) []uint16
-    Uint16Slice looks up the value of a local Uint16SliceFlag, returns nil if
-    not found
-
-func (cmd *Command) Uint32(name string) uint32
-    Uint32 looks up the value of a local Uint32Flag, returns 0 if not found
-
-func (cmd *Command) Uint32Slice(name string) []uint32
-    Uint32Slice looks up the value of a local Uint32SliceFlag, returns nil if
-    not found
-
-func (cmd *Command) Uint64(name string) uint64
-    Uint64 looks up the value of a local Uint64Flag, returns 0 if not found
-
-func (cmd *Command) Uint64Slice(name string) []uint64
-    Uint64Slice looks up the value of a local Uint64SliceFlag, returns nil if
-    not found
-
-func (cmd *Command) Uint8(name string) uint8
-    Uint8 looks up the value of a local Uint8Flag, returns 0 if not found
-
-func (cmd *Command) Uint8Slice(name string) []uint8
-    Uint8Slice looks up the value of a local Uint8SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) UintSlice(name string) []uint
+func (cmd *Command) UintSlice(name string) []uint64
     UintSlice looks up the value of a local UintSliceFlag, returns nil if not
     found
 
@@ -940,7 +898,7 @@ func (f FlagsByName) Less(i, j int) bool
 
 func (f FlagsByName) Swap(i, j int)
 
-type FloatArg = ArgumentBase[float64, NoConfig, floatValue]
+type FloatArgs = ArgumentsBase[float64, NoConfig, floatValue]
 
 type FloatFlag = FlagBase[float64, NoConfig, floatValue]
 
@@ -950,11 +908,7 @@ type FloatSliceFlag = FlagBase[[]float64, NoConfig, FloatSlice]
 
 type GenericFlag = FlagBase[Value, NoConfig, genericValue]
 
-type Int16Arg = ArgumentBase[int16, IntegerConfig, intValue[int16]]
-
-type Int16Flag = FlagBase[int16, IntegerConfig, intValue[int16]]
-
-type Int16Slice = SliceBase[int16, IntegerConfig, intValue[int16]]
+type IntArgs = ArgumentsBase[int64, IntegerConfig, intValue]
 
 type Int16SliceFlag = FlagBase[[]int16, IntegerConfig, Int16Slice]
 
@@ -1119,7 +1073,7 @@ func (i SliceBase[T, C, VC]) ToString(t []T) string
 func (i *SliceBase[T, C, VC]) Value() []T
     Value returns the slice of values set by this flag
 
-type StringArg = ArgumentBase[string, StringConfig, stringValue]
+type StringArgs = ArgumentsBase[string, StringConfig, stringValue]
 
 type StringConfig struct {
 	// Whether to trim whitespace of parsed value
@@ -1131,7 +1085,7 @@ type StringFlag = FlagBase[string, StringConfig, stringValue]
 
 type StringMap = MapBase[string, StringConfig, stringValue]
 
-type StringMapArg = ArgumentBase[map[string]string, StringConfig, StringMap]
+type StringMapArgs = ArgumentsBase[map[string]string, StringConfig, StringMap]
 
 type StringMapFlag = FlagBase[map[string]string, StringConfig, StringMap]
 
@@ -1143,7 +1097,7 @@ type SuggestCommandFunc func(commands []*Command, provided string) string
 
 type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
 
-type TimestampArg = ArgumentBase[time.Time, TimestampConfig, timestampValue]
+type TimestampArgs = ArgumentsBase[time.Time, TimestampConfig, timestampValue]
 
 type TimestampConfig struct {
 	Timezone *time.Location
@@ -1158,39 +1112,7 @@ type TimestampConfig struct {
 
 type TimestampFlag = FlagBase[time.Time, TimestampConfig, timestampValue]
 
-type Uint16Arg = ArgumentBase[uint16, IntegerConfig, uintValue[uint16]]
-
-type Uint16Flag = FlagBase[uint16, IntegerConfig, uintValue[uint16]]
-
-type Uint16Slice = SliceBase[uint16, IntegerConfig, uintValue[uint16]]
-
-type Uint16SliceFlag = FlagBase[[]uint16, IntegerConfig, Uint16Slice]
-
-type Uint32Arg = ArgumentBase[uint32, IntegerConfig, uintValue[uint32]]
-
-type Uint32Flag = FlagBase[uint32, IntegerConfig, uintValue[uint32]]
-
-type Uint32Slice = SliceBase[uint32, IntegerConfig, uintValue[uint32]]
-
-type Uint32SliceFlag = FlagBase[[]uint32, IntegerConfig, Uint32Slice]
-
-type Uint64Arg = ArgumentBase[uint64, IntegerConfig, uintValue[uint64]]
-
-type Uint64Flag = FlagBase[uint64, IntegerConfig, uintValue[uint64]]
-
-type Uint64Slice = SliceBase[uint64, IntegerConfig, uintValue[uint64]]
-
-type Uint64SliceFlag = FlagBase[[]uint64, IntegerConfig, Uint64Slice]
-
-type Uint8Arg = ArgumentBase[uint8, IntegerConfig, uintValue[uint8]]
-
-type Uint8Flag = FlagBase[uint8, IntegerConfig, uintValue[uint8]]
-
-type Uint8Slice = SliceBase[uint8, IntegerConfig, uintValue[uint8]]
-
-type Uint8SliceFlag = FlagBase[[]uint8, IntegerConfig, Uint8Slice]
-
-type UintArg = ArgumentBase[uint, IntegerConfig, uintValue[uint]]
+type UintArgs = ArgumentsBase[uint64, IntegerConfig, uintValue]
 
 type UintFlag = FlagBase[uint, IntegerConfig, uintValue[uint]]
 

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -247,11 +247,19 @@ type Args interface {
 }
 
 type Argument interface {
+	// which this argument can be accessed using the given name
 	HasName(string) bool
+
+	// Parse the given args and return unparsed args and/or error
 	Parse([]string) ([]string, error)
+
+	// The usage template for this argument to use in help
 	Usage() string
+
+	// The Value of this Arg
 	Get() any
 }
+    Argument captures a positional argument that can be parsed
 
 type ArgumentsBase[T any, C any, VC ValueCreator[T, C]] struct {
 	Name        string `json:"name"`      // the name of this argument

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -549,11 +549,55 @@ func (cmd *Command) HasName(name string) bool
 func (cmd *Command) Int(name string) int
     Int looks up the value of a local Int64Flag, returns 0 if not found
 
-func (c *Command) IntArg(name string) int64
+func (cmd *Command) Int16(name string) int16
+    Int16 looks up the value of a local Int16Flag, returns 0 if not found
 
-func (c *Command) IntArgs(name string) []int64
+func (c *Command) Int16Arg(name string) int16
 
-func (cmd *Command) IntSlice(name string) []int64
+func (c *Command) Int16Args(name string) []int16
+
+func (cmd *Command) Int16Slice(name string) []int16
+    Int16Slice looks up the value of a local Int16SliceFlag, returns nil if not
+    found
+
+func (cmd *Command) Int32(name string) int32
+    Int32 looks up the value of a local Int32Flag, returns 0 if not found
+
+func (c *Command) Int32Arg(name string) int32
+
+func (c *Command) Int32Args(name string) []int32
+
+func (cmd *Command) Int32Slice(name string) []int32
+    Int32Slice looks up the value of a local Int32SliceFlag, returns nil if not
+    found
+
+func (cmd *Command) Int64(name string) int64
+    Int64 looks up the value of a local Int64Flag, returns 0 if not found
+
+func (c *Command) Int64Arg(name string) int64
+
+func (c *Command) Int64Args(name string) []int64
+
+func (cmd *Command) Int64Slice(name string) []int64
+    Int64Slice looks up the value of a local Int64SliceFlag, returns nil if not
+    found
+
+func (cmd *Command) Int8(name string) int8
+    Int8 looks up the value of a local Int8Flag, returns 0 if not found
+
+func (c *Command) Int8Arg(name string) int8
+
+func (c *Command) Int8Args(name string) []int8
+
+func (cmd *Command) Int8Slice(name string) []int8
+    Int8Slice looks up the value of a local Int8SliceFlag, returns nil if not
+    found
+
+func (c *Command) IntArg(name string) int
+
+func (c *Command) IntArgs(name string) []int
+
+func (cmd *Command) IntSlice(name string) []int
     IntSlice looks up the value of a local IntSliceFlag, returns nil if not
     found
 
@@ -615,11 +659,55 @@ func (cmd *Command) ToFishCompletion() (string, error)
 func (cmd *Command) Uint(name string) uint
     Uint looks up the value of a local Uint64Flag, returns 0 if not found
 
-func (c *Command) UintArg(name string) uint64
+func (cmd *Command) Uint16(name string) uint16
+    Uint16 looks up the value of a local Uint16Flag, returns 0 if not found
 
-func (c *Command) UintArgs(name string) []uint64
+func (c *Command) Uint16Arg(name string) uint16
 
-func (cmd *Command) UintSlice(name string) []uint64
+func (c *Command) Uint16Args(name string) []uint16
+
+func (cmd *Command) Uint16Slice(name string) []uint16
+    Uint16Slice looks up the value of a local Uint16SliceFlag, returns nil if
+    not found
+
+func (cmd *Command) Uint32(name string) uint32
+    Uint32 looks up the value of a local Uint32Flag, returns 0 if not found
+
+func (c *Command) Uint32Arg(name string) uint32
+
+func (c *Command) Uint32Args(name string) []uint32
+
+func (cmd *Command) Uint32Slice(name string) []uint32
+    Uint32Slice looks up the value of a local Uint32SliceFlag, returns nil if
+    not found
+
+func (cmd *Command) Uint64(name string) uint64
+    Uint64 looks up the value of a local Uint64Flag, returns 0 if not found
+
+func (c *Command) Uint64Arg(name string) uint64
+
+func (c *Command) Uint64Args(name string) []uint64
+
+func (cmd *Command) Uint64Slice(name string) []uint64
+    Uint64Slice looks up the value of a local Uint64SliceFlag, returns nil if
+    not found
+
+func (cmd *Command) Uint8(name string) uint8
+    Uint8 looks up the value of a local Uint8Flag, returns 0 if not found
+
+func (c *Command) Uint8Arg(name string) uint8
+
+func (c *Command) Uint8Args(name string) []uint8
+
+func (cmd *Command) Uint8Slice(name string) []uint8
+    Uint8Slice looks up the value of a local Uint8SliceFlag, returns nil if not
+    found
+
+func (c *Command) UintArg(name string) uint
+
+func (c *Command) UintArgs(name string) []uint
+
+func (cmd *Command) UintSlice(name string) []uint
     UintSlice looks up the value of a local UintSliceFlag, returns nil if not
     found
 
@@ -947,13 +1035,19 @@ type FloatSliceFlag = FlagBase[[]float64, NoConfig, FloatSlice]
 
 type GenericFlag = FlagBase[Value, NoConfig, genericValue]
 
-type IntArg = ArgumentBase[int64, IntegerConfig, intValue]
+type Int16Arg = ArgumentBase[int16, IntegerConfig, intValue[int16]]
 
-type IntArgs = ArgumentsBase[int64, IntegerConfig, intValue]
+type Int16Args = ArgumentsBase[int16, IntegerConfig, intValue[int16]]
+
+type Int16Flag = FlagBase[int16, IntegerConfig, intValue[int16]]
+
+type Int16Slice = SliceBase[int16, IntegerConfig, intValue[int16]]
 
 type Int16SliceFlag = FlagBase[[]int16, IntegerConfig, Int16Slice]
 
 type Int32Arg = ArgumentBase[int32, IntegerConfig, intValue[int32]]
+
+type Int32Args = ArgumentsBase[int32, IntegerConfig, intValue[int32]]
 
 type Int32Flag = FlagBase[int32, IntegerConfig, intValue[int32]]
 
@@ -963,6 +1057,8 @@ type Int32SliceFlag = FlagBase[[]int32, IntegerConfig, Int32Slice]
 
 type Int64Arg = ArgumentBase[int64, IntegerConfig, intValue[int64]]
 
+type Int64Args = ArgumentsBase[int64, IntegerConfig, intValue[int64]]
+
 type Int64Flag = FlagBase[int64, IntegerConfig, intValue[int64]]
 
 type Int64Slice = SliceBase[int64, IntegerConfig, intValue[int64]]
@@ -971,6 +1067,8 @@ type Int64SliceFlag = FlagBase[[]int64, IntegerConfig, Int64Slice]
 
 type Int8Arg = ArgumentBase[int8, IntegerConfig, intValue[int8]]
 
+type Int8Args = ArgumentsBase[int8, IntegerConfig, intValue[int8]]
+
 type Int8Flag = FlagBase[int8, IntegerConfig, intValue[int8]]
 
 type Int8Slice = SliceBase[int8, IntegerConfig, intValue[int8]]
@@ -978,6 +1076,8 @@ type Int8Slice = SliceBase[int8, IntegerConfig, intValue[int8]]
 type Int8SliceFlag = FlagBase[[]int8, IntegerConfig, Int8Slice]
 
 type IntArg = ArgumentBase[int, IntegerConfig, intValue[int]]
+
+type IntArgs = ArgumentsBase[int, IntegerConfig, intValue[int]]
 
 type IntFlag = FlagBase[int, IntegerConfig, intValue[int]]
 
@@ -1157,9 +1257,49 @@ type TimestampConfig struct {
 
 type TimestampFlag = FlagBase[time.Time, TimestampConfig, timestampValue]
 
-type UintArg = ArgumentBase[uint64, IntegerConfig, uintValue]
+type Uint16Arg = ArgumentBase[uint16, IntegerConfig, uintValue[uint16]]
 
-type UintArgs = ArgumentsBase[uint64, IntegerConfig, uintValue]
+type Uint16Args = ArgumentsBase[uint16, IntegerConfig, uintValue[uint16]]
+
+type Uint16Flag = FlagBase[uint16, IntegerConfig, uintValue[uint16]]
+
+type Uint16Slice = SliceBase[uint16, IntegerConfig, uintValue[uint16]]
+
+type Uint16SliceFlag = FlagBase[[]uint16, IntegerConfig, Uint16Slice]
+
+type Uint32Arg = ArgumentBase[uint32, IntegerConfig, uintValue[uint32]]
+
+type Uint32Args = ArgumentsBase[uint32, IntegerConfig, uintValue[uint32]]
+
+type Uint32Flag = FlagBase[uint32, IntegerConfig, uintValue[uint32]]
+
+type Uint32Slice = SliceBase[uint32, IntegerConfig, uintValue[uint32]]
+
+type Uint32SliceFlag = FlagBase[[]uint32, IntegerConfig, Uint32Slice]
+
+type Uint64Arg = ArgumentBase[uint64, IntegerConfig, uintValue[uint64]]
+
+type Uint64Args = ArgumentsBase[uint64, IntegerConfig, uintValue[uint64]]
+
+type Uint64Flag = FlagBase[uint64, IntegerConfig, uintValue[uint64]]
+
+type Uint64Slice = SliceBase[uint64, IntegerConfig, uintValue[uint64]]
+
+type Uint64SliceFlag = FlagBase[[]uint64, IntegerConfig, Uint64Slice]
+
+type Uint8Arg = ArgumentBase[uint8, IntegerConfig, uintValue[uint8]]
+
+type Uint8Args = ArgumentsBase[uint8, IntegerConfig, uintValue[uint8]]
+
+type Uint8Flag = FlagBase[uint8, IntegerConfig, uintValue[uint8]]
+
+type Uint8Slice = SliceBase[uint8, IntegerConfig, uintValue[uint8]]
+
+type Uint8SliceFlag = FlagBase[[]uint8, IntegerConfig, Uint8Slice]
+
+type UintArg = ArgumentBase[uint, IntegerConfig, uintValue[uint]]
+
+type UintArgs = ArgumentsBase[uint, IntegerConfig, uintValue[uint]]
 
 type UintFlag = FlagBase[uint, IntegerConfig, uintValue[uint]]
 

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -261,6 +261,24 @@ type Argument interface {
 }
     Argument captures a positional argument that can be parsed
 
+type ArgumentBase[T any, C any, VC ValueCreator[T, C]] struct {
+	Name        string `json:"name"`      // the name of this argument
+	Value       T      `json:"value"`     // the default value of this argument
+	Destination *T     `json:"-"`         // the destination point for this argument
+	UsageText   string `json:"usageText"` // the usage text to show
+	Config      C      `json:"config"`    // config for this argument similar to Flag Config
+
+	// Has unexported fields.
+}
+
+func (a *ArgumentBase[T, C, VC]) Get() any
+
+func (a *ArgumentBase[T, C, VC]) HasName(s string) bool
+
+func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error)
+
+func (a *ArgumentBase[T, C, VC]) Usage() string
+
 type ArgumentsBase[T any, C any, VC ValueCreator[T, C]] struct {
 	Name        string `json:"name"`      // the name of this argument
 	Value       T      `json:"value"`     // the default value of this argument
@@ -272,6 +290,7 @@ type ArgumentsBase[T any, C any, VC ValueCreator[T, C]] struct {
 
 	// Has unexported fields.
 }
+    ArgumentsBase is a base type for slice arguments
 
 func (a *ArgumentsBase[T, C, VC]) Get() any
 
@@ -509,6 +528,8 @@ func (cmd *Command) FlagNames() []string
 func (cmd *Command) Float(name string) float64
     Float looks up the value of a local FloatFlag, returns 0 if not found
 
+func (c *Command) FloatArg(name string) float64
+
 func (c *Command) FloatArgs(name string) []float64
 
 func (cmd *Command) FloatSlice(name string) []float64
@@ -527,6 +548,8 @@ func (cmd *Command) HasName(name string) bool
 
 func (cmd *Command) Int(name string) int
     Int looks up the value of a local Int64Flag, returns 0 if not found
+
+func (c *Command) IntArg(name string) int64
 
 func (c *Command) IntArgs(name string) []int64
 
@@ -566,6 +589,8 @@ func (cmd *Command) Set(name, value string) error
 
 func (cmd *Command) String(name string) string
 
+func (c *Command) StringArg(name string) string
+
 func (c *Command) StringArgs(name string) []string
 
 func (cmd *Command) StringMap(name string) map[string]string
@@ -579,6 +604,8 @@ func (cmd *Command) StringSlice(name string) []string
 func (cmd *Command) Timestamp(name string) time.Time
     Timestamp gets the timestamp from a flag name
 
+func (c *Command) TimestampArg(name string) time.Time
+
 func (c *Command) TimestampArgs(name string) []time.Time
 
 func (cmd *Command) ToFishCompletion() (string, error)
@@ -587,6 +614,8 @@ func (cmd *Command) ToFishCompletion() (string, error)
 
 func (cmd *Command) Uint(name string) uint
     Uint looks up the value of a local Uint64Flag, returns 0 if not found
+
+func (c *Command) UintArg(name string) uint64
 
 func (c *Command) UintArgs(name string) []uint64
 
@@ -906,6 +935,8 @@ func (f FlagsByName) Less(i, j int) bool
 
 func (f FlagsByName) Swap(i, j int)
 
+type FloatArg = ArgumentBase[float64, NoConfig, floatValue]
+
 type FloatArgs = ArgumentsBase[float64, NoConfig, floatValue]
 
 type FloatFlag = FlagBase[float64, NoConfig, floatValue]
@@ -915,6 +946,8 @@ type FloatSlice = SliceBase[float64, NoConfig, floatValue]
 type FloatSliceFlag = FlagBase[[]float64, NoConfig, FloatSlice]
 
 type GenericFlag = FlagBase[Value, NoConfig, genericValue]
+
+type IntArg = ArgumentBase[int64, IntegerConfig, intValue]
 
 type IntArgs = ArgumentsBase[int64, IntegerConfig, intValue]
 
@@ -1081,6 +1114,8 @@ func (i SliceBase[T, C, VC]) ToString(t []T) string
 func (i *SliceBase[T, C, VC]) Value() []T
     Value returns the slice of values set by this flag
 
+type StringArg = ArgumentBase[string, StringConfig, stringValue]
+
 type StringArgs = ArgumentsBase[string, StringConfig, stringValue]
 
 type StringConfig struct {
@@ -1093,7 +1128,7 @@ type StringFlag = FlagBase[string, StringConfig, stringValue]
 
 type StringMap = MapBase[string, StringConfig, stringValue]
 
-type StringMapArgs = ArgumentsBase[map[string]string, StringConfig, StringMap]
+type StringMapArgs = ArgumentBase[map[string]string, StringConfig, StringMap]
 
 type StringMapFlag = FlagBase[map[string]string, StringConfig, StringMap]
 
@@ -1104,6 +1139,8 @@ type StringSliceFlag = FlagBase[[]string, StringConfig, StringSlice]
 type SuggestCommandFunc func(commands []*Command, provided string) string
 
 type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
+
+type TimestampArg = ArgumentBase[time.Time, TimestampConfig, timestampValue]
 
 type TimestampArgs = ArgumentsBase[time.Time, TimestampConfig, timestampValue]
 
@@ -1119,6 +1156,8 @@ type TimestampConfig struct {
     TimestampConfig defines the config for timestamp flags
 
 type TimestampFlag = FlagBase[time.Time, TimestampConfig, timestampValue]
+
+type UintArg = ArgumentBase[uint64, IntegerConfig, uintValue]
 
 type UintArgs = ArgumentsBase[uint64, IntegerConfig, uintValue]
 

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -249,6 +249,7 @@ type Args interface {
 type Argument interface {
 	Parse([]string) ([]string, error)
 	Usage() string
+	Get() any
 }
 
 type ArgumentBase[T any, C any, VC ValueCreator[T, C]] struct {
@@ -261,6 +262,8 @@ type ArgumentBase[T any, C any, VC ValueCreator[T, C]] struct {
 	Max         int    `json:"maxTimes"`  // the max num of occurrences of this argument, set to -1 for unlimited
 	Config      C      `json:"config"`    // config for this argument similar to Flag Config
 }
+
+func (a *ArgumentBase[T, C, VC]) Get() any
 
 func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error)
 

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -549,11 +549,55 @@ func (cmd *Command) HasName(name string) bool
 func (cmd *Command) Int(name string) int
     Int looks up the value of a local Int64Flag, returns 0 if not found
 
-func (c *Command) IntArg(name string) int64
+func (cmd *Command) Int16(name string) int16
+    Int16 looks up the value of a local Int16Flag, returns 0 if not found
 
-func (c *Command) IntArgs(name string) []int64
+func (c *Command) Int16Arg(name string) int16
 
-func (cmd *Command) IntSlice(name string) []int64
+func (c *Command) Int16Args(name string) []int16
+
+func (cmd *Command) Int16Slice(name string) []int16
+    Int16Slice looks up the value of a local Int16SliceFlag, returns nil if not
+    found
+
+func (cmd *Command) Int32(name string) int32
+    Int32 looks up the value of a local Int32Flag, returns 0 if not found
+
+func (c *Command) Int32Arg(name string) int32
+
+func (c *Command) Int32Args(name string) []int32
+
+func (cmd *Command) Int32Slice(name string) []int32
+    Int32Slice looks up the value of a local Int32SliceFlag, returns nil if not
+    found
+
+func (cmd *Command) Int64(name string) int64
+    Int64 looks up the value of a local Int64Flag, returns 0 if not found
+
+func (c *Command) Int64Arg(name string) int64
+
+func (c *Command) Int64Args(name string) []int64
+
+func (cmd *Command) Int64Slice(name string) []int64
+    Int64Slice looks up the value of a local Int64SliceFlag, returns nil if not
+    found
+
+func (cmd *Command) Int8(name string) int8
+    Int8 looks up the value of a local Int8Flag, returns 0 if not found
+
+func (c *Command) Int8Arg(name string) int8
+
+func (c *Command) Int8Args(name string) []int8
+
+func (cmd *Command) Int8Slice(name string) []int8
+    Int8Slice looks up the value of a local Int8SliceFlag, returns nil if not
+    found
+
+func (c *Command) IntArg(name string) int
+
+func (c *Command) IntArgs(name string) []int
+
+func (cmd *Command) IntSlice(name string) []int
     IntSlice looks up the value of a local IntSliceFlag, returns nil if not
     found
 
@@ -615,11 +659,55 @@ func (cmd *Command) ToFishCompletion() (string, error)
 func (cmd *Command) Uint(name string) uint
     Uint looks up the value of a local Uint64Flag, returns 0 if not found
 
-func (c *Command) UintArg(name string) uint64
+func (cmd *Command) Uint16(name string) uint16
+    Uint16 looks up the value of a local Uint16Flag, returns 0 if not found
 
-func (c *Command) UintArgs(name string) []uint64
+func (c *Command) Uint16Arg(name string) uint16
 
-func (cmd *Command) UintSlice(name string) []uint64
+func (c *Command) Uint16Args(name string) []uint16
+
+func (cmd *Command) Uint16Slice(name string) []uint16
+    Uint16Slice looks up the value of a local Uint16SliceFlag, returns nil if
+    not found
+
+func (cmd *Command) Uint32(name string) uint32
+    Uint32 looks up the value of a local Uint32Flag, returns 0 if not found
+
+func (c *Command) Uint32Arg(name string) uint32
+
+func (c *Command) Uint32Args(name string) []uint32
+
+func (cmd *Command) Uint32Slice(name string) []uint32
+    Uint32Slice looks up the value of a local Uint32SliceFlag, returns nil if
+    not found
+
+func (cmd *Command) Uint64(name string) uint64
+    Uint64 looks up the value of a local Uint64Flag, returns 0 if not found
+
+func (c *Command) Uint64Arg(name string) uint64
+
+func (c *Command) Uint64Args(name string) []uint64
+
+func (cmd *Command) Uint64Slice(name string) []uint64
+    Uint64Slice looks up the value of a local Uint64SliceFlag, returns nil if
+    not found
+
+func (cmd *Command) Uint8(name string) uint8
+    Uint8 looks up the value of a local Uint8Flag, returns 0 if not found
+
+func (c *Command) Uint8Arg(name string) uint8
+
+func (c *Command) Uint8Args(name string) []uint8
+
+func (cmd *Command) Uint8Slice(name string) []uint8
+    Uint8Slice looks up the value of a local Uint8SliceFlag, returns nil if not
+    found
+
+func (c *Command) UintArg(name string) uint
+
+func (c *Command) UintArgs(name string) []uint
+
+func (cmd *Command) UintSlice(name string) []uint
     UintSlice looks up the value of a local UintSliceFlag, returns nil if not
     found
 
@@ -947,13 +1035,19 @@ type FloatSliceFlag = FlagBase[[]float64, NoConfig, FloatSlice]
 
 type GenericFlag = FlagBase[Value, NoConfig, genericValue]
 
-type IntArg = ArgumentBase[int64, IntegerConfig, intValue]
+type Int16Arg = ArgumentBase[int16, IntegerConfig, intValue[int16]]
 
-type IntArgs = ArgumentsBase[int64, IntegerConfig, intValue]
+type Int16Args = ArgumentsBase[int16, IntegerConfig, intValue[int16]]
+
+type Int16Flag = FlagBase[int16, IntegerConfig, intValue[int16]]
+
+type Int16Slice = SliceBase[int16, IntegerConfig, intValue[int16]]
 
 type Int16SliceFlag = FlagBase[[]int16, IntegerConfig, Int16Slice]
 
 type Int32Arg = ArgumentBase[int32, IntegerConfig, intValue[int32]]
+
+type Int32Args = ArgumentsBase[int32, IntegerConfig, intValue[int32]]
 
 type Int32Flag = FlagBase[int32, IntegerConfig, intValue[int32]]
 
@@ -963,6 +1057,8 @@ type Int32SliceFlag = FlagBase[[]int32, IntegerConfig, Int32Slice]
 
 type Int64Arg = ArgumentBase[int64, IntegerConfig, intValue[int64]]
 
+type Int64Args = ArgumentsBase[int64, IntegerConfig, intValue[int64]]
+
 type Int64Flag = FlagBase[int64, IntegerConfig, intValue[int64]]
 
 type Int64Slice = SliceBase[int64, IntegerConfig, intValue[int64]]
@@ -971,6 +1067,8 @@ type Int64SliceFlag = FlagBase[[]int64, IntegerConfig, Int64Slice]
 
 type Int8Arg = ArgumentBase[int8, IntegerConfig, intValue[int8]]
 
+type Int8Args = ArgumentsBase[int8, IntegerConfig, intValue[int8]]
+
 type Int8Flag = FlagBase[int8, IntegerConfig, intValue[int8]]
 
 type Int8Slice = SliceBase[int8, IntegerConfig, intValue[int8]]
@@ -978,6 +1076,8 @@ type Int8Slice = SliceBase[int8, IntegerConfig, intValue[int8]]
 type Int8SliceFlag = FlagBase[[]int8, IntegerConfig, Int8Slice]
 
 type IntArg = ArgumentBase[int, IntegerConfig, intValue[int]]
+
+type IntArgs = ArgumentsBase[int, IntegerConfig, intValue[int]]
 
 type IntFlag = FlagBase[int, IntegerConfig, intValue[int]]
 
@@ -1157,9 +1257,49 @@ type TimestampConfig struct {
 
 type TimestampFlag = FlagBase[time.Time, TimestampConfig, timestampValue]
 
-type UintArg = ArgumentBase[uint64, IntegerConfig, uintValue]
+type Uint16Arg = ArgumentBase[uint16, IntegerConfig, uintValue[uint16]]
 
-type UintArgs = ArgumentsBase[uint64, IntegerConfig, uintValue]
+type Uint16Args = ArgumentsBase[uint16, IntegerConfig, uintValue[uint16]]
+
+type Uint16Flag = FlagBase[uint16, IntegerConfig, uintValue[uint16]]
+
+type Uint16Slice = SliceBase[uint16, IntegerConfig, uintValue[uint16]]
+
+type Uint16SliceFlag = FlagBase[[]uint16, IntegerConfig, Uint16Slice]
+
+type Uint32Arg = ArgumentBase[uint32, IntegerConfig, uintValue[uint32]]
+
+type Uint32Args = ArgumentsBase[uint32, IntegerConfig, uintValue[uint32]]
+
+type Uint32Flag = FlagBase[uint32, IntegerConfig, uintValue[uint32]]
+
+type Uint32Slice = SliceBase[uint32, IntegerConfig, uintValue[uint32]]
+
+type Uint32SliceFlag = FlagBase[[]uint32, IntegerConfig, Uint32Slice]
+
+type Uint64Arg = ArgumentBase[uint64, IntegerConfig, uintValue[uint64]]
+
+type Uint64Args = ArgumentsBase[uint64, IntegerConfig, uintValue[uint64]]
+
+type Uint64Flag = FlagBase[uint64, IntegerConfig, uintValue[uint64]]
+
+type Uint64Slice = SliceBase[uint64, IntegerConfig, uintValue[uint64]]
+
+type Uint64SliceFlag = FlagBase[[]uint64, IntegerConfig, Uint64Slice]
+
+type Uint8Arg = ArgumentBase[uint8, IntegerConfig, uintValue[uint8]]
+
+type Uint8Args = ArgumentsBase[uint8, IntegerConfig, uintValue[uint8]]
+
+type Uint8Flag = FlagBase[uint8, IntegerConfig, uintValue[uint8]]
+
+type Uint8Slice = SliceBase[uint8, IntegerConfig, uintValue[uint8]]
+
+type Uint8SliceFlag = FlagBase[[]uint8, IntegerConfig, Uint8Slice]
+
+type UintArg = ArgumentBase[uint, IntegerConfig, uintValue[uint]]
+
+type UintArgs = ArgumentsBase[uint, IntegerConfig, uintValue[uint]]
 
 type UintFlag = FlagBase[uint, IntegerConfig, uintValue[uint]]
 

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -261,6 +261,24 @@ type Argument interface {
 }
     Argument captures a positional argument that can be parsed
 
+type ArgumentBase[T any, C any, VC ValueCreator[T, C]] struct {
+	Name        string `json:"name"`      // the name of this argument
+	Value       T      `json:"value"`     // the default value of this argument
+	Destination *T     `json:"-"`         // the destination point for this argument
+	UsageText   string `json:"usageText"` // the usage text to show
+	Config      C      `json:"config"`    // config for this argument similar to Flag Config
+
+	// Has unexported fields.
+}
+
+func (a *ArgumentBase[T, C, VC]) Get() any
+
+func (a *ArgumentBase[T, C, VC]) HasName(s string) bool
+
+func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error)
+
+func (a *ArgumentBase[T, C, VC]) Usage() string
+
 type ArgumentsBase[T any, C any, VC ValueCreator[T, C]] struct {
 	Name        string `json:"name"`      // the name of this argument
 	Value       T      `json:"value"`     // the default value of this argument
@@ -272,6 +290,7 @@ type ArgumentsBase[T any, C any, VC ValueCreator[T, C]] struct {
 
 	// Has unexported fields.
 }
+    ArgumentsBase is a base type for slice arguments
 
 func (a *ArgumentsBase[T, C, VC]) Get() any
 
@@ -509,6 +528,8 @@ func (cmd *Command) FlagNames() []string
 func (cmd *Command) Float(name string) float64
     Float looks up the value of a local FloatFlag, returns 0 if not found
 
+func (c *Command) FloatArg(name string) float64
+
 func (c *Command) FloatArgs(name string) []float64
 
 func (cmd *Command) FloatSlice(name string) []float64
@@ -527,6 +548,8 @@ func (cmd *Command) HasName(name string) bool
 
 func (cmd *Command) Int(name string) int
     Int looks up the value of a local Int64Flag, returns 0 if not found
+
+func (c *Command) IntArg(name string) int64
 
 func (c *Command) IntArgs(name string) []int64
 
@@ -566,6 +589,8 @@ func (cmd *Command) Set(name, value string) error
 
 func (cmd *Command) String(name string) string
 
+func (c *Command) StringArg(name string) string
+
 func (c *Command) StringArgs(name string) []string
 
 func (cmd *Command) StringMap(name string) map[string]string
@@ -579,6 +604,8 @@ func (cmd *Command) StringSlice(name string) []string
 func (cmd *Command) Timestamp(name string) time.Time
     Timestamp gets the timestamp from a flag name
 
+func (c *Command) TimestampArg(name string) time.Time
+
 func (c *Command) TimestampArgs(name string) []time.Time
 
 func (cmd *Command) ToFishCompletion() (string, error)
@@ -587,6 +614,8 @@ func (cmd *Command) ToFishCompletion() (string, error)
 
 func (cmd *Command) Uint(name string) uint
     Uint looks up the value of a local Uint64Flag, returns 0 if not found
+
+func (c *Command) UintArg(name string) uint64
 
 func (c *Command) UintArgs(name string) []uint64
 
@@ -906,6 +935,8 @@ func (f FlagsByName) Less(i, j int) bool
 
 func (f FlagsByName) Swap(i, j int)
 
+type FloatArg = ArgumentBase[float64, NoConfig, floatValue]
+
 type FloatArgs = ArgumentsBase[float64, NoConfig, floatValue]
 
 type FloatFlag = FlagBase[float64, NoConfig, floatValue]
@@ -915,6 +946,8 @@ type FloatSlice = SliceBase[float64, NoConfig, floatValue]
 type FloatSliceFlag = FlagBase[[]float64, NoConfig, FloatSlice]
 
 type GenericFlag = FlagBase[Value, NoConfig, genericValue]
+
+type IntArg = ArgumentBase[int64, IntegerConfig, intValue]
 
 type IntArgs = ArgumentsBase[int64, IntegerConfig, intValue]
 
@@ -1081,6 +1114,8 @@ func (i SliceBase[T, C, VC]) ToString(t []T) string
 func (i *SliceBase[T, C, VC]) Value() []T
     Value returns the slice of values set by this flag
 
+type StringArg = ArgumentBase[string, StringConfig, stringValue]
+
 type StringArgs = ArgumentsBase[string, StringConfig, stringValue]
 
 type StringConfig struct {
@@ -1093,7 +1128,7 @@ type StringFlag = FlagBase[string, StringConfig, stringValue]
 
 type StringMap = MapBase[string, StringConfig, stringValue]
 
-type StringMapArgs = ArgumentsBase[map[string]string, StringConfig, StringMap]
+type StringMapArgs = ArgumentBase[map[string]string, StringConfig, StringMap]
 
 type StringMapFlag = FlagBase[map[string]string, StringConfig, StringMap]
 
@@ -1104,6 +1139,8 @@ type StringSliceFlag = FlagBase[[]string, StringConfig, StringSlice]
 type SuggestCommandFunc func(commands []*Command, provided string) string
 
 type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
+
+type TimestampArg = ArgumentBase[time.Time, TimestampConfig, timestampValue]
 
 type TimestampArgs = ArgumentsBase[time.Time, TimestampConfig, timestampValue]
 
@@ -1119,6 +1156,8 @@ type TimestampConfig struct {
     TimestampConfig defines the config for timestamp flags
 
 type TimestampFlag = FlagBase[time.Time, TimestampConfig, timestampValue]
+
+type UintArg = ArgumentBase[uint64, IntegerConfig, uintValue]
 
 type UintArgs = ArgumentsBase[uint64, IntegerConfig, uintValue]
 

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -46,7 +46,7 @@ var (
 	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
 )
 var AnyArguments = []Argument{
-	&StringArg{
+	&StringArgs{
 		Max: -1,
 	},
 }
@@ -247,24 +247,39 @@ type Args interface {
 }
 
 type Argument interface {
-	Parse([]string) ([]string, error)
-	Usage() string
-}
+	// which this argument can be accessed using the given name
+	HasName(string) bool
 
-type ArgumentBase[T any, C any, VC ValueCreator[T, C]] struct {
+	// Parse the given args and return unparsed args and/or error
+	Parse([]string) ([]string, error)
+
+	// The usage template for this argument to use in help
+	Usage() string
+
+	// The Value of this Arg
+	Get() any
+}
+    Argument captures a positional argument that can be parsed
+
+type ArgumentsBase[T any, C any, VC ValueCreator[T, C]] struct {
 	Name        string `json:"name"`      // the name of this argument
 	Value       T      `json:"value"`     // the default value of this argument
-	Destination *T     `json:"-"`         // the destination point for this argument
-	Values      *[]T   `json:"-"`         // all the values of this argument, only if multiple are supported
+	Destination *[]T   `json:"-"`         // the destination point for this argument
 	UsageText   string `json:"usageText"` // the usage text to show
 	Min         int    `json:"minTimes"`  // the min num of occurrences of this argument
 	Max         int    `json:"maxTimes"`  // the max num of occurrences of this argument, set to -1 for unlimited
 	Config      C      `json:"config"`    // config for this argument similar to Flag Config
+
+	// Has unexported fields.
 }
 
-func (a *ArgumentBase[T, C, VC]) Parse(s []string) ([]string, error)
+func (a *ArgumentsBase[T, C, VC]) Get() any
 
-func (a *ArgumentBase[T, C, VC]) Usage() string
+func (a *ArgumentsBase[T, C, VC]) HasName(s string) bool
+
+func (a *ArgumentsBase[T, C, VC]) Parse(s []string) ([]string, error)
+
+func (a *ArgumentsBase[T, C, VC]) Usage() string
 
 type BeforeFunc func(context.Context, *Command) (context.Context, error)
     BeforeFunc is an action that executes prior to any subcommands being run
@@ -494,6 +509,8 @@ func (cmd *Command) FlagNames() []string
 func (cmd *Command) Float(name string) float64
     Float looks up the value of a local FloatFlag, returns 0 if not found
 
+func (c *Command) FloatArgs(name string) []float64
+
 func (cmd *Command) FloatSlice(name string) []float64
     FloatSlice looks up the value of a local FloatSliceFlag, returns nil if not
     found
@@ -511,35 +528,9 @@ func (cmd *Command) HasName(name string) bool
 func (cmd *Command) Int(name string) int
     Int looks up the value of a local Int64Flag, returns 0 if not found
 
-func (cmd *Command) Int16(name string) int16
-    Int16 looks up the value of a local Int16Flag, returns 0 if not found
+func (c *Command) IntArgs(name string) []int64
 
-func (cmd *Command) Int16Slice(name string) []int16
-    Int16Slice looks up the value of a local Int16SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) Int32(name string) int32
-    Int32 looks up the value of a local Int32Flag, returns 0 if not found
-
-func (cmd *Command) Int32Slice(name string) []int32
-    Int32Slice looks up the value of a local Int32SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) Int64(name string) int64
-    Int64 looks up the value of a local Int64Flag, returns 0 if not found
-
-func (cmd *Command) Int64Slice(name string) []int64
-    Int64Slice looks up the value of a local Int64SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) Int8(name string) int8
-    Int8 looks up the value of a local Int8Flag, returns 0 if not found
-
-func (cmd *Command) Int8Slice(name string) []int8
-    Int8Slice looks up the value of a local Int8SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) IntSlice(name string) []int
+func (cmd *Command) IntSlice(name string) []int64
     IntSlice looks up the value of a local IntSliceFlag, returns nil if not
     found
 
@@ -575,6 +566,8 @@ func (cmd *Command) Set(name, value string) error
 
 func (cmd *Command) String(name string) string
 
+func (c *Command) StringArgs(name string) []string
+
 func (cmd *Command) StringMap(name string) map[string]string
     StringMap looks up the value of a local StringMapFlag, returns nil if not
     found
@@ -586,6 +579,8 @@ func (cmd *Command) StringSlice(name string) []string
 func (cmd *Command) Timestamp(name string) time.Time
     Timestamp gets the timestamp from a flag name
 
+func (c *Command) TimestampArgs(name string) []time.Time
+
 func (cmd *Command) ToFishCompletion() (string, error)
     ToFishCompletion creates a fish completion string for the `*App` The
     function errors if either parsing or writing of the string fails.
@@ -593,35 +588,9 @@ func (cmd *Command) ToFishCompletion() (string, error)
 func (cmd *Command) Uint(name string) uint
     Uint looks up the value of a local Uint64Flag, returns 0 if not found
 
-func (cmd *Command) Uint16(name string) uint16
-    Uint16 looks up the value of a local Uint16Flag, returns 0 if not found
+func (c *Command) UintArgs(name string) []uint64
 
-func (cmd *Command) Uint16Slice(name string) []uint16
-    Uint16Slice looks up the value of a local Uint16SliceFlag, returns nil if
-    not found
-
-func (cmd *Command) Uint32(name string) uint32
-    Uint32 looks up the value of a local Uint32Flag, returns 0 if not found
-
-func (cmd *Command) Uint32Slice(name string) []uint32
-    Uint32Slice looks up the value of a local Uint32SliceFlag, returns nil if
-    not found
-
-func (cmd *Command) Uint64(name string) uint64
-    Uint64 looks up the value of a local Uint64Flag, returns 0 if not found
-
-func (cmd *Command) Uint64Slice(name string) []uint64
-    Uint64Slice looks up the value of a local Uint64SliceFlag, returns nil if
-    not found
-
-func (cmd *Command) Uint8(name string) uint8
-    Uint8 looks up the value of a local Uint8Flag, returns 0 if not found
-
-func (cmd *Command) Uint8Slice(name string) []uint8
-    Uint8Slice looks up the value of a local Uint8SliceFlag, returns nil if not
-    found
-
-func (cmd *Command) UintSlice(name string) []uint
+func (cmd *Command) UintSlice(name string) []uint64
     UintSlice looks up the value of a local UintSliceFlag, returns nil if not
     found
 
@@ -937,7 +906,7 @@ func (f FlagsByName) Less(i, j int) bool
 
 func (f FlagsByName) Swap(i, j int)
 
-type FloatArg = ArgumentBase[float64, NoConfig, floatValue]
+type FloatArgs = ArgumentsBase[float64, NoConfig, floatValue]
 
 type FloatFlag = FlagBase[float64, NoConfig, floatValue]
 
@@ -947,11 +916,7 @@ type FloatSliceFlag = FlagBase[[]float64, NoConfig, FloatSlice]
 
 type GenericFlag = FlagBase[Value, NoConfig, genericValue]
 
-type Int16Arg = ArgumentBase[int16, IntegerConfig, intValue[int16]]
-
-type Int16Flag = FlagBase[int16, IntegerConfig, intValue[int16]]
-
-type Int16Slice = SliceBase[int16, IntegerConfig, intValue[int16]]
+type IntArgs = ArgumentsBase[int64, IntegerConfig, intValue]
 
 type Int16SliceFlag = FlagBase[[]int16, IntegerConfig, Int16Slice]
 
@@ -1116,7 +1081,7 @@ func (i SliceBase[T, C, VC]) ToString(t []T) string
 func (i *SliceBase[T, C, VC]) Value() []T
     Value returns the slice of values set by this flag
 
-type StringArg = ArgumentBase[string, StringConfig, stringValue]
+type StringArgs = ArgumentsBase[string, StringConfig, stringValue]
 
 type StringConfig struct {
 	// Whether to trim whitespace of parsed value
@@ -1128,7 +1093,7 @@ type StringFlag = FlagBase[string, StringConfig, stringValue]
 
 type StringMap = MapBase[string, StringConfig, stringValue]
 
-type StringMapArg = ArgumentBase[map[string]string, StringConfig, StringMap]
+type StringMapArgs = ArgumentsBase[map[string]string, StringConfig, StringMap]
 
 type StringMapFlag = FlagBase[map[string]string, StringConfig, StringMap]
 
@@ -1140,7 +1105,7 @@ type SuggestCommandFunc func(commands []*Command, provided string) string
 
 type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
 
-type TimestampArg = ArgumentBase[time.Time, TimestampConfig, timestampValue]
+type TimestampArgs = ArgumentsBase[time.Time, TimestampConfig, timestampValue]
 
 type TimestampConfig struct {
 	Timezone *time.Location
@@ -1155,39 +1120,7 @@ type TimestampConfig struct {
 
 type TimestampFlag = FlagBase[time.Time, TimestampConfig, timestampValue]
 
-type Uint16Arg = ArgumentBase[uint16, IntegerConfig, uintValue[uint16]]
-
-type Uint16Flag = FlagBase[uint16, IntegerConfig, uintValue[uint16]]
-
-type Uint16Slice = SliceBase[uint16, IntegerConfig, uintValue[uint16]]
-
-type Uint16SliceFlag = FlagBase[[]uint16, IntegerConfig, Uint16Slice]
-
-type Uint32Arg = ArgumentBase[uint32, IntegerConfig, uintValue[uint32]]
-
-type Uint32Flag = FlagBase[uint32, IntegerConfig, uintValue[uint32]]
-
-type Uint32Slice = SliceBase[uint32, IntegerConfig, uintValue[uint32]]
-
-type Uint32SliceFlag = FlagBase[[]uint32, IntegerConfig, Uint32Slice]
-
-type Uint64Arg = ArgumentBase[uint64, IntegerConfig, uintValue[uint64]]
-
-type Uint64Flag = FlagBase[uint64, IntegerConfig, uintValue[uint64]]
-
-type Uint64Slice = SliceBase[uint64, IntegerConfig, uintValue[uint64]]
-
-type Uint64SliceFlag = FlagBase[[]uint64, IntegerConfig, Uint64Slice]
-
-type Uint8Arg = ArgumentBase[uint8, IntegerConfig, uintValue[uint8]]
-
-type Uint8Flag = FlagBase[uint8, IntegerConfig, uintValue[uint8]]
-
-type Uint8Slice = SliceBase[uint8, IntegerConfig, uintValue[uint8]]
-
-type Uint8SliceFlag = FlagBase[[]uint8, IntegerConfig, Uint8Slice]
-
-type UintArg = ArgumentBase[uint, IntegerConfig, uintValue[uint]]
+type UintArgs = ArgumentsBase[uint64, IntegerConfig, uintValue]
 
 type UintFlag = FlagBase[uint, IntegerConfig, uintValue[uint]]
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

Add functions to allow Args access. Two classes of functions are available on the command
one for single value arguments and one for multi value/slice

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

Fixes #2056 

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

go test -run=Test*Args

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
New classes of accessor functions for different argument types has been added. One for single value arguments and one for multiple values/slices

- StringArg
- StringArgs
- FloatArg
- FloatArgs
- IntArg
- IntArgs
- UintArg
- UintArgs
- TimestampArg
- TimestampArgs

Only the single value arguments can have a default value. Parsing of arguments will stop at the first argument that fails either parsing or constraint mismatch
```
