### PR TITLE
Fix docs for shell completions

### DIFF
--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -23,7 +23,7 @@ Enabling auto complete requires 2 things
 
 Consider the following program
 
- ```go
+```go
 package main
 
 import (


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

The documentation at [shell-completions](https://cli.urfave.org/v3/examples/completions/shell-completions/) seems to be broken
This PR fixes it

*Before*
<img width="400" alt="Before" src="https://github.com/user-attachments/assets/3267997d-8c5c-45c0-9613-abf02b7abde3" />

## Testing

Tested locally using `mkdocs serve`

*After*
<img width="400" alt="After" src="https://github.com/user-attachments/assets/32277888-48db-44c6-bf68-d04e22caf3b2" />


## Release Notes

```release-note
docs: fix broken code block
