### PR TITLE
fix: make fish completions work

### DIFF
--- a/command_setup.go
+++ b/command_setup.go
@@ -89,7 +89,7 @@ func (cmd *Command) setupDefaults(osArgs []string) {
 	}
 
 	if cmd.EnableShellCompletion || cmd.Root().shellCompletion {
-		completionCommand := buildCompletionCommand(cmd.Name)
+		completionCommand := buildCompletionCommand(cmd)
 
 		if cmd.ShellCompletionCommandName != "" {
 			tracef(

--- a/completion_test.go
+++ b/completion_test.go
@@ -202,7 +202,7 @@ func TestCompletionInvalidShell(t *testing.T) {
 	assert.ErrorContains(t, err, "unknown shell junky-sheell")
 
 	enableError := true
-	shellCompletions[unknownShellName] = func(c *Command, appName string) (string, error) {
+	shellCompletions[unknownShellName] = func(c *Command) (string, error) {
 		if enableError {
 			return "", fmt.Errorf("cant do completion")
 		}


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

This PR fixes a bug where `./cli completion fish` always outputs 

```
# completion fish shell completion

function __fish_completion_no_subcommand --description 'Test if there has been any subcommand yet'
    for i in (commandline -opc)
        if contains -- $i
            return 1
        end
    end
    return 0
end

complete -c completion -n '__fish_completion_no_subcommand' -f -l help -s h -d 'show help'
complete -c completion -n '__fish_completion_no_subcommand' -f -l help -s h -d 'show help'
```

This is because the command used to generate the completions is _always_ the one corresponding to the `completion` command, and it needs to know the root command.

## Which issue(s) this PR fixes:

issue #2105 

## Testing

After making these changes, completions for my CLI generated successfully.

## Release Notes

```release-note
Fixes issue with fish completions which showed completions only for the `complete` command
```
