### PR TITLE
feat: adds support for explicit `float32` and `float64`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,26 +14,6 @@ permissions:
   contents: read
 
 jobs:
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-
-      - name: Set up gofumpt
-        run: go install mvdan.cc/gofumpt@latest
-
-      - name: Run gofumpt
-        run: |
-          non_formatted_files="$(gofumpt -l .)"
-          echo "$non_formatted_files"
-          test -z "$non_formatted_files"
-
   golangci-lint:
     runs-on: ubuntu-latest
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,9 @@
 version: "2"
+
+formatters:
+  enable:
+    - gofumpt
+
 linters:
   enable:
     - makezero

--- a/args.go
+++ b/args.go
@@ -226,7 +226,9 @@ func (a *ArgumentsBase[T, C, VC]) Get() any {
 }
 
 type (
-	FloatArg      = ArgumentBase[float64, NoConfig, floatValue]
+	FloatArg      = ArgumentBase[float64, NoConfig, floatValue[float64]]
+	Float32Arg    = ArgumentBase[float32, NoConfig, floatValue[float32]]
+	Float64Arg    = ArgumentBase[float64, NoConfig, floatValue[float64]]
 	IntArg        = ArgumentBase[int, IntegerConfig, intValue[int]]
 	Int8Arg       = ArgumentBase[int8, IntegerConfig, intValue[int8]]
 	Int16Arg      = ArgumentBase[int16, IntegerConfig, intValue[int16]]
@@ -241,7 +243,9 @@ type (
 	Uint32Arg     = ArgumentBase[uint32, IntegerConfig, uintValue[uint32]]
 	Uint64Arg     = ArgumentBase[uint64, IntegerConfig, uintValue[uint64]]
 
-	FloatArgs     = ArgumentsBase[float64, NoConfig, floatValue]
+	FloatArgs     = ArgumentsBase[float64, NoConfig, floatValue[float64]]
+	Float32Args   = ArgumentsBase[float32, NoConfig, floatValue[float32]]
+	Float64Args   = ArgumentsBase[float64, NoConfig, floatValue[float64]]
 	IntArgs       = ArgumentsBase[int, IntegerConfig, intValue[int]]
 	Int8Args      = ArgumentsBase[int8, IntegerConfig, intValue[int8]]
 	Int16Args     = ArgumentsBase[int16, IntegerConfig, intValue[int16]]
@@ -290,6 +294,22 @@ func (c *Command) FloatArg(name string) float64 {
 }
 
 func (c *Command) FloatArgs(name string) []float64 {
+	return arg[[]float64](name, c)
+}
+
+func (c *Command) Float32Arg(name string) float32 {
+	return arg[float32](name, c)
+}
+
+func (c *Command) Float32Args(name string) []float32 {
+	return arg[[]float32](name, c)
+}
+
+func (c *Command) Float64Arg(name string) float64 {
+	return arg[float64](name, c)
+}
+
+func (c *Command) Float64Args(name string) []float64 {
 	return arg[[]float64](name, c)
 }
 

--- a/args_test.go
+++ b/args_test.go
@@ -8,6 +8,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestArgsFloatTypes(t *testing.T) {
+	cmd := buildMinimalTestCommand()
+	var fval float64
+	cmd.Arguments = []Argument{
+		&FloatArg{
+			Name:        "ia",
+			Destination: &fval,
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"foo", "10"})
+	r := require.New(t)
+	r.NoError(err)
+	r.Equal(float64(10), fval)
+	r.Equal(float64(10), cmd.FloatArg("ia"))
+	r.Equal(float64(10), cmd.Float64Arg("ia"))
+	r.Equal(float32(0), cmd.Float32Arg("ia"))
+	r.Equal(float64(0), cmd.FloatArg("iab"))
+	r.Equal(int8(0), cmd.Int8Arg("ia"))
+	r.Equal(int16(0), cmd.Int16Arg("ia"))
+	r.Equal(int32(0), cmd.Int32Arg("ia"))
+	r.Equal(int64(0), cmd.Int64Arg("ia"))
+	r.Empty(cmd.StringArg("ia"))
+
+	r.Error(cmd.Run(buildTestContext(t), []string{"foo", "a"}))
+}
+
 func TestArgsIntTypes(t *testing.T) {
 	cmd := buildMinimalTestCommand()
 	var ival int
@@ -32,6 +59,29 @@ func TestArgsIntTypes(t *testing.T) {
 	r.Empty(cmd.StringArg("ia"))
 
 	r.Error(cmd.Run(buildTestContext(t), []string{"foo", "10.0"}))
+}
+
+func TestArgsFloatSliceTypes(t *testing.T) {
+	cmd := buildMinimalTestCommand()
+	var fval []float64
+	cmd.Arguments = []Argument{
+		&FloatArgs{
+			Name:        "ia",
+			Min:         1,
+			Max:         -1,
+			Destination: &fval,
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"foo", "10", "20", "30"})
+	r := require.New(t)
+	r.NoError(err)
+	r.Equal([]float64{10, 20, 30}, fval)
+	r.Equal([]float64{10, 20, 30}, cmd.FloatArgs("ia"))
+	r.Equal([]float64{10, 20, 30}, cmd.Float64Args("ia"))
+	r.Nil(cmd.Float32Args("ia"))
+
+	r.Error(cmd.Run(buildTestContext(t), []string{"foo", "10", "a"}))
 }
 
 func TestArgsIntSliceTypes(t *testing.T) {

--- a/docs/v3/examples/flags/basics.md
+++ b/docs/v3/examples/flags/basics.md
@@ -147,6 +147,8 @@ The following basic flags are supported
 - `BoolFlag`
 - `DurationFlag`
 - `FloatFlag`
+- `Float32Flag`
+- `Float64Flag`
 - `StringFlag`
 - `TimestampFlag`
 

--- a/flag_float.go
+++ b/flag_float.go
@@ -2,44 +2,71 @@ package cli
 
 import (
 	"strconv"
+	"unsafe"
 )
 
-type FloatFlag = FlagBase[float64, NoConfig, floatValue]
+type (
+	FloatFlag   = FlagBase[float64, NoConfig, floatValue[float64]]
+	Float32Flag = FlagBase[float32, NoConfig, floatValue[float32]]
+	Float64Flag = FlagBase[float64, NoConfig, floatValue[float64]]
+)
 
-// -- float64 Value
-type floatValue float64
+// -- float Value
+type floatValue[T float32 | float64] struct {
+	val *T
+}
 
 // Below functions are to satisfy the ValueCreator interface
 
-func (f floatValue) Create(val float64, p *float64, c NoConfig) Value {
+func (f floatValue[T]) Create(val T, p *T, c NoConfig) Value {
 	*p = val
-	return (*floatValue)(p)
+
+	return &floatValue[T]{val: p}
 }
 
-func (f floatValue) ToString(b float64) string {
-	return strconv.FormatFloat(b, 'g', -1, 64)
+func (f floatValue[T]) ToString(b T) string {
+	return strconv.FormatFloat(float64(b), 'g', -1, int(unsafe.Sizeof(T(0))*8))
 }
 
 // Below functions are to satisfy the flag.Value interface
 
-func (f *floatValue) Set(s string) error {
-	v, err := strconv.ParseFloat(s, 64)
+func (f *floatValue[T]) Set(s string) error {
+	v, err := strconv.ParseFloat(s, int(unsafe.Sizeof(T(0))*8))
 	if err != nil {
 		return err
 	}
-	*f = floatValue(v)
-	return err
+	*f.val = T(v)
+	return nil
 }
 
-func (f *floatValue) Get() any { return float64(*f) }
+func (f *floatValue[T]) Get() any { return *f.val }
 
-func (f *floatValue) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 64) }
+func (f *floatValue[T]) String() string {
+	return strconv.FormatFloat(float64(*f.val), 'g', -1, int(unsafe.Sizeof(T(0))*8))
+}
 
 // Float looks up the value of a local FloatFlag, returns
 // 0 if not found
 func (cmd *Command) Float(name string) float64 {
-	if v, ok := cmd.Value(name).(float64); ok {
+	return getFloat[float64](cmd, name)
+}
+
+// Float32 looks up the value of a local Float32Flag, returns
+// 0 if not found
+func (cmd *Command) Float32(name string) float32 {
+	return getFloat[float32](cmd, name)
+}
+
+// Float64 looks up the value of a local Float32Flag, returns
+// 0 if not found
+func (cmd *Command) Float64(name string) float64 {
+	return getFloat[float64](cmd, name)
+}
+
+func getFloat[T float32 | float64](cmd *Command, name string) T {
+	if v, ok := cmd.Value(name).(T); ok {
 		tracef("float available for flag name %[1]q with value=%[2]v (cmd=%[3]q)", name, v, cmd.Name)
+
 		return v
 	}
 

--- a/flag_float.go
+++ b/flag_float.go
@@ -57,7 +57,7 @@ func (cmd *Command) Float32(name string) float32 {
 	return getFloat[float32](cmd, name)
 }
 
-// Float64 looks up the value of a local Float32Flag, returns
+// Float64 looks up the value of a local Float64Flag, returns
 // 0 if not found
 func (cmd *Command) Float64(name string) float64 {
 	return getFloat[float64](cmd, name)

--- a/flag_float_slice.go
+++ b/flag_float_slice.go
@@ -1,17 +1,42 @@
 package cli
 
 type (
-	FloatSlice     = SliceBase[float64, NoConfig, floatValue]
-	FloatSliceFlag = FlagBase[[]float64, NoConfig, FloatSlice]
+	FloatSlice       = SliceBase[float64, NoConfig, floatValue[float64]]
+	Float32Slice     = SliceBase[float32, NoConfig, floatValue[float32]]
+	Float64Slice     = SliceBase[float64, NoConfig, floatValue[float64]]
+	FloatSliceFlag   = FlagBase[[]float64, NoConfig, FloatSlice]
+	Float32SliceFlag = FlagBase[[]float32, NoConfig, Float32Slice]
+	Float64SliceFlag = FlagBase[[]float64, NoConfig, Float64Slice]
 )
 
-var NewFloatSlice = NewSliceBase[float64, NoConfig, floatValue]
+var (
+	NewFloatSlice   = NewSliceBase[float64, NoConfig, floatValue[float64]]
+	NewFloat32Slice = NewSliceBase[float32, NoConfig, floatValue[float32]]
+	NewFloat64Slice = NewSliceBase[float64, NoConfig, floatValue[float64]]
+)
 
 // FloatSlice looks up the value of a local FloatSliceFlag, returns
 // nil if not found
 func (cmd *Command) FloatSlice(name string) []float64 {
-	if v, ok := cmd.Value(name).([]float64); ok {
+	return getFloatSlice[float64](cmd, name)
+}
+
+// Float32Slice looks up the value of a local Float32Slice, returns
+// nil if not found
+func (cmd *Command) Float32Slice(name string) []float32 {
+	return getFloatSlice[float32](cmd, name)
+}
+
+// Float64Slice looks up the value of a local Float64SliceFlag, returns
+// nil if not found
+func (cmd *Command) Float64Slice(name string) []float64 {
+	return getFloatSlice[float64](cmd, name)
+}
+
+func getFloatSlice[T float32 | float64](cmd *Command, name string) []T {
+	if v, ok := cmd.Value(name).([]T); ok {
 		tracef("float slice available for flag name %[1]q with value=%[2]v (cmd=%[3]q)", name, v, cmd.Name)
+
 		return v
 	}
 

--- a/flag_float_slice.go
+++ b/flag_float_slice.go
@@ -18,28 +18,17 @@ var (
 // FloatSlice looks up the value of a local FloatSliceFlag, returns
 // nil if not found
 func (cmd *Command) FloatSlice(name string) []float64 {
-	return getFloatSlice[float64](cmd, name)
+	return getNumberSlice[float64](cmd, name)
 }
 
 // Float32Slice looks up the value of a local Float32Slice, returns
 // nil if not found
 func (cmd *Command) Float32Slice(name string) []float32 {
-	return getFloatSlice[float32](cmd, name)
+	return getNumberSlice[float32](cmd, name)
 }
 
 // Float64Slice looks up the value of a local Float64SliceFlag, returns
 // nil if not found
 func (cmd *Command) Float64Slice(name string) []float64 {
-	return getFloatSlice[float64](cmd, name)
-}
-
-func getFloatSlice[T float32 | float64](cmd *Command, name string) []T {
-	if v, ok := cmd.Value(name).([]T); ok {
-		tracef("float slice available for flag name %[1]q with value=%[2]v (cmd=%[3]q)", name, v, cmd.Name)
-
-		return v
-	}
-
-	tracef("float slice NOT available for flag name %[1]q (cmd=%[2]q)", name, cmd.Name)
-	return nil
+	return getNumberSlice[float64](cmd, name)
 }

--- a/flag_float_slice_test.go
+++ b/flag_float_slice_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommand_FloatSlice(t *testing.T) {
+	tests := []struct {
+		name      string
+		flag      Flag
+		arguments []string
+		expect    []float64
+		expectErr bool
+	}{
+		{
+			flag: &FloatSliceFlag{
+				Name: "numbers",
+			},
+			arguments: []string{"--numbers", "1,2,3,4"},
+			expect:    []float64{1, 2, 3, 4},
+		},
+		{
+			flag: &FloatSliceFlag{
+				Name: "numbers",
+			},
+			arguments: []string{"--numbers", "1,2", "--numbers", "3,4"},
+			expect:    []float64{1, 2, 3, 4},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &Command{
+				Name:      "mock",
+				Flags:     []Flag{tt.flag},
+				Writer:    io.Discard,
+				ErrWriter: io.Discard,
+			}
+
+			err := cmd.Run(buildTestContext(t), append([]string{"mock"}, tt.arguments...))
+
+			if tt.expectErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			for _, name := range tt.flag.Names() {
+				assert.Equalf(t, tt.expect, cmd.FloatSlice(name), "FloatSlice(%v)", name)
+			}
+		})
+	}
+}
+
+func TestCommand_Float32Slice(t *testing.T) {
+	tests := []struct {
+		name      string
+		flag      Flag
+		arguments []string
+		expect    []float32
+		expectErr bool
+	}{
+		{
+			flag: &Float32SliceFlag{
+				Name: "numbers",
+			},
+			arguments: []string{"--numbers", "1,2,3,4"},
+			expect:    []float32{1, 2, 3, 4},
+		},
+		{
+			flag: &Float32SliceFlag{
+				Name: "numbers",
+			},
+			arguments: []string{"--numbers", "1,2", "--numbers", "3,4"},
+			expect:    []float32{1, 2, 3, 4},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &Command{
+				Name:      "mock",
+				Flags:     []Flag{tt.flag},
+				Writer:    io.Discard,
+				ErrWriter: io.Discard,
+			}
+
+			err := cmd.Run(buildTestContext(t), append([]string{"mock"}, tt.arguments...))
+
+			if tt.expectErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			for _, name := range tt.flag.Names() {
+				assert.Equalf(t, tt.expect, cmd.Float32Slice(name), "Float32Slice(%v)", name)
+			}
+		})
+	}
+}
+
+func TestCommand_Float64Slice(t *testing.T) {
+	tests := []struct {
+		name      string
+		flag      Flag
+		arguments []string
+		expect    []float64
+		expectErr bool
+	}{
+		{
+			flag: &Float64SliceFlag{
+				Name: "numbers",
+			},
+			arguments: []string{"--numbers", "1,2,3,4"},
+			expect:    []float64{1, 2, 3, 4},
+		},
+		{
+			flag: &Float64SliceFlag{
+				Name: "numbers",
+			},
+			arguments: []string{"--numbers", "1,2", "--numbers", "3,4"},
+			expect:    []float64{1, 2, 3, 4},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &Command{
+				Name:      "mock",
+				Flags:     []Flag{tt.flag},
+				Writer:    io.Discard,
+				ErrWriter: io.Discard,
+			}
+
+			err := cmd.Run(buildTestContext(t), append([]string{"mock"}, tt.arguments...))
+
+			if tt.expectErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			for _, name := range tt.flag.Names() {
+				assert.Equalf(t, tt.expect, cmd.Float64Slice(name), "Float64Slice(%v)", name)
+			}
+		})
+	}
+}

--- a/flag_float_test.go
+++ b/flag_float_test.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_FloatFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		flag          Flag
+		arguments     []string
+		expectedValue float64
+		expectErr     bool
+	}{
+		{
+			name: "valid",
+			flag: &FloatFlag{
+				Name:    "number",
+				Aliases: []string{"n"},
+			},
+			arguments:     []string{"--number", "-234567"},
+			expectedValue: -234567,
+		},
+		{
+			name: "invalid",
+			flag: &FloatFlag{
+				Name: "number",
+			},
+			arguments: []string{"--number", "gopher"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &Command{
+				Name:      "mock",
+				Flags:     []Flag{tt.flag},
+				Writer:    io.Discard,
+				ErrWriter: io.Discard,
+			}
+
+			err := cmd.Run(buildTestContext(t), append([]string{"mock"}, tt.arguments...))
+
+			if tt.expectErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			for _, name := range tt.flag.Names() {
+				assert.Equal(t, tt.expectedValue, cmd.Float(name))
+			}
+		})
+	}
+}
+
+func Test_Float32Flag(t *testing.T) {
+	tests := []struct {
+		name          string
+		flag          Flag
+		arguments     []string
+		expectedValue float32
+		expectErr     bool
+	}{
+		{
+			name: "valid",
+			flag: &Float32Flag{
+				Name:    "number",
+				Aliases: []string{"n"},
+			},
+			arguments:     []string{"--number", "2147483647"},
+			expectedValue: 2147483647,
+		},
+		{
+			name: "invalid",
+			flag: &Float32Flag{
+				Name: "number",
+			},
+
+			arguments: []string{"--number", "gopher"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &Command{
+				Name:      "mock",
+				Flags:     []Flag{tt.flag},
+				Writer:    io.Discard,
+				ErrWriter: io.Discard,
+			}
+
+			err := cmd.Run(buildTestContext(t), append([]string{"mock"}, tt.arguments...))
+
+			if tt.expectErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			for _, name := range tt.flag.Names() {
+				assert.Equal(t, tt.expectedValue, cmd.Float32(name))
+			}
+		})
+	}
+}
+
+func Test_Float64Flag(t *testing.T) {
+	tests := []struct {
+		name          string
+		flag          Flag
+		arguments     []string
+		expectedValue float64
+		expectErr     bool
+	}{
+		{
+			name: "valid",
+			flag: &Float64Flag{
+				Name:    "number",
+				Aliases: []string{"n"},
+			},
+			arguments:     []string{"--number", "-2147483648"},
+			expectedValue: -2147483648,
+		},
+		{
+			name: "invalid",
+			flag: &Float64Flag{
+				Name: "number",
+			},
+			arguments: []string{"--number", "gopher"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &Command{
+				Name:      "mock",
+				Flags:     []Flag{tt.flag},
+				Writer:    io.Discard,
+				ErrWriter: io.Discard,
+			}
+
+			err := cmd.Run(buildTestContext(t), append([]string{"mock"}, tt.arguments...))
+
+			if tt.expectErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			for _, name := range tt.flag.Names() {
+				assert.Equal(t, tt.expectedValue, cmd.Float64(name))
+			}
+		})
+	}
+}

--- a/flag_float_test.go
+++ b/flag_float_test.go
@@ -167,3 +167,10 @@ func Test_Float64Flag(t *testing.T) {
 		})
 	}
 }
+
+func Test_floatValue_String(t *testing.T) {
+	var f float64 = 100
+	fv := floatValue[float64]{val: &f}
+
+	assert.Equal(t, "100", fv.String())
+}

--- a/flag_int_slice.go
+++ b/flag_int_slice.go
@@ -24,40 +24,29 @@ var (
 // IntSlice looks up the value of a local IntSliceFlag, returns
 // nil if not found
 func (cmd *Command) IntSlice(name string) []int {
-	return getIntSlice[int](cmd, name)
+	return getNumberSlice[int](cmd, name)
 }
 
 // Int8Slice looks up the value of a local Int8SliceFlag, returns
 // nil if not found
 func (cmd *Command) Int8Slice(name string) []int8 {
-	return getIntSlice[int8](cmd, name)
+	return getNumberSlice[int8](cmd, name)
 }
 
 // Int16Slice looks up the value of a local Int16SliceFlag, returns
 // nil if not found
 func (cmd *Command) Int16Slice(name string) []int16 {
-	return getIntSlice[int16](cmd, name)
+	return getNumberSlice[int16](cmd, name)
 }
 
 // Int32Slice looks up the value of a local Int32SliceFlag, returns
 // nil if not found
 func (cmd *Command) Int32Slice(name string) []int32 {
-	return getIntSlice[int32](cmd, name)
+	return getNumberSlice[int32](cmd, name)
 }
 
 // Int64Slice looks up the value of a local Int64SliceFlag, returns
 // nil if not found
 func (cmd *Command) Int64Slice(name string) []int64 {
-	return getIntSlice[int64](cmd, name)
-}
-
-func getIntSlice[T int | int8 | int16 | int32 | int64](cmd *Command, name string) []T {
-	if v, ok := cmd.Value(name).([]T); ok {
-		tracef("int slice available for flag name %[1]q with value=%[2]v (cmd=%[3]q)", name, v, cmd.Name)
-
-		return v
-	}
-
-	tracef("int slice NOT available for flag name %[1]q (cmd=%[2]q)", name, cmd.Name)
-	return nil
+	return getNumberSlice[int64](cmd, name)
 }

--- a/flag_number_slice.go
+++ b/flag_number_slice.go
@@ -1,0 +1,15 @@
+package cli
+
+type numberType interface {
+	int | int8 | int16 | int32 | int64 | float32 | float64
+}
+
+func getNumberSlice[T numberType](cmd *Command, name string) []T {
+	if v, ok := cmd.Value(name).([]T); ok {
+		tracef("%T slice available for flag name %[1]q with value=%[2]v (cmd=%[3]q)", *new(T), name, v, cmd.Name)
+		return v
+	}
+
+	tracef("%T slice NOT available for flag name %[1]q (cmd=%[2]q)", *new(T), name, cmd.Name)
+	return nil
+}

--- a/flag_number_slice_test.go
+++ b/flag_number_slice_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getNumberSlice_int64(t *testing.T) {
+	f := &Int64SliceFlag{Name: "numbers"}
+
+	cmd := &Command{
+		Name:      "mock",
+		Flags:     []Flag{f},
+		Writer:    io.Discard,
+		ErrWriter: io.Discard,
+	}
+
+	err := f.Set("", "1,2,3")
+	require.NoError(t, err)
+
+	expected := []int64{1, 2, 3}
+
+	assert.Equal(t, expected, getNumberSlice[int64](cmd, "numbers"))
+}
+
+func Test_getNumberSlice_float64(t *testing.T) {
+	f := &Float64SliceFlag{Name: "numbers"}
+
+	cmd := &Command{
+		Name:      "mock",
+		Flags:     []Flag{f},
+		Writer:    io.Discard,
+		ErrWriter: io.Discard,
+	}
+
+	err := f.Set("", "1,2,3")
+	require.NoError(t, err)
+
+	expected := []float64{1, 2, 3}
+
+	assert.Equal(t, expected, getNumberSlice[float64](cmd, "numbers"))
+}

--- a/flag_test.go
+++ b/flag_test.go
@@ -2607,7 +2607,7 @@ func TestTimestampFlagApply_MultipleFormats(t *testing.T) {
 }
 
 func TestTimestampFlagApply_ShortenedLayouts(t *testing.T) {
-	now := time.Now().In(time.UTC)
+	now := time.Now().UTC()
 
 	shortenedLayoutsPrecisions := map[string]time.Duration{
 		time.Kitchen:    time.Minute,
@@ -2726,8 +2726,20 @@ func TestFlagDefaultValue(t *testing.T) {
 			expect:  `--flag string [ --flag string ]	(default: "default1", "default2")`,
 		},
 		{
-			name:    "float64Slice",
+			name:    "floatSlice",
 			flag:    &FloatSliceFlag{Name: "flag", Value: []float64{1.1, 2.2}},
+			toParse: []string{"--flag", "13.3"},
+			expect:  `--flag float [ --flag float ]	(default: 1.1, 2.2)`,
+		},
+		{
+			name:    "float32Slice",
+			flag:    &Float32SliceFlag{Name: "flag", Value: []float32{1.1, 2.2}},
+			toParse: []string{"--flag", "13.3"},
+			expect:  `--flag float [ --flag float ]	(default: 1.1, 2.2)`,
+		},
+		{
+			name:    "float64Slice",
+			flag:    &Float64SliceFlag{Name: "flag", Value: []float64{1.1, 2.2}},
 			toParse: []string{"--flag", "13.3"},
 			expect:  `--flag float [ --flag float ]	(default: 1.1, 2.2)`,
 		},
@@ -3243,11 +3255,15 @@ func TestExtFlag(t *testing.T) {
 
 func TestSliceValuesNil(t *testing.T) {
 	assert.Equal(t, []float64(nil), NewFloatSlice().Value())
+	assert.Equal(t, []float32(nil), NewFloat32Slice().Value())
+	assert.Equal(t, []float64(nil), NewFloat64Slice().Value())
 	assert.Equal(t, []int64(nil), NewInt64Slice().Value())
 	assert.Equal(t, []uint64(nil), NewUint64Slice().Value())
 	assert.Equal(t, []string(nil), NewStringSlice().Value())
 
 	assert.Equal(t, []float64(nil), (&FloatSlice{}).Value())
+	assert.Equal(t, []float32(nil), (&Float32Slice{}).Value())
+	assert.Equal(t, []float64(nil), (&Float64Slice{}).Value())
 	assert.Equal(t, []int64(nil), (&Int64Slice{}).Value())
 	assert.Equal(t, []uint64(nil), (&Uint64Slice{}).Value())
 	assert.Equal(t, []string(nil), (&StringSlice{}).Value())

--- a/flag_test.go
+++ b/flag_test.go
@@ -743,7 +743,7 @@ var _ = []struct {
 	}, "env: ENV_VAR, str: -f value\t"},
 }
 
-//func TestFlagEnvHinter(t *testing.T) {
+// func TestFlagEnvHinter(t *testing.T) {
 //	defer func() {
 //		FlagEnvHinter = withEnvHint
 //	}()
@@ -756,7 +756,7 @@ var _ = []struct {
 //			t.Errorf("%q does not match %q", output, test.expected)
 //		}
 //	}
-//}
+// }
 
 var stringSliceFlagTests = []struct {
 	name     string
@@ -2607,7 +2607,7 @@ func TestTimestampFlagApply_MultipleFormats(t *testing.T) {
 }
 
 func TestTimestampFlagApply_ShortenedLayouts(t *testing.T) {
-	now := time.Now().UTC()
+	now := time.Now().In(time.UTC)
 
 	shortenedLayoutsPrecisions := map[string]time.Duration{
 		time.Kitchen:    time.Minute,
@@ -3289,12 +3289,12 @@ func TestFlagsByName(t *testing.T) {
 
 func TestNonStringMap(t *testing.T) {
 	type (
-		floatMap = MapBase[float64, NoConfig, floatValue]
+		floatMap = MapBase[float64, NoConfig, floatValue[float64]]
 	)
 
 	p := map[string]float64{}
 
-	var fv floatValue
+	var fv floatValue[float64]
 
 	f := &floatMap{
 		value: &fv,
@@ -3352,10 +3352,11 @@ func TestGenericFlag_SatisfiesFlagInterface(t *testing.T) {
 
 func TestGenericValue_SatisfiesBoolInterface(t *testing.T) {
 	var f boolFlag = &genericValue{}
+	var fpv float64
 
 	assert.False(t, f.IsBoolFlag())
 
-	fv := floatValue(0)
+	fv := floatValue[float64]{val: &fpv}
 	f = &genericValue{
 		val: &fv,
 	}

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -544,7 +544,7 @@ func (cmd *Command) Float32Slice(name string) []float32
     found
 
 func (cmd *Command) Float64(name string) float64
-    Float64 looks up the value of a local Float32Flag, returns 0 if not found
+    Float64 looks up the value of a local Float64Flag, returns 0 if not found
 
 func (c *Command) Float64Arg(name string) float64
 

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -27,6 +27,11 @@ application:
 VARIABLES
 
 var (
+	NewFloatSlice   = NewSliceBase[float64, NoConfig, floatValue[float64]]
+	NewFloat32Slice = NewSliceBase[float32, NoConfig, floatValue[float32]]
+	NewFloat64Slice = NewSliceBase[float64, NoConfig, floatValue[float64]]
+)
+var (
 	NewIntSlice   = NewSliceBase[int, IntegerConfig, intValue[int]]
 	NewInt8Slice  = NewSliceBase[int8, IntegerConfig, intValue[int8]]
 	NewInt16Slice = NewSliceBase[int16, IntegerConfig, intValue[int16]]
@@ -92,7 +97,6 @@ end
 
 {{ range $v := .Completions }}{{ $v }}
 {{ end }}`
-var NewFloatSlice = NewSliceBase[float64, NoConfig, floatValue]
 var NewStringMap = NewMapBase[string, StringConfig, stringValue]
 var NewStringSlice = NewSliceBase[string, StringConfig, stringValue]
 var OsExiter = os.Exit
@@ -527,6 +531,28 @@ func (cmd *Command) FlagNames() []string
 
 func (cmd *Command) Float(name string) float64
     Float looks up the value of a local FloatFlag, returns 0 if not found
+
+func (cmd *Command) Float32(name string) float32
+    Float32 looks up the value of a local Float32Flag, returns 0 if not found
+
+func (c *Command) Float32Arg(name string) float32
+
+func (c *Command) Float32Args(name string) []float32
+
+func (cmd *Command) Float32Slice(name string) []float32
+    Float32Slice looks up the value of a local Float32Slice, returns nil if not
+    found
+
+func (cmd *Command) Float64(name string) float64
+    Float64 looks up the value of a local Float32Flag, returns 0 if not found
+
+func (c *Command) Float64Arg(name string) float64
+
+func (c *Command) Float64Args(name string) []float64
+
+func (cmd *Command) Float64Slice(name string) []float64
+    Float64Slice looks up the value of a local Float64SliceFlag, returns nil if
+    not found
 
 func (c *Command) FloatArg(name string) float64
 
@@ -1023,13 +1049,33 @@ func (f FlagsByName) Less(i, j int) bool
 
 func (f FlagsByName) Swap(i, j int)
 
-type FloatArg = ArgumentBase[float64, NoConfig, floatValue]
+type Float32Arg = ArgumentBase[float32, NoConfig, floatValue[float32]]
 
-type FloatArgs = ArgumentsBase[float64, NoConfig, floatValue]
+type Float32Args = ArgumentsBase[float32, NoConfig, floatValue[float32]]
 
-type FloatFlag = FlagBase[float64, NoConfig, floatValue]
+type Float32Flag = FlagBase[float32, NoConfig, floatValue[float32]]
 
-type FloatSlice = SliceBase[float64, NoConfig, floatValue]
+type Float32Slice = SliceBase[float32, NoConfig, floatValue[float32]]
+
+type Float32SliceFlag = FlagBase[[]float32, NoConfig, Float32Slice]
+
+type Float64Arg = ArgumentBase[float64, NoConfig, floatValue[float64]]
+
+type Float64Args = ArgumentsBase[float64, NoConfig, floatValue[float64]]
+
+type Float64Flag = FlagBase[float64, NoConfig, floatValue[float64]]
+
+type Float64Slice = SliceBase[float64, NoConfig, floatValue[float64]]
+
+type Float64SliceFlag = FlagBase[[]float64, NoConfig, Float64Slice]
+
+type FloatArg = ArgumentBase[float64, NoConfig, floatValue[float64]]
+
+type FloatArgs = ArgumentsBase[float64, NoConfig, floatValue[float64]]
+
+type FloatFlag = FlagBase[float64, NoConfig, floatValue[float64]]
+
+type FloatSlice = SliceBase[float64, NoConfig, floatValue[float64]]
 
 type FloatSliceFlag = FlagBase[[]float64, NoConfig, FloatSlice]
 

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -544,7 +544,7 @@ func (cmd *Command) Float32Slice(name string) []float32
     found
 
 func (cmd *Command) Float64(name string) float64
-    Float64 looks up the value of a local Float32Flag, returns 0 if not found
+    Float64 looks up the value of a local Float64Flag, returns 0 if not found
 
 func (c *Command) Float64Arg(name string) float64
 

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -27,6 +27,11 @@ application:
 VARIABLES
 
 var (
+	NewFloatSlice   = NewSliceBase[float64, NoConfig, floatValue[float64]]
+	NewFloat32Slice = NewSliceBase[float32, NoConfig, floatValue[float32]]
+	NewFloat64Slice = NewSliceBase[float64, NoConfig, floatValue[float64]]
+)
+var (
 	NewIntSlice   = NewSliceBase[int, IntegerConfig, intValue[int]]
 	NewInt8Slice  = NewSliceBase[int8, IntegerConfig, intValue[int8]]
 	NewInt16Slice = NewSliceBase[int16, IntegerConfig, intValue[int16]]
@@ -92,7 +97,6 @@ end
 
 {{ range $v := .Completions }}{{ $v }}
 {{ end }}`
-var NewFloatSlice = NewSliceBase[float64, NoConfig, floatValue]
 var NewStringMap = NewMapBase[string, StringConfig, stringValue]
 var NewStringSlice = NewSliceBase[string, StringConfig, stringValue]
 var OsExiter = os.Exit
@@ -527,6 +531,28 @@ func (cmd *Command) FlagNames() []string
 
 func (cmd *Command) Float(name string) float64
     Float looks up the value of a local FloatFlag, returns 0 if not found
+
+func (cmd *Command) Float32(name string) float32
+    Float32 looks up the value of a local Float32Flag, returns 0 if not found
+
+func (c *Command) Float32Arg(name string) float32
+
+func (c *Command) Float32Args(name string) []float32
+
+func (cmd *Command) Float32Slice(name string) []float32
+    Float32Slice looks up the value of a local Float32Slice, returns nil if not
+    found
+
+func (cmd *Command) Float64(name string) float64
+    Float64 looks up the value of a local Float32Flag, returns 0 if not found
+
+func (c *Command) Float64Arg(name string) float64
+
+func (c *Command) Float64Args(name string) []float64
+
+func (cmd *Command) Float64Slice(name string) []float64
+    Float64Slice looks up the value of a local Float64SliceFlag, returns nil if
+    not found
 
 func (c *Command) FloatArg(name string) float64
 
@@ -1023,13 +1049,33 @@ func (f FlagsByName) Less(i, j int) bool
 
 func (f FlagsByName) Swap(i, j int)
 
-type FloatArg = ArgumentBase[float64, NoConfig, floatValue]
+type Float32Arg = ArgumentBase[float32, NoConfig, floatValue[float32]]
 
-type FloatArgs = ArgumentsBase[float64, NoConfig, floatValue]
+type Float32Args = ArgumentsBase[float32, NoConfig, floatValue[float32]]
 
-type FloatFlag = FlagBase[float64, NoConfig, floatValue]
+type Float32Flag = FlagBase[float32, NoConfig, floatValue[float32]]
 
-type FloatSlice = SliceBase[float64, NoConfig, floatValue]
+type Float32Slice = SliceBase[float32, NoConfig, floatValue[float32]]
+
+type Float32SliceFlag = FlagBase[[]float32, NoConfig, Float32Slice]
+
+type Float64Arg = ArgumentBase[float64, NoConfig, floatValue[float64]]
+
+type Float64Args = ArgumentsBase[float64, NoConfig, floatValue[float64]]
+
+type Float64Flag = FlagBase[float64, NoConfig, floatValue[float64]]
+
+type Float64Slice = SliceBase[float64, NoConfig, floatValue[float64]]
+
+type Float64SliceFlag = FlagBase[[]float64, NoConfig, Float64Slice]
+
+type FloatArg = ArgumentBase[float64, NoConfig, floatValue[float64]]
+
+type FloatArgs = ArgumentsBase[float64, NoConfig, floatValue[float64]]
+
+type FloatFlag = FlagBase[float64, NoConfig, floatValue[float64]]
+
+type FloatSlice = SliceBase[float64, NoConfig, floatValue[float64]]
 
 type FloatSliceFlag = FlagBase[[]float64, NoConfig, FloatSlice]
 


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Adds support for explicit `float32` and `float64`.

## Which issue(s) this PR fixes:

NA

## Special notes for your reviewer:

Same idea as https://github.com/urfave/cli/pull/2094

## Testing

Added tests.

## Release Notes

```release-note
Added support for explicit float32 and float64.
```
