### PR TITLE
Simpler top-level context detection for fish completions

### DIFF
--- a/fish.go
+++ b/fish.go
@@ -34,22 +34,6 @@ func (cmd *Command) writeFishCompletionTemplate(w io.Writer) error {
 	// Add global flags
 	completions := cmd.prepareFishFlags(cmd.VisibleFlags(), []string{})
 
-	// Add help flag
-	if !cmd.HideHelp {
-		completions = append(
-			completions,
-			cmd.prepareFishFlags([]Flag{HelpFlag}, []string{})...,
-		)
-	}
-
-	// Add version flag
-	if !cmd.HideVersion {
-		completions = append(
-			completions,
-			cmd.prepareFishFlags([]Flag{VersionFlag}, []string{})...,
-		)
-	}
-
 	// Add commands and their flags
 	completions = append(
 		completions,
@@ -84,14 +68,6 @@ func (cmd *Command) prepareFishCommands(commands []*Command, previousCommands []
 				" -d '%s'",
 				escapeSingleQuotes(command.Usage))
 		}
-
-		if !command.HideHelp {
-			completions = append(
-				completions,
-				cmd.prepareFishFlags([]Flag{HelpFlag}, command.Names())...,
-			)
-		}
-
 		completions = append(completions, completion.String())
 		completions = append(
 			completions,

--- a/testdata/expected-fish-full.fish
+++ b/testdata/expected-fish-full.fish
@@ -2,7 +2,7 @@
 
 function __fish_greet_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i config c sub-config s ss info i in some-command usage u sub-usage su
+        if contains -- $i config c info i in some-command hidden-command usage u
             return 1
         end
     end

--- a/testdata/expected-fish-full.fish
+++ b/testdata/expected-fish-full.fish
@@ -14,24 +14,16 @@ complete -c greet -n '__fish_greet_no_subcommand' -f -l flag -s fl -s f -r
 complete -c greet -n '__fish_greet_no_subcommand' -f -l another-flag -s b -d 'another usage text'
 complete -c greet -n '__fish_greet_no_subcommand' -l logfile -r
 complete -c greet -n '__fish_greet_no_subcommand' -l foofile -r
-complete -c greet -n '__fish_greet_no_subcommand' -f -l help -s h -d 'show help'
-complete -c greet -n '__fish_greet_no_subcommand' -f -l version -s v -d 'print the version'
-complete -c greet -n '__fish_seen_subcommand_from config c' -f -l help -s h -d 'show help'
 complete -x -c greet -n '__fish_greet_no_subcommand' -a 'config c' -d 'another usage test'
 complete -c greet -n '__fish_seen_subcommand_from config c' -l flag -s fl -s f -r
 complete -c greet -n '__fish_seen_subcommand_from config c' -f -l another-flag -s b -d 'another usage text'
-complete -c greet -n '__fish_seen_subcommand_from sub-config s ss' -f -l help -s h -d 'show help'
 complete -x -c greet -n '__fish_seen_subcommand_from config c; and not __fish_seen_subcommand_from sub-config s ss' -a 'sub-config s ss' -d 'another usage test'
 complete -c greet -n '__fish_seen_subcommand_from sub-config s ss' -f -l sub-flag -s sub-fl -s s -r
 complete -c greet -n '__fish_seen_subcommand_from sub-config s ss' -f -l sub-command-flag -s s -d 'some usage text'
-complete -c greet -n '__fish_seen_subcommand_from info i in' -f -l help -s h -d 'show help'
 complete -x -c greet -n '__fish_greet_no_subcommand' -a 'info i in' -d 'retrieve generic information'
-complete -c greet -n '__fish_seen_subcommand_from some-command' -f -l help -s h -d 'show help'
 complete -x -c greet -n '__fish_greet_no_subcommand' -a 'some-command'
-complete -c greet -n '__fish_seen_subcommand_from usage u' -f -l help -s h -d 'show help'
 complete -x -c greet -n '__fish_greet_no_subcommand' -a 'usage u' -d 'standard usage text'
 complete -c greet -n '__fish_seen_subcommand_from usage u' -l flag -s fl -s f -r
 complete -c greet -n '__fish_seen_subcommand_from usage u' -f -l another-flag -s b -d 'another usage text'
-complete -c greet -n '__fish_seen_subcommand_from sub-usage su' -f -l help -s h -d 'show help'
 complete -x -c greet -n '__fish_seen_subcommand_from usage u; and not __fish_seen_subcommand_from sub-usage su' -a 'sub-usage su' -d 'standard usage text'
 complete -c greet -n '__fish_seen_subcommand_from sub-usage su' -f -l sub-command-flag -s s -d 'some usage text'


### PR DESCRIPTION
## What type of PR is this?

- optimization

## What this PR does / why we need it:

Three optimizations:

1. Previously, completions checked against all levels of subcommands. In case a cli has hundreds of subcommands, this lookup would be a significant effort. This change has it look only for top-level commands, which must necessarily be present before their children.
1. Add hidden top-level commands to the list that were previously not in the list. Before, this would confuse completions inside hidden commands. (Additional issue related to completion inside 
1. Stop adding help commands in the fish completion code; `ensureHelp()` has already seen to this.

## Which issue(s) this PR fixes:

None. I can make one if it helps. This is in preparation for #2120.

## Special notes for your reviewer:

For full disclosure, I probably do not know enough about urfave/cli to say conclusively that there is no way you can "skip" a level such that a deeper sub-command could show up without being preceded by its parent?

## Testing

Current main (53ad542) will give this result when `more-awesome` has `Hidden: true` before 2. above is addressed.

```go
$ mycli more-awesome -- <tab>
--global-opt  --help  (show help)  --version  (print the version)
```

## Release Notes

```release-note
Remove superfluous parts from fish completions.
```
For less confusion, I'll save the bits about hidden command completion for the next PR.