### PR TITLE
fix: off-by-one in timestamp parsing

### DIFF
--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -86,7 +86,7 @@ func (t *timestampValue) Set(value string) error {
 
 	defaultTS, _ := time.ParseInLocation(time.TimeOnly, time.TimeOnly, timestamp.Location())
 
-	n := time.Now()
+	n := time.Now().In(timestamp.Location())
 
 	// If format is missing date (or year only), set it explicitly to current
 	if timestamp.Truncate(time.Hour*24).UnixNano() == defaultTS.Truncate(time.Hour*24).UnixNano() {


### PR DESCRIPTION
Timestamps without dates would infer the correct date based on the local time. This can lead to bugs where the current local date is different than the date in the timezone of the original value. Fix this by using time.Now().In() to adjust the timezone.

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

* Update timestamp flags to respect the timezone of the original value when inferring missing dates/years.

## Which issue(s) this PR fixes:

None.

## Special notes for your reviewer:

None in particular.

## Testing

Tested with minimal reproduction:

```go
func main() {
	x := &cli.Command{
		Flags: []cli.Flag{
			&cli.TimestampFlag{
				Name: "time",
				Config: cli.TimestampConfig{
					Layouts: []string{
						"15:04Z07:00",
					},
				},
			},
		},
		Action: func(ctx context.Context, c *cli.Command) error {
			y := c.Timestamp("time")
			fmt.Println(y)
			return nil
		},
	}

	x.Run(context.Background(), os.Args)
}
```

Without fix, running on May 9 6:00 PM UTC-7. Note the date is incorrectly set to the 9th:

```bash
$ go run . --time "10:30+00:00"
2025-05-09 10:30:00 +0000 UTC
$ date
Fri May  9 06:26:09 PM PDT 2025
```

With fix:

```bash
$ go run . --time "10:30+00:00"
2025-05-10 10:30:00 +0000 UTC
$ date
Fri May  9 06:26:56 PM PDT 2025
```

This can also be observed when running the unit tests of this repository:
```
        	Error:      	Not equal: 
        	            	expected: time.Date(2025, time.May, 10, 0, 33, 0, 0, time.UTC)
        	            	actual  : time.Date(2025, time.May, 9, 0, 33, 0, 0, time.UTC)
```
## Release Notes

```release-note
Fix an issue where timestamp values without dates failed to respect timezones.
```
