### PR TITLE
Fix:(issue_2135) Correct formatting of default subcommand USAGE text

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -2174,7 +2174,7 @@ func TestCommand_Run_SubcommandFullPath(t *testing.T) {
 
 	outString := out.String()
 	require.Contains(t, outString, "foo bar - does bar things")
-	require.Contains(t, outString, "foo bar [command [command options]] [arguments...]")
+	require.Contains(t, outString, "foo bar [options] [arguments...]")
 }
 
 func TestCommand_Run_Help(t *testing.T) {

--- a/examples_test.go
+++ b/examples_test.go
@@ -232,7 +232,7 @@ func ExampleCommand_Run_subcommandNoAction() {
 	//    greet describeit - use it to see a description
 	//
 	// USAGE:
-	//    greet describeit [command [command options]] [arguments...]
+	//    greet describeit [options] [arguments...]
 	//
 	// DESCRIPTION:
 	//    This is how we describe describeit the function

--- a/help_test.go
+++ b/help_test.go
@@ -713,7 +713,7 @@ func TestShowSubcommandHelp_GlobalOptions(t *testing.T) {
    foo frobbly
 
 USAGE:
-   foo frobbly [command [command options]]
+   foo frobbly [options]
 
 OPTIONS:
    --bar string  

--- a/template.go
+++ b/template.go
@@ -3,7 +3,7 @@ package cli
 var (
 	helpNameTemplate    = `{{$v := offset .FullName 6}}{{wrap .FullName 3}}{{if .Usage}} - {{wrap .Usage $v}}{{end}}`
 	argsTemplate        = `{{if .Arguments}}{{range .Arguments}}{{.Usage}}{{end}}{{end}}`
-	usageTemplate       = `{{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleFlags}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} {{template "argsTemplate" .}}{{end}}{{end}}{{end}}`
+	usageTemplate       = `{{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleFlags}} [options]{{end}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} {{template "argsTemplate" .}}{{end}}{{end}}{{end}}`
 	descriptionTemplate = `{{wrap .Description 3}}`
 	authorsTemplate     = `{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
    {{range $index, $author := .Authors}}{{if $index}}


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug
## What this PR does / why we need it:

template.go [usageTemplate](https://github.com/urfave/cli/blob/897feda2291c9c345b2a1378fd7faeac57c6e4cd/template.go#L6) omits the `.VisibleCommands` function, causing improper formatting of help menu default USAGE text on subcommands

## Which issue(s) this PR fixes:

Fixes [issue #2135](https://github.com/urfave/cli/issues/2135)

## Release Notes

```release-note
Correct formatting of default subcommand USAGE text
```
