### PR TITLE
Export help display functions as variables to allow custom help display logic

### DIFF
--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -131,6 +131,15 @@ COPYRIGHT:
     cli.go uses text/template to render templates. You can render custom help
     text by setting this variable.
 
+var ShowAppHelp = showAppHelp
+    ShowAppHelp is an action that displays the help
+
+var ShowCommandHelp = showCommandHelp
+    ShowCommandHelp prints help for the given command
+
+var ShowSubcommandHelp = showSubcommandHelp
+    ShowSubcommandHelp prints help for the given subcommand
+
 var SubcommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
@@ -195,21 +204,12 @@ func HandleExitCoder(err error)
 
     This function is the default error-handling behavior for an App.
 
-func ShowAppHelp(cmd *Command) error
-    ShowAppHelp is an action that displays the help.
-
 func ShowAppHelpAndExit(cmd *Command, exitCode int)
     ShowAppHelpAndExit - Prints the list of subcommands for the app and exits
     with exit code.
 
-func ShowCommandHelp(ctx context.Context, cmd *Command, commandName string) error
-    ShowCommandHelp prints help for the given command
-
 func ShowCommandHelpAndExit(ctx context.Context, cmd *Command, command string, code int)
     ShowCommandHelpAndExit - exits with code after showing help
-
-func ShowSubcommandHelp(cmd *Command) error
-    ShowSubcommandHelp prints help for the given subcommand
 
 func ShowSubcommandHelpAndExit(cmd *Command, exitCode int)
     ShowSubcommandHelpAndExit - Prints help for the given subcommand and exits

--- a/help.go
+++ b/help.go
@@ -44,6 +44,15 @@ var HelpPrinterCustom helpPrinterCustom = printHelpCustom
 // VersionPrinter prints the version for the App
 var VersionPrinter = printVersion
 
+// ShowAppHelp is an action that displays the help
+var ShowAppHelp = showAppHelp
+
+// ShowCommandHelp prints help for the given command
+var ShowCommandHelp = showCommandHelp
+
+// ShowSubcommandHelp prints help for the given subcommand
+var ShowSubcommandHelp = showSubcommandHelp
+
 func buildHelpCommand(withAction bool) *Command {
 	cmd := &Command{
 		Name:      helpName,
@@ -131,7 +140,7 @@ func ShowAppHelpAndExit(cmd *Command, exitCode int) {
 }
 
 // ShowAppHelp is an action that displays the help.
-func ShowAppHelp(cmd *Command) error {
+func showAppHelp(cmd *Command) error {
 	tmpl := cmd.CustomRootCommandHelpTemplate
 	if tmpl == "" {
 		tracef("using RootCommandHelpTemplate")
@@ -270,8 +279,7 @@ func ShowCommandHelpAndExit(ctx context.Context, cmd *Command, command string, c
 	os.Exit(code)
 }
 
-// ShowCommandHelp prints help for the given command
-func ShowCommandHelp(ctx context.Context, cmd *Command, commandName string) error {
+func showCommandHelp(ctx context.Context, cmd *Command, commandName string) error {
 	for _, subCmd := range cmd.Commands {
 		if !subCmd.HasName(commandName) {
 			continue
@@ -322,8 +330,7 @@ func ShowSubcommandHelpAndExit(cmd *Command, exitCode int) {
 	os.Exit(exitCode)
 }
 
-// ShowSubcommandHelp prints help for the given subcommand
-func ShowSubcommandHelp(cmd *Command) error {
+func showSubcommandHelp(cmd *Command) error {
 	HelpPrinter(cmd.Root().Writer, SubcommandHelpTemplate, cmd)
 	return nil
 }

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -131,6 +131,15 @@ COPYRIGHT:
     cli.go uses text/template to render templates. You can render custom help
     text by setting this variable.
 
+var ShowAppHelp = showAppHelp
+    ShowAppHelp is an action that displays the help
+
+var ShowCommandHelp = showCommandHelp
+    ShowCommandHelp prints help for the given command
+
+var ShowSubcommandHelp = showSubcommandHelp
+    ShowSubcommandHelp prints help for the given subcommand
+
 var SubcommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
@@ -195,21 +204,12 @@ func HandleExitCoder(err error)
 
     This function is the default error-handling behavior for an App.
 
-func ShowAppHelp(cmd *Command) error
-    ShowAppHelp is an action that displays the help.
-
 func ShowAppHelpAndExit(cmd *Command, exitCode int)
     ShowAppHelpAndExit - Prints the list of subcommands for the app and exits
     with exit code.
 
-func ShowCommandHelp(ctx context.Context, cmd *Command, commandName string) error
-    ShowCommandHelp prints help for the given command
-
 func ShowCommandHelpAndExit(ctx context.Context, cmd *Command, command string, code int)
     ShowCommandHelpAndExit - exits with code after showing help
-
-func ShowSubcommandHelp(cmd *Command) error
-    ShowSubcommandHelp prints help for the given subcommand
 
 func ShowSubcommandHelpAndExit(cmd *Command, exitCode int)
     ShowSubcommandHelpAndExit - Prints help for the given subcommand and exits


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

- Exported `ShowAppHelp`, `ShowCommandHelp`, and `ShowSubcommandHelp` as variables assigned to private functions.

- This allows users to override the help display logic for the app and commands, improving extensibility and flexibility for custom help behaviors.

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Exported `ShowAppHelp`, `ShowCommandHelp`, and `ShowSubcommandHelp` as variables assigned to private functions, allowing users to override help display logic for custom behaviors.
```
