### PR TITLE
fix: add missing `IsLocal` for BoolWithInverseFlag

### DIFF
--- a/flag_bool_with_inverse.go
+++ b/flag_bool_with_inverse.go
@@ -55,6 +55,10 @@ func (bif *BoolWithInverseFlag) RunAction(ctx context.Context, cmd *Command) err
 	return nil
 }
 
+func (bif *BoolWithInverseFlag) IsLocal() bool {
+	return bif.Local
+}
+
 func (bif *BoolWithInverseFlag) inversePrefix() string {
 	if bif.InversePrefix == "" {
 		bif.InversePrefix = DefaultInverseBoolPrefix

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -367,6 +367,8 @@ func (bif *BoolWithInverseFlag) IsBoolFlag() bool
 func (bif *BoolWithInverseFlag) IsDefaultVisible() bool
     IsDefaultVisible returns true if the flag is not hidden, otherwise false
 
+func (bif *BoolWithInverseFlag) IsLocal() bool
+
 func (bif *BoolWithInverseFlag) IsRequired() bool
 
 func (bif *BoolWithInverseFlag) IsSet() bool

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -367,6 +367,8 @@ func (bif *BoolWithInverseFlag) IsBoolFlag() bool
 func (bif *BoolWithInverseFlag) IsDefaultVisible() bool
     IsDefaultVisible returns true if the flag is not hidden, otherwise false
 
+func (bif *BoolWithInverseFlag) IsLocal() bool
+
 func (bif *BoolWithInverseFlag) IsRequired() bool
 
 func (bif *BoolWithInverseFlag) IsSet() bool


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Add missing `IsLocal` method for `BoolWithInverseFlag`.