### PR TITLE
Fix OnUsageError Trigger When Error Is Caused by Mutually Exclusive Flags

### DIFF
--- a/command_run.go
+++ b/command_run.go
@@ -223,7 +223,11 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 
 	for _, grp := range cmd.MutuallyExclusiveFlags {
 		if err := grp.check(cmd); err != nil {
-			_ = ShowSubcommandHelp(cmd)
+			if cmd.OnUsageError != nil {
+				err = cmd.OnUsageError(ctx, cmd, err, cmd.parent != nil)
+			} else {
+				_ = ShowSubcommandHelp(cmd)
+			}
 			return ctx, err
 		}
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -5169,28 +5169,20 @@ func TestJSONExportCommand(t *testing.T) {
 }
 
 func TestCommand_ExclusiveFlags(t *testing.T) {
-	var (
-		foo1 = &StringFlag{
-			Name: "foo1",
-		}
-		foo2 = &StringFlag{
-			Name: "foo2",
-		}
-	)
 	cmd := &Command{
 		Name: "bar",
-		Flags: []Flag{
-			foo1,
-			foo2,
-		},
 		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
 			{
 				Flags: [][]Flag{
 					{
-						foo1,
+						&StringFlag{
+							Name: "foo1",
+						},
 					},
 					{
-						foo2,
+						&StringFlag{
+							Name: "foo2",
+						},
 					},
 				},
 			},
@@ -5203,28 +5195,20 @@ func TestCommand_ExclusiveFlags(t *testing.T) {
 }
 
 func TestCommand_ExclusiveFlagsWithOnUsageError(t *testing.T) {
-	var (
-		foo1 = &StringFlag{
-			Name: "foo1",
-		}
-		foo2 = &StringFlag{
-			Name: "foo2",
-		}
-	)
 	cmd := &Command{
 		Name: "bar",
-		Flags: []Flag{
-			foo1,
-			foo2,
-		},
 		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
 			{
 				Flags: [][]Flag{
 					{
-						foo1,
+						&StringFlag{
+							Name: "foo1",
+						},
 					},
 					{
-						foo2,
+						&StringFlag{
+							Name: "foo2",
+						},
 					},
 				},
 			},

--- a/command_test.go
+++ b/command_test.go
@@ -5195,6 +5195,7 @@ func TestCommand_ExclusiveFlags(t *testing.T) {
 }
 
 func TestCommand_ExclusiveFlagsWithOnUsageError(t *testing.T) {
+	expectedErr := errors.New("my custom error")
 	cmd := &Command{
 		Name: "bar",
 		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
@@ -5214,13 +5215,13 @@ func TestCommand_ExclusiveFlagsWithOnUsageError(t *testing.T) {
 			},
 		},
 		OnUsageError: func(_ context.Context, _ *Command, _ error, _ bool) error {
-			return errors.New("my custom error")
+			return expectedErr
 		},
 	}
 
-	err := cmd.Run(buildTestContext(t), []string{"bar", "--foo1", "v1", "--foo2", "v2"})
+	actualErr := cmd.Run(buildTestContext(t), []string{"bar", "--foo1", "v1", "--foo2", "v2"})
 
-	require.Equal(t, "my custom error", err.Error())
+	require.ErrorIs(t, actualErr, expectedErr)
 }
 
 func TestCommand_ExclusiveFlagsWithAfter(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?
- bug

## What this PR does / why we need it:
The `OnUsageError` function is not triggered when mutually exclusive flags are provided. This PR fixes the issue by ensuring `OnUsageError` is properly called in that case.

## Which issue(s) this PR fixes:
Fixes #2146 

## Special notes for your reviewer:
Could not think of other cases. Let me know if it makes sense for more coverage.

## Release Notes
- Fixes an issue where mutually exclusive flags did not trigger the `OnUsageError` handler.
