### PR TITLE
Remove "alpha" wording around `v3` series

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,8 +20,7 @@ milestones and import paths to which they correspond are:
 
 <https://github.com/urfave/cli/tree/main>
 
-The majority of active development and issue management is targeting the `main` branch,
-which is currently in *alpha*.
+The majority of active development and issue management is targeting the `main` branch.
 
 - :arrow_right: [`v3.x`](https://github.com/urfave/cli/milestone/5)
 - :arrow_right: `github.com/urfave/cli/v3`
@@ -29,11 +28,13 @@ which is currently in *alpha*.
 The `main` branch includes tooling to help with keeping track of `v3.x` series backward
 compatibility. More details on this process are in the development workflow section below.
 
-#### `v1` branch
+#### `v1-maint` branch
 
-<https://github.com/urfave/cli/tree/v1>
+<https://github.com/urfave/cli/tree/v1-maint>
 
-The `v1` branch is no longer maintained.
+The `v1-maint` branch **MUST** only receive bug fixes in the `v1.22.x` series. There is no
+strict rule regarding bug fixes to the `v3.x` or `v2.23.x` series being backported to the
+`v1.22.x` series.
 
 - :arrow_right: [`v1.22.x`](https://github.com/urfave/cli/milestone/11)
 - :arrow_right: `github.com/urfave/cli`

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,23 @@ Using this package requires a working Go environment. [See the install instructi
 
 Go Modules are required when using this package. [See the go blog guide on using Go Modules](https://blog.golang.org/using-go-modules).
 
+### Using `v3` releases
+
+The latest `v3` release may be installed via the `/v3` suffix. The state of the [`main`
+branch](https://github.com/urfave/cli/tree/main) at any given time may correspond to a
+`v3` series release or pre-release.  Please see the [`v3` migration
+guide](./migrate-v2-to-v3.md) on using v3 if you are upgrading from v2.
+
+```sh
+go get github.com/urfave/cli/v3@latest
+```
+
+```go
+import (
+  "github.com/urfave/cli/v3" // imports as package "cli"
+)
+```
+
 ### Using `v2` releases
 
 The `v2` series is the recommended version for new development. Ongoing
@@ -58,25 +75,6 @@ go get github.com/urfave/cli/v2@latest
 ```go
 import (
   "github.com/urfave/cli/v2" // imports as package "cli"
-)
-```
-
-### Using **alpha-level** `v3` releases
-
-The latest pre-release in progress on the [`main`
-branch](https://github.com/urfave/cli/tree/main) is the `v3` series which should
-be considered **alpha-level** with an unstable API. Occasional **alpha** tags
-are pushed to allow for limited stability without pinning to an arbitrary
-commit. Please see the [`v3` migration
-guide](./migrate-v2-to-v3.md) on using v3 if you are upgrading from v2
-
-```sh
-go get github.com/urfave/cli/v3@latest
-```
-
-```go
-import (
-  "github.com/urfave/cli/v3" // imports as package "cli"
 )
 ```
 


### PR DESCRIPTION


<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- cleanup
- documentation

## What this PR does / why we need it:

This removes the "alpha" wording around the `v3` series since we are now currently up to `v3.3.3`.