### PR TITLE
Invoke OnUsageError when missing required flags

### DIFF
--- a/command_run.go
+++ b/command_run.go
@@ -314,7 +314,11 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 
 	if err := cmd.checkAllRequiredFlags(); err != nil {
 		cmd.isInError = true
-		_ = ShowSubcommandHelp(cmd)
+		if cmd.OnUsageError != nil {
+			err = cmd.OnUsageError(ctx, cmd, err, cmd.parent != nil)
+		} else {
+			_ = ShowSubcommandHelp(cmd)
+		}
 		return ctx, err
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

This PR aims to fix the issue noted in https://github.com/urfave/cli/issues/2145
* `command_run.go` - `func (cmd *Command) run` has been modified to run the
`OnUsageError` function when the `checkAllRequiredFlags` check fails.


## Which issue(s) this PR fixes:

Fixed #2145 

