### PR TITLE
Fix/custom help for subcommand

### DIFF
--- a/help.go
+++ b/help.go
@@ -324,7 +324,11 @@ func ShowSubcommandHelpAndExit(cmd *Command, exitCode int) {
 
 // ShowSubcommandHelp prints help for the given subcommand
 func ShowSubcommandHelp(cmd *Command) error {
-	HelpPrinter(cmd.Root().Writer, SubcommandHelpTemplate, cmd)
+	tmpl := cmd.CustomHelpTemplate
+	if tmpl == "" {
+		tmpl = SubcommandHelpTemplate
+	}
+	HelpPrinter(cmd.Root().Writer, tmpl, cmd)
 	return nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The custom help template was not getting used in subcommand help. This is called when using `HideHelpCommand`. Updated `ShowSubcommand` to use the custom template.

It's possible a minor refactor in the help display cases is needed here, but this change fixes our immediate problem.

## Which issue(s) this PR fixes:

No known issue, just discovered locally.

## Special notes for your reviewer:

None.

## Testing

Test case for the bug added.

## Release Notes

```release-note
fix: use the custom help template in a subcommand when in HideHelpCommand is active
```
