### PR TITLE
Fix:(issue_2169) Allow trim space for string slice flags

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -4311,6 +4311,9 @@ func TestCommandReadArgsFromStdIn(t *testing.T) {
 				},
 				&StringSliceFlag{
 					Name: "ssf",
+					Config: StringConfig{
+						TrimSpace: true,
+					},
 				},
 			}
 

--- a/flag_slice_base.go
+++ b/flag_slice_base.go
@@ -47,8 +47,21 @@ func (i *SliceBase[T, C, VC]) Set(value string) error {
 		return nil
 	}
 
+	trimSpace := true
+	// hack. How do we know if we should trim spaces?
+	// it makes sense only for string slice flags which have
+	// an option to not trim spaces. So by default we trim spaces
+	// otherwise we let the underlying value type handle it.
+	var t T
+	if reflect.TypeOf(t).Kind() == reflect.String {
+		trimSpace = false
+	}
+
 	for _, s := range flagSplitMultiValues(value) {
-		if err := i.value.Set(strings.TrimSpace(s)); err != nil {
+		if trimSpace {
+			s = strings.TrimSpace(s)
+		}
+		if err := i.value.Set(s); err != nil {
 			return err
 		}
 		*i.slice = append(*i.slice, i.value.Get().(T))

--- a/flag_test.go
+++ b/flag_test.go
@@ -350,6 +350,12 @@ func TestFlagsFromEnv(t *testing.T) {
 			output: []string{"foo", "bar"},
 			fl:     &StringSliceFlag{Name: "names", Sources: EnvVars("NAMES"), Config: StringConfig{TrimSpace: true}},
 		},
+		{
+			name:   "StringSliceFlag valid without TrimSpace",
+			input:  "foo , bar ",
+			output: []string{"foo ", " bar "},
+			fl:     &StringSliceFlag{Name: "names", Sources: EnvVars("NAMES")},
+		},
 
 		{
 			name:   "StringMapFlag valid",


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

Fixes #2169 

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

Update the string slice test in flag_test to have a case which has trim space off by default. 

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
StringSlice flags now honour the TrimSpace in StringConfig
```
