### PR TITLE
fix: zsh autocompletions

### DIFF
--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -9,7 +9,7 @@ _%[1]s() {
 	current=${words[-1]} # -1 means "the last element"
 	if [[ "$current" == "-"* ]]; then
 		# Current word starts with a hyphen, so complete flags/options
-		opts=("${(@f)$(${words[@]:0:#words[@]-1} ${current} --generate-shell-completion)}")
+		opts=("${(@f)$(${words[@]:0:#words[@]-1} - --generate-shell-completion)}")
 	else
 		# Current word does not start with a hyphen, so complete subcommands
 		opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-shell-completion)}")


### PR DESCRIPTION
Actually auto-complete.

For some reason, the auto-completion wasn't working for me. Running `<prog> -- --generate-shell-completion` just ran the command, and did not provide the correct results. The reason that was happening (if I had to guess) is because `--` is being treated as an end of flags. As such, the literal string `--generate-shell-completion` was being passed to the underlying program.

## What type of PR is this?

- bug

## What this PR does / why we need it:

Current completions do not work for ZSH. I spent 3 hours trying to figure out what it was.

## Which issue(s) this PR fixes:

N/A

## Release Notes

```release-note
fix: zsh autocompletions
```
