### PR TITLE
Add installation instructions for gfmrun

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,7 +66,7 @@ verify one's changes are harmonious in nature. The same steps are also run durin
 [continuous integration
 phase](https://github.com/urfave/cli/blob/main/.github/workflows/test.yml).
 
-`gfmrun` is required to run the examples, and without it `make all` may fail.
+`gfmrun` is required to run the examples, and without it `make all` will fail.
 
 You can find `gfmrun` here:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,6 +66,18 @@ verify one's changes are harmonious in nature. The same steps are also run durin
 [continuous integration
 phase](https://github.com/urfave/cli/blob/main/.github/workflows/test.yml).
 
+`gfmrun` is required to run the examples, and without it `make all` may fail.
+
+You can find `gfmrun` here:
+
+- [urfave/gfmrun](https://github.com/urfave/gfmrun)
+
+To install `gfmrun`, you can use `go install`:
+
+```
+go install github.com/urfave/gfmrun/cmd/gfmrun@latest
+```
+
 In the event that the `v3diff` target exits non-zero, this is a signal that the public API
 surface area has changed. If the changes are acceptable, then manually running the
 approval step will "promote" the current `go doc` output:


### PR DESCRIPTION
## What type of PR is this?

- Documentation

## What this PR does / why we need it:

Contributor docs did not include that `gfmrun` is a dependency for running `make all`. The PR adds a few lines with instructions on doing that.

## Special notes for your reviewer:

This is my first PR for this repo. Any suggestions - or a correction if I'm off base here - would be helpful.

## Testing

On a machine that does not have`gfmrun`, run:

```
git clone https://github.com/urfave/cli.git
```

Run

```
make
```

Final steps should fail.

Now run installation described in PR:

```
go install github.com/urfave/gfmrun/cmd/gfmrun@latest
```

Re-run 

```
make
```

Final steps should pass.

## Release Notes

```release-note
NONE
```
