### PR TITLE
Add example of flag groups to docs

### DIFF
--- a/docs/v3/examples/flags/advanced.md
+++ b/docs/v3/examples/flags/advanced.md
@@ -334,6 +334,107 @@ If the command is run without the `lang` flag, the user will see the following m
 Required flag "lang" not set
 ```
 
+#### Flag Groups
+
+You can make groups of flags that are mutually exclusive of each other.
+This provides the ability to provide configuration options out of which
+only one can be defined on the command line.
+
+Take for example this app that looks up a user using one of multiple options:
+
+<!-- {
+  "error": "one of these flags needs to be provided: login, id"
+} -->
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+func main() {
+	cmd := &cli.Command{
+		Name: "authors",
+		MutuallyExclusiveFlags: []cli.MutuallyExclusiveFlags{
+			{
+				Required: true,
+				Flags: [][]cli.Flag{
+					{
+						&cli.StringFlag{
+							Name:  "login",
+							Usage: "the username of the user",
+						},
+					},
+					{
+						&cli.StringFlag{
+							Name:  "id",
+							Usage: "the user id (defaults to 'me' for current user)",
+						},
+					},
+				},
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			u, err := getUser(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			data, err := json.Marshal(u)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(data))
+			return nil
+		},
+	}
+
+	if err := cmd.Run(context.Background(), os.Args); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type User struct {
+	Id        string `json:"id"`
+	Login     string `json:"login"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+}
+
+// Mock function that returns a static user value.
+// Would retrieve a user from an API or database with other functions.
+func getUser(ctx context.Context, cmd *cli.Command) (User, error) {
+	u := User{
+		Id:        "abc123",
+		Login:     "vwoolf@example.com",
+		FirstName: "Virginia",
+		LastName:  "Woolf",
+	}
+	if login := cmd.String("login"); login != "" {
+		fmt.Printf("Getting user by login: %s\n", login)
+		u.Login = login
+	}
+	if id := cmd.String("id"); id != "" {
+		fmt.Printf("Getting user by id: %s\n", id)
+		u.Id = id
+	}
+	return u, nil
+}
+```
+
+If the command is run without either the `login` or `id` flag, the user will
+see the following message
+
+```
+one of these flags needs to be provided: login, id
+```
+
+
 #### Default Values for help output
 
 Sometimes it's useful to specify a flag's default help-text value within the


### PR DESCRIPTION
## What type of PR is this?

- Documentation

## What this PR does / why we need it:

The documentation was missing a section on Flag Groups.


## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

I have an additional proposal for a feature based on behavior that I found while building the example for this that I would like to talk about.

## Testing

Save the example to a file called `main.go`.

Run:
```
go run main.go
```

Want the following, mod the date:
```
NAME:
   authors - A new cli application

USAGE:
   authors

OPTIONS:
   --help, -h      show help
   --login string  the username of the user
   --id string     the user id (defaults to 'me' for current user)
2025/08/08 23:09:13 one of these flags needs to be provided: login, id
```

---

Run:
```
go run main.go --id 987zyx
```

Want:

```
Getting user by id: 987zyx
{"id":"987zyx","login":"vwoolf@example.com","firstName":"Virginia","lastName":"Woolf"}
```

---

Run:
```
go run main.go --login example@example.com
```

Want:

```
Getting user by login: example@example.com
{"id":"abc123","login":"example@example.com","firstName":"Virginia","lastName":"Woolf"}
```

## Release Notes

```release-note
Documentation additions on flag groups
```
