### PR TITLE
add space between arguments usage

### DIFF
--- a/template.go
+++ b/template.go
@@ -2,7 +2,7 @@ package cli
 
 var (
 	helpNameTemplate    = `{{$v := offset .FullName 6}}{{wrap .FullName 3}}{{if .Usage}} - {{wrap .Usage $v}}{{end}}`
-	argsTemplate        = `{{if .Arguments}}{{range .Arguments}}{{.Usage}}{{end}}{{end}}`
+	argsTemplate        = `{{if .Arguments}}{{range .Arguments}}{{.Usage}} {{end}}{{end}}`
 	usageTemplate       = `{{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleFlags}} [options]{{end}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} {{template "argsTemplate" .}}{{end}}{{end}}{{end}}`
 	descriptionTemplate = `{{wrap .Description 3}}`
 	authorsTemplate     = `{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

This PR fixes a minor formatting issue in the CLI usage template where multiple arguments are displayed without spaces between them.

Previously, when defining command arguments like:
```go
Commands: []*cli.Command{
	{
		Name:    "foobar",
		Usage:   "foo bar",
		Arguments: []cli.Argument{
			&cli.StringArg{
				Name:      "foo",
				UsageText: "[foo]",
			},
			&cli.StringArg{
				Name:      "bar",
				UsageText: "[bar]",
			},
		},
		Action: ...,
	},
}
```
the generated help output for foobar would look like:

```bash                                                                                                                                                                                                                      
USAGE:                                                                                                                                                                                                                                     
   app foobar [options] [foo][bar]   
```

after:

```bash
USAGE:
   app foobar [options] [foo] [bar]
```

## Which issue(s) this PR fixes:

None.
