### PR TITLE
Fix: Make DefaultText behaviour consistent

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -107,9 +107,12 @@ func stringifyFlag(f Flag) string {
 
 	// don't print default text for required flags
 	if rf, ok := f.(RequiredFlag); !ok || !rf.IsRequired() {
-		isVisible := df.IsDefaultVisible()
-		if s := df.GetDefaultText(); isVisible && s != "" {
-			defaultValueString = fmt.Sprintf(formatDefault("%s"), s)
+		if df.IsDefaultVisible() {
+			if s := df.GetDefaultText(); s != "" {
+				defaultValueString = fmt.Sprintf(formatDefault("%s"), s)
+			} else if df.TakesValue() && df.GetValue() != "" {
+				defaultValueString = fmt.Sprintf(formatDefault("%s"), df.GetValue())
+			}
 		}
 	}
 

--- a/flag_impl.go
+++ b/flag_impl.go
@@ -70,10 +70,8 @@ type FlagBase[T any, C any, VC ValueCreator[T, C]] struct {
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *FlagBase[T, C, V]) GetValue() string {
-	if !f.TakesValue() {
-		return ""
-	}
-	return fmt.Sprintf("%v", f.Value)
+	var v V
+	return v.ToString(f.Value)
 }
 
 // TypeName returns the type of the flag.
@@ -253,11 +251,7 @@ func (f *FlagBase[T, C, V]) TakesValue() bool {
 
 // GetDefaultText returns the default text for this flag
 func (f *FlagBase[T, C, V]) GetDefaultText() string {
-	if f.DefaultText != "" {
-		return f.DefaultText
-	}
-	var v V
-	return v.ToString(f.Value)
+	return f.DefaultText
 }
 
 // RunAction executes flag action if set

--- a/flag_test.go
+++ b/flag_test.go
@@ -44,8 +44,8 @@ var boolFlagTests = []struct {
 	name     string
 	expected string
 }{
-	{"help", "--help\t(default: false)"},
-	{"h", "-h\t(default: false)"},
+	{"help", "--help\t"},
+	{"h", "-h\t"},
 }
 
 func TestBoolFlagHelpOutput(t *testing.T) {
@@ -470,7 +470,7 @@ func TestFlagStringifying(t *testing.T) {
 		{
 			name:     "bool-flag",
 			fl:       &BoolFlag{Name: "vividly"},
-			expected: "--vividly\t(default: false)",
+			expected: "--vividly\t",
 		},
 		{
 			name:     "bool-flag-with-default-text",
@@ -2771,7 +2771,7 @@ func TestFlagDefaultValue(t *testing.T) {
 			name:    "bool",
 			flag:    &BoolFlag{Name: "flag", Value: true},
 			toParse: []string{"--flag=false"},
-			expect:  `--flag	(default: true)`,
+			expect:  `--flag	`,
 		},
 		{
 			name:    "uint",
@@ -2866,7 +2866,7 @@ func TestFlagDefaultValueWithEnv(t *testing.T) {
 			name:    "bool",
 			flag:    &BoolFlag{Name: "flag", Value: true, Sources: EnvVars("uflag")},
 			toParse: []string{"--flag=false"},
-			expect:  `--flag	(default: true)` + withEnvHint([]string{"uflag"}, ""),
+			expect:  `--flag	` + withEnvHint([]string{"uflag"}, ""),
 			environ: map[string]string{
 				"uflag": "false",
 			},
@@ -3359,9 +3359,9 @@ func TestEnvHintWindows(t *testing.T) {
 }
 
 func TestDocGetValue(t *testing.T) {
-	assert.Equal(t, "", (&BoolFlag{Name: "foo", Value: true}).GetValue())
-	assert.Equal(t, "", (&BoolFlag{Name: "foo", Value: false}).GetValue())
-	assert.Equal(t, "bar", (&StringFlag{Name: "foo", Value: "bar"}).GetValue())
+	assert.Equal(t, "true", (&BoolFlag{Name: "foo", Value: true}).GetValue())
+	assert.Equal(t, "false", (&BoolFlag{Name: "foo", Value: false}).GetValue())
+	assert.Equal(t, "\"bar\"", (&StringFlag{Name: "foo", Value: "bar"}).GetValue())
 	assert.Equal(t, "", (&BoolWithInverseFlag{Name: "foo", Value: false}).GetValue())
 }
 

--- a/help_test.go
+++ b/help_test.go
@@ -1479,8 +1479,7 @@ GLOBAL OPTIONS:
       really long help text
       line, let's see where it
       wraps. blah blah blah
-      and so on. (default:
-      false)
+      and so on.
 
 COPYRIGHT:
    Here's a sample copyright


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- cleanup

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
The behaviour of GetDefaultText was too unpredictable, depending on whether the DefaultText is set or whether Value is set and what not. This change takes the guesswork out of flag_impl.go and puts the logic into docs.go where it should be

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->
make test

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
flag.GetDefaultText returns the DefaultText set by the user without any modification
```
