### PR TITLE
Call actions on flags set from env

### DIFF
--- a/command_run.go
+++ b/command_run.go
@@ -207,8 +207,13 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 	}
 
 	for _, flag := range cmd.allFlags() {
+		isSet := flag.IsSet()
 		if err := flag.PostParse(); err != nil {
 			return ctx, err
+		}
+		// add env set flags here
+		if !isSet && flag.IsSet() {
+			cmd.setFlags[flag] = struct{}{}
 		}
 	}
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -1727,6 +1727,28 @@ func TestParseGenericFromEnv(t *testing.T) {
 	assert.NoError(t, cmd.Run(buildTestContext(t), []string{"run"}))
 }
 
+func TestFlagActionFromEnv(t *testing.T) {
+	t.Setenv("X", "42")
+	x := 0
+
+	cmd := &Command{
+		Flags: []Flag{
+			&IntFlag{
+				Name:    "x",
+				Sources: EnvVars("X"),
+				Action: func(ctx context.Context, cmd *Command, v int) error {
+					x = v
+					return nil
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, cmd.Run(buildTestContext(t), []string{"run"}))
+	assert.Equal(t, cmd.Int("x"), 42)
+	assert.Equal(t, x, 42)
+}
+
 func TestParseMultiString(t *testing.T) {
 	_ = (&Command{
 		Flags: []Flag{


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

Flag actions are invoked in [`cmd.runFlagActions`](https://github.com/urfave/cli/blob/46345bb3890625a76221e1d4ddc8d43aeb430b87/command.go#L585) which is called after the flag values have been set, whether by `-x val` or from other sources. This method ranges over `cmd.setFlags` which is a `map[Flag]struct{}`.

Currently `cmd.setFlags` is only populated with flags that are set via `-x val` etc. `cmd.setFlags` is unchanged when flag values are loaded from the env.

This PR checks if the flag was unset before `Flag.PostParse()`, but was set after `Flag.PostParse()` was called. If so, the flag is added to `cmd.setFlags` and it's `Action` (if present) is invoked.

## Which issue(s) this PR fixes:

Fixes #2041 
Fixes #2132

## Special notes for your reviewer:

@dearchap has raised some concerns over local vs non-local flag actions. I don't fully understand the context of those concerns so a sanity check of this PR would be appreciated. Note that in the regression test added in this PR `Local` makes no difference, the test fails before the changes whether `Local` is `true` or `false`.

## Testing

A regression test is provided.

## Release Notes

```release-note
Fix v3 regression where flag actions were no longer called for flags set from env vars.
```
