### PR TITLE
Docs: correct typo in migration guide

### DIFF
--- a/docs/migrate-v2-to-v3.md
+++ b/docs/migrate-v2-to-v3.md
@@ -394,7 +394,7 @@ Similar messages would be shown for other funcs.
     ```go
     &cli.StringFlag{
         Name:  "foo",
-        TakesFiles: true,
+        TakesFile: true,
     }
     ```
 


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

This PR correct typo for `PathFlag` in v2 to v3 migration guide.

## Which issue(s) this PR fixes:

N/A

## Release Notes

N/A

