### PR TITLE
Fix: use the correct type name in the tracef message

### DIFF
--- a/flag_duration.go
+++ b/flag_duration.go
@@ -45,6 +45,6 @@ func (cmd *Command) Duration(name string) time.Duration {
 		return v
 	}
 
-	tracef("bool NOT available for flag name %[1]q (cmd=%[2]q)", name, cmd.Name)
+	tracef("duration NOT available for flag name %[1]q (cmd=%[2]q)", name, cmd.Name)
 	return 0
 }


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

I noticed that the duration flag `tracef` log was logging "bool" instead of "duration".

## Which issue(s) this PR fixes:

None

## Release Notes

```release-note
NONE
```