### PR TITLE
Fix issue 2260: Try not to break custom Help cmds.

### DIFF
--- a/command_run.go
+++ b/command_run.go
@@ -141,7 +141,7 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 	var rargs Args = &stringSliceArgs{v: osArgs}
 	var args Args = &stringSliceArgs{rargs.Tail()}
 
-	if cmd.isCompletionCommand || cmd.Name == helpName {
+	if cmd.isCompletionCommand || isHelpCommand(cmd) {
 		tracef("special command detected, skipping pre-parse (cmd=%[1]q)", cmd.Name)
 		cmd.parsedArgs = args
 		return ctx, cmd.Action(ctx, cmd)
@@ -364,4 +364,23 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 
 	tracef("returning deferErr (cmd=%[1]q) %[2]q", cmd.Name, deferErr)
 	return ctx, deferErr
+}
+
+func isHelpCommand(cmd *Command) bool {
+	if cmd.Name != helpName {
+		return false
+	}
+	if len(cmd.Aliases) != 1 {
+		return false
+	}
+	if cmd.Aliases[0] != helpAlias {
+		return false
+	}
+	if cmd.Usage != UsageCommandHelp {
+		return false
+	}
+	if cmd.ArgsUsage != ArgsUsageCommandHelp {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Expand the check for the default help command to look at more than just the name.

## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes breakage in applications with custom Help commands.

## Which issue(s) this PR fixes:

Fixes #2260 

## Special notes for your reviewer:

This change is sort of a hacky kludge I used when bringing in the latest version to not break existing applications. I would be more than happy if the issue gets fixed some other way.

## Testing

I ran the equivalent change against tests for applications with custom Help commands.

## Release Notes

```release-note
Don't assume all commands named "help" are the default Help command.
```
