### PR TITLE
Fix: propagate MutuallyExclusiveFlags persistent flags to subcommands

### DIFF
--- a/command_parse.go
+++ b/command_parse.go
@@ -36,7 +36,7 @@ func (cmd *Command) parseFlags(args Args) (Args, error) {
 			pCmd.Name, cmd.Name,
 		)
 
-		for _, fl := range pCmd.Flags {
+		for _, fl := range pCmd.allFlags() {
 			flNames := fl.Names()
 
 			pfl, ok := fl.(LocalFlag)

--- a/command_test.go
+++ b/command_test.go
@@ -5417,3 +5417,40 @@ func TestCommand_ParallelRun(t *testing.T) {
 		})
 	}
 }
+
+func TestCommand_ExclusiveFlagsPersistentPropagation(t *testing.T) {
+	var subCmdAlphaValue string
+
+	cmd := &Command{
+		Name: "root",
+		MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
+			{
+				Flags: [][]Flag{
+					{
+						&StringFlag{
+							Name: "alpha",
+						},
+					},
+					{
+						&StringFlag{
+							Name: "beta",
+						},
+					},
+				},
+			},
+		},
+		Commands: []*Command{
+			{
+				Name: "sub",
+				Action: func(_ context.Context, cmd *Command) error {
+					subCmdAlphaValue = cmd.String("alpha")
+					return nil
+				},
+			},
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"root", "sub", "--alpha", "hello"})
+	require.NoError(t, err)
+	assert.Equal(t, "hello", subCmdAlphaValue)
+}

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -11,6 +11,6 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -9,6 +9,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli-altsrc/v3 v3.0.0-alpha2 h1:j4SaBpPB8++L0c0KuTnz/Yus3UQoWJ54hQjhIMW8rCM=
 github.com/urfave/cli-altsrc/v3 v3.0.0-alpha2/go.mod h1:Q79oyIY/z4jtzIrKEK6MUeWC7/szGr46x4QdOaOAIWc=
 github.com/urfave/cli-altsrc/v3 v3.0.1 h1:v+gHk59syLk8ao9rYybZs43+D5ut/gzj0omqQ1XYl8k=


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

- Fixes persistent flag propagation for flags defined in `MutuallyExclusiveFlags` groups
- Changed `pCmd.Flags` to `pCmd.allFlags()` in the persistent flag inheritance loop in `command_parse.go:39`, so that flags from `MutuallyExclusiveFlags` are included when walking the command lineage
- Added test `TestCommand_ExclusiveFlagsPersistentPropagation` to verify the fix

## Which issue(s) this PR fixes:

Fixes #2265

## Special notes for your reviewer:

`allFlags()` is already used on line 29 of the same function to populate `cmd.appliedFlags` for the current command. The ancestor loop on line 39 was the only place still using `pCmd.Flags` directly, which excluded `MutuallyExclusiveFlags` groups from propagation.

## Testing

- Added `TestCommand_ExclusiveFlagsPersistentPropagation` which creates a root command with a `MutuallyExclusiveFlags` group containing persistent string flags, then verifies a subcommand can receive the flag value
- All existing tests continue to pass

## Release Notes

```release-note
Fixed persistent flags defined in `MutuallyExclusiveFlags` not being propagated to subcommands
```
