### PR TITLE
flag: replace regexp use

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -17,11 +16,7 @@ const (
 	disableSliceFlagSeparator       = false
 )
 
-var (
-	slPfx = fmt.Sprintf("sl:::%d:::", time.Now().UTC().UnixNano())
-
-	commaWhitespace = regexp.MustCompile("[, ]+.*")
-)
+var slPfx = fmt.Sprintf("sl:::%d:::", time.Now().UTC().UnixNano())
 
 // GenerateShellCompletionFlag enables shell completion
 var GenerateShellCompletionFlag Flag = &BoolFlag{
@@ -202,7 +197,11 @@ func FlagNames(name string, aliases []string) []string {
 		// Strip off anything after the first found comma or space, which
 		// *hopefully* makes it a tiny bit more obvious that unexpected behavior is
 		// caused by using the v1 form of stringly typed "Name".
-		ret = append(ret, commaWhitespace.ReplaceAllString(part, ""))
+		if i := strings.IndexAny(part, ", "); i >= 0 {
+			ret = append(ret, part[:i])
+		} else {
+			ret = append(ret, part)
+		}
 	}
 
 	return ret


### PR DESCRIPTION

## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Commit ec05a8d3 introduces the only (non-test) user of regexp package.
It is pretty easy to not use regexp here, so let's get rid of it.

References:
 - https://github.com/opencontainers/runc/pull/5184#issuecomment-4100226858
 - https://github.com/opencontainers/runc/pull/3460

## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

None

## Testing

Assuming existing tests cover the change.

## Release Notes

```release-note
Remove regexp dependency.
```
