### PR TITLE
fix: apply SliceFlagSeparator to env var sources

### DIFF
--- a/command_run.go
+++ b/command_run.go
@@ -213,6 +213,7 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 	}
 
 	for _, flag := range cmd.allFlags() {
+		cmd.setMultiValueParsingConfig(flag)
 		isSet := flag.IsSet()
 		if err := flag.PostParse(); err != nil {
 			return ctx, err

--- a/command_test.go
+++ b/command_test.go
@@ -4590,6 +4590,24 @@ func TestCommandSliceFlagSeparator(t *testing.T) {
 	r.Equal([]string{"ff", "dd", "gg", "t,u"}, cmd.Value("foo"))
 }
 
+func TestCommandSliceFlagSeparatorFromEnvVar(t *testing.T) {
+	t.Setenv("APP_FOO", "0 1 2")
+
+	cmd := &Command{
+		SliceFlagSeparator: " ",
+		Flags: []Flag{
+			&StringSliceFlag{
+				Name:    "foo",
+				Sources: EnvVars("APP_FOO"),
+			},
+		},
+	}
+
+	r := require.New(t)
+	r.NoError(cmd.Run(buildTestContext(t), []string{"app"}))
+	r.Equal([]string{"0", "1", "2"}, cmd.Value("foo"))
+}
+
 func TestCommandMapKeyValueFlagSeparator(t *testing.T) {
 	cmd := &Command{
 		MapFlagKeyValueSeparator: ":",


### PR DESCRIPTION
## What type of PR is this?

- bug fix

## What this PR does / why we need it:

`SliceFlagSeparator` is ignored when a flag's value comes from an environment variable. The custom separator only works for CLI arguments.

**Root cause:** `setMultiValueParsingConfig` is called during CLI argument parsing (via `cmd.set`), but `PostParse`—which handles env var sources—never applies the separator config to the flag's underlying `SliceBase`. The value is parsed with the default comma separator instead.

**Fix:** Call `cmd.setMultiValueParsingConfig(flag)` in the `PostParse` loop before env var values are read, so `SliceBase` has the correct separator config.

Before:
```
A="0 1" go run main.go   # SliceFlagSeparator=" " → returns ["0 1"] (single element)
```

After:
```
A="0 1" go run main.go   # SliceFlagSeparator=" " → returns ["0", "1"]
```

## Which issue(s) this PR fixes:

Fixes #2262

## Validation:

- Added `TestCommandSliceFlagSeparatorFromEnvVar` — fails before the fix, passes after
- All existing tests pass (`go test ./...`, `go vet ./...`)