### PR TITLE
fix: don't print empty line to stderr when Exit message is empty

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -150,10 +150,12 @@ func HandleExitCoder(err error) {
 	}
 
 	if exitErr, ok := err.(ExitCoder); ok {
-		if _, ok := exitErr.(ErrorFormatter); ok {
-			_, _ = fmt.Fprintf(ErrWriter, "%+v\n", err)
-		} else {
-			_, _ = fmt.Fprintln(ErrWriter, err)
+		if msg := err.Error(); msg != "" {
+			if _, ok := exitErr.(ErrorFormatter); ok {
+				_, _ = fmt.Fprintf(ErrWriter, "%+v\n", err)
+			} else {
+				_, _ = fmt.Fprintln(ErrWriter, err)
+			}
 		}
 		OsExiter(exitErr.ExitCode())
 		return

--- a/errors_test.go
+++ b/errors_test.go
@@ -232,3 +232,29 @@ func TestErrRequiredFlags_Error(t *testing.T) {
 	expectedMsg = "Required flag \"flag1\" not set"
 	assert.Equal(t, expectedMsg, err.Error())
 }
+
+func TestHandleExitCoder_ExitCoderEmptyMessage(t *testing.T) {
+	exitCode := 0
+	called := false
+
+	OsExiter = func(rc int) {
+		if !called {
+			exitCode = rc
+			called = true
+		}
+	}
+
+	defer func() { OsExiter = fakeOsExiter }()
+
+	// Capture stderr output
+	savedErrWriter := ErrWriter
+	var errBuf bytes.Buffer
+	ErrWriter = &errBuf
+	defer func() { ErrWriter = savedErrWriter }()
+
+	HandleExitCoder(Exit("", 42))
+
+	assert.Equal(t, 42, exitCode)
+	assert.True(t, called)
+	assert.Empty(t, errBuf.String(), "expected no output to stderr for empty exit message")
+}


### PR DESCRIPTION
Fixes #2263

## Problem

`HandleExitCoder` unconditionally prints the error to `ErrWriter`, causing an empty line on stderr when `Exit("", code)` is used:

```go
cli.Exit("", exitError.ExitCode()) // prints "\n" to stderr
```

This was introduced in #2237.

## Fix

Check if the error message is non-empty before printing to `ErrWriter`. The exit code is still passed to `OsExiter` regardless.

## Test

Added `TestHandleExitCoder_ExitCoderEmptyMessage` to verify no output is written when the message is empty.