### PR TITLE
errors: don't print an empty line for Exit with empty message

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -150,10 +150,12 @@ func HandleExitCoder(err error) {
 	}
 
 	if exitErr, ok := err.(ExitCoder); ok {
-		if _, ok := exitErr.(ErrorFormatter); ok {
-			_, _ = fmt.Fprintf(ErrWriter, "%+v\n", err)
-		} else {
-			_, _ = fmt.Fprintln(ErrWriter, err)
+		if msg := err.Error(); msg != "" {
+			if _, ok := exitErr.(ErrorFormatter); ok {
+				_, _ = fmt.Fprintf(ErrWriter, "%+v\n", err)
+			} else {
+				_, _ = fmt.Fprintln(ErrWriter, err)
+			}
 		}
 		OsExiter(exitErr.ExitCode())
 		return

--- a/errors_test.go
+++ b/errors_test.go
@@ -257,3 +257,23 @@ func TestHandleExitCoder_EmptyMessage(t *testing.T) {
 	assert.True(t, called)
 	assert.Empty(t, ErrWriter.(*bytes.Buffer).String(), "expected no output for empty-message exit")
 }
+
+// TestHandleExitCoder_ErrorFormatterDirect verifies the ErrorFormatter branch
+// (Fprintf path) is exercised when the ExitCoder is passed to HandleExitCoder
+// directly with a non-empty message. Distinct from
+// TestHandleExitCoder_ErrorFormatter above which routes through a multiError.
+func TestHandleExitCoder_ErrorFormatterDirect(t *testing.T) {
+	called := false
+	OsExiter = func(rc int) { called = true }
+	ErrWriter = &bytes.Buffer{}
+
+	defer func() {
+		OsExiter = fakeOsExiter
+		ErrWriter = fakeErrWriter
+	}()
+
+	HandleExitCoder(&exitFormatter{code: 7})
+
+	assert.True(t, called)
+	assert.Contains(t, ErrWriter.(*bytes.Buffer).String(), "some other special")
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -232,3 +232,28 @@ func TestErrRequiredFlags_Error(t *testing.T) {
 	expectedMsg = "Required flag \"flag1\" not set"
 	assert.Equal(t, expectedMsg, err.Error())
 }
+
+// TestHandleExitCoder_EmptyMessage is a regression test for
+// https://github.com/urfave/cli/issues/2263.
+// HandleExitCoder must not print an empty line to ErrWriter when the ExitCoder
+// message is empty (e.g. cli.Exit("", code)).
+func TestHandleExitCoder_EmptyMessage(t *testing.T) {
+	called := false
+
+	OsExiter = func(rc int) {
+		if !called {
+			called = true
+		}
+	}
+	ErrWriter = &bytes.Buffer{}
+
+	defer func() {
+		OsExiter = fakeOsExiter
+		ErrWriter = fakeErrWriter
+	}()
+
+	HandleExitCoder(Exit("", 2))
+
+	assert.True(t, called)
+	assert.Empty(t, ErrWriter.(*bytes.Buffer).String(), "expected no output for empty-message exit")
+}


### PR DESCRIPTION
## Summary

When `cli.Exit("", exitCode)` is called, `HandleExitCoder` still wrote a bare newline to `ErrWriter` (usually stderr), because it called `fmt.Fprintln(ErrWriter, err)` unconditionally. An `ExitCoder` with an empty message should produce no output.

### Before

```go
cli.Exit("", 1)
// stderr: "\n"  ← unexpected blank line
```

### After

```go
cli.Exit("", 1)
// stderr: ""    ← nothing printed
```

## Fix

Guard the `fmt.Fprintln` / `fmt.Fprintf` calls with a check that `err.Error() != ""` before writing to `ErrWriter`.

Fixes #2263

## Checklist

- [x] Test added (`TestHandleExitCoder_EmptyMessage`)
- [x] Full test suite passes