### PR TITLE
flag: prevent BoolWithInverseFlag.String from panicking without a tab

### DIFF
--- a/flag_bool_with_inverse.go
+++ b/flag_bool_with_inverse.go
@@ -179,6 +179,14 @@ func (bif *BoolWithInverseFlag) String() string {
 		prefix = "-"
 	}
 
+	// Guard against a FlagStringer that returns a string without a tab (e.g.
+	// a custom stringer or the default stringer when the flag does not
+	// implement DocGenerationFlag). In that case treat the entire output as
+	// the tab-delimited suffix so the slice never goes out of bounds.
+	if i < 0 {
+		i = 0
+	}
+
 	return fmt.Sprintf("%s[%s]%s%s", prefix, bif.inversePrefix(), bif.Name, out[i:])
 }
 

--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -520,3 +520,26 @@ func TestBoolWithInverseFlag_SatisfiesVisibleFlagInterface(t *testing.T) {
 
 	_ = f.IsVisible()
 }
+
+// TestBoolWithInverseFlagStringNoPanicWithNoTabStringer is a regression test for
+// https://github.com/urfave/cli/issues/2303.
+// BoolWithInverseFlag.String() panicked with "slice bounds out of range [-1:]"
+// when the FlagStringer returned a string without a tab character.
+func TestBoolWithInverseFlagStringNoPanicWithNoTabStringer(t *testing.T) {
+	orig := FlagStringer
+	defer func() { FlagStringer = orig }()
+
+	FlagStringer = func(f Flag) string {
+		return "no tab here"
+	}
+
+	flag := &BoolWithInverseFlag{
+		Name: "verbose",
+	}
+
+	// Must not panic.
+	got := flag.String()
+	if !strings.Contains(got, "verbose") {
+		t.Errorf("expected String() to contain the flag name, got %q", got)
+	}
+}

--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -533,13 +533,19 @@ func TestBoolWithInverseFlagStringNoPanicWithNoTabStringer(t *testing.T) {
 		return "no tab here"
 	}
 
-	flag := &BoolWithInverseFlag{
-		Name: "verbose",
-	}
+	t.Run("multi-character name uses -- prefix", func(t *testing.T) {
+		flag := &BoolWithInverseFlag{Name: "verbose"}
+		got := flag.String() // must not panic
+		if !strings.Contains(got, "--[no-]verbose") {
+			t.Errorf("expected String() to contain --[no-]verbose, got %q", got)
+		}
+	})
 
-	// Must not panic.
-	got := flag.String()
-	if !strings.Contains(got, "verbose") {
-		t.Errorf("expected String() to contain the flag name, got %q", got)
-	}
+	t.Run("single-character name uses - prefix", func(t *testing.T) {
+		flag := &BoolWithInverseFlag{Name: "v"}
+		got := flag.String() // must not panic
+		if !strings.Contains(got, "-[no-]v") {
+			t.Errorf("expected String() to contain -[no-]v, got %q", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

\`BoolWithInverseFlag.String()\` panics with \`slice bounds out of range [-1:]\` when the configured \`FlagStringer\` returns a string that does not contain a tab character.

\`\`\`go
out := FlagStringer(bif)
i := strings.Index(out, \"\\t\")  // -1 when no tab
// ...
out[i:]                            // panic: slice bounds out of range [-1:]
\`\`\`

This happens with custom stringers and with the default stringer when the flag doesn't implement \`DocGenerationFlag\`.

## Fix

Clamp the tab index to 0 when no tab is found. The full \`FlagStringer\` output is then used as the suffix portion of the formatted string, matching the intent of callers using a custom stringer without the usual tab layout.

Fixes #2303

## Checklist

- [x] Test added covering both multi-character and single-character flag names with a no-tab \`FlagStringer\`
- [x] Full test suite passes