### PR TITLE
fix: show flag completions when completing a double-dash prefix

### DIFF
--- a/command_parse.go
+++ b/command_parse.go
@@ -86,6 +86,11 @@ func (cmd *Command) parseFlags(args Args) (Args, error) {
 
 		// stop parsing once we see a "--"
 		if firstArg == "--" {
+			// In shell completion mode, preserve "--" so that completion can detect
+			// when the user is completing "--" itself vs. completing after "--"
+			if cmd.Root().shellCompletion {
+				posArgs = append(posArgs, firstArg)
+			}
 			posArgs = append(posArgs, rargs[1:]...)
 			return &stringSliceArgs{posArgs}, nil
 		}
@@ -166,6 +171,12 @@ func (cmd *Command) parseFlags(args Args) (Args, error) {
 			// not a bool flag so need to get the next arg
 			if flagVal == "" && !valFromEqual {
 				if len(rargs) == 1 {
+					// In shell completion mode, preserve the flag so that DefaultCompleteWithFlags can use it
+					// as lastArg and offer suggestions for it.
+					if cmd.Root().shellCompletion {
+						posArgs = append(posArgs, rargs...)
+						return &stringSliceArgs{posArgs}, nil
+					}
 					return &stringSliceArgs{posArgs}, fmt.Errorf("%s%s", argumentNotProvidedErrMsg, firstArg)
 				}
 				flagVal = rargs[1]
@@ -182,6 +193,12 @@ func (cmd *Command) parseFlags(args Args) (Args, error) {
 
 		// no flag lookup found and short handling is disabled
 		if !shortOptionHandling {
+			// In shell completion mode, preserve the partial flag so that DefaultCompleteWithFlags can use it
+			// as lastArg and offer suggestions that match the prefix.
+			if cmd.Root().shellCompletion {
+				posArgs = append(posArgs, rargs...)
+				return &stringSliceArgs{posArgs}, nil
+			}
 			return &stringSliceArgs{posArgs}, fmt.Errorf("%s%s", providedButNotDefinedErrMsg, flagName)
 		}
 

--- a/command_test.go
+++ b/command_test.go
@@ -599,8 +599,8 @@ func TestCommand_Run_CustomShellCompleteAcceptsMalformedFlags(t *testing.T) {
 		testArgs    *stringSliceArgs
 		expectedOut string
 	}{
-		{testArgs: &stringSliceArgs{v: []string{"--undefined"}}, expectedOut: "found 0 args"},
-		{testArgs: &stringSliceArgs{v: []string{"--number"}}, expectedOut: "found 0 args"},
+		{testArgs: &stringSliceArgs{v: []string{"--undefined"}}, expectedOut: "found 1 args"},
+		{testArgs: &stringSliceArgs{v: []string{"--number"}}, expectedOut: "found 1 args"},
 		{testArgs: &stringSliceArgs{v: []string{"--number", "forty-two"}}, expectedOut: "found 0 args"},
 		{testArgs: &stringSliceArgs{v: []string{"--number", "42"}}, expectedOut: "found 0 args"},
 		{testArgs: &stringSliceArgs{v: []string{"--number", "42", "newArg"}}, expectedOut: "found 1 args"},

--- a/completion_test.go
+++ b/completion_test.go
@@ -121,14 +121,13 @@ func TestCompletionSubcommand(t *testing.T) {
 			},
 		},
 		{
-			name:     "subcommand flag no completion",
+			name:     "subcommand double dash shows long flags",
 			args:     []string{"foo", "bar", "--", completionFlag},
-			contains: "l1",
-			msg:      "Expected output to contain shell name %[1]q",
+			contains: "--l1",
+			msg:      "Expected output to contain flag %[1]q",
 			msgArgs: []any{
-				"l1",
+				"--l1",
 			},
-			notContains: true,
 		},
 		{
 			name:     "sub sub command general completion",
@@ -150,14 +149,13 @@ func TestCompletionSubcommand(t *testing.T) {
 			},
 		},
 		{
-			name:     "sub sub command no completion",
+			name:     "sub sub command double dash shows flags",
 			args:     []string{"foo", "bar", "xyz", "--", completionFlag},
-			contains: "-g",
+			contains: "--help",
 			msg:      "Expected output to contain flag %[1]q",
 			msgArgs: []any{
-				"-g",
+				"--help",
 			},
-			notContains: true,
 		},
 		{
 			name:     "sub sub command no completion extra args",
@@ -168,6 +166,24 @@ func TestCompletionSubcommand(t *testing.T) {
 				"-g",
 			},
 			notContains: true,
+		},
+		{
+			name:     "subcommand partial double dash flag completion",
+			args:     []string{"foo", "bar", "--l", completionFlag},
+			contains: "--l1",
+			msg:      "Expected output to contain flag %[1]q",
+			msgArgs: []any{
+				"--l1",
+			},
+		},
+		{
+			name:     "sub sub command partial double dash flag completion",
+			args:     []string{"foo", "bar", "xyz", "--he", completionFlag},
+			contains: "--help",
+			msg:      "Expected output to contain flag %[1]q",
+			msgArgs: []any{
+				"--help",
+			},
 		},
 	}
 

--- a/help.go
+++ b/help.go
@@ -256,11 +256,6 @@ func DefaultCompleteWithFlags(ctx context.Context, cmd *Command) {
 		lastArg = args[argsLen-1]
 	}
 
-	if lastArg == "--" {
-		tracef("No completions due to termination")
-		return
-	}
-
 	if lastArg == completionFlag {
 		lastArg = ""
 	}
@@ -485,10 +480,12 @@ func checkShellCompleteFlag(c *Command, arguments []string) (bool, []string) {
 		return false, arguments
 	}
 
-	// If arguments include "--", shell completion is disabled
-	// because after "--" only positional arguments are accepted.
+	// If arguments include "--" before the token being completed, shell completion
+	// is disabled because after "--" only positional arguments are accepted.
 	// https://unix.stackexchange.com/a/11382
-	if slices.Contains(arguments, "--") {
+	// Note: The token being completed is at position pos-1 (immediately before completionFlag).
+	// We only check arguments before that position, so completing "--" itself still works.
+	if pos >= 1 && slices.Contains(arguments[:pos-1], "--") {
 		return false, arguments[:pos]
 	}
 

--- a/help_test.go
+++ b/help_test.go
@@ -1325,7 +1325,7 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 			expected: "",
 		},
 		{
-			name: "flag-suggestion-end-args",
+			name: "flag-suggestion-double-dash-shows-all-flags",
 			cmd: &Command{
 				Flags: []Flag{
 					&BoolFlag{Name: "excitement"},
@@ -1344,7 +1344,7 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 			},
 			argv:     []string{"cmd", "--e", "--", completionFlag},
 			env:      map[string]string{"SHELL": "bash"},
-			expected: "",
+			expected: "--excitement\n--hat-shape\n",
 		},
 		{
 			name: "typical-command-suggestion",
@@ -1906,6 +1906,15 @@ func Test_checkShellCompleteFlag(t *testing.T) {
 			},
 			wantShellCompletion: true,
 			wantArgs:            []string{"foo"},
+		},
+		{
+			name:      "double dash is the token being completed",
+			arguments: []string{"foo", "--", completionFlag},
+			cmd: &Command{
+				EnableShellCompletion: true,
+			},
+			wantShellCompletion: true,
+			wantArgs:            []string{"foo", "--"},
 		},
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

When the user types `cmd subcommand --<TAB>` or `cmd subcommand --prefix<TAB>`, the CLI should show available flags. Previously, this produced no completions or malformed output because of four bugs:

1. `checkShellCompleteFlag()` disabled completion mode when `--` appeared anywhere in arguments, including when `--` was the token being completed.
2. `DefaultCompleteWithFlags()` returned early when `lastArg == "--"`.
3. `parseFlags()` stripped `--` from args during completion, causing `lastArg` to be empty and triggering command suggestions instead of flag suggestions.
4. `parseFlags()` dropped unknown or value-less flags from `posArgs` and returned an error, so partial prefixes like `--prefix` were lost before `DefaultCompleteWithFlags` could use them to filter flag suggestions.

**Changes:**

- **help.go**: `checkShellCompleteFlag` now only disables completion if `--` appears *before* the token being completed, not when it IS the token being completed
- **help.go**: Removed early return in `DefaultCompleteWithFlags` for `lastArg == "--"`
- **command_parse.go**: Preserve `--` in `posArgs` during shell completion mode
- **command_parse.go**: Preserve unknown flags and flags missing a value in `posArgs` during shell completion mode, so partial prefixes reach `DefaultCompleteWithFlags`

## Which issue(s) this PR fixes:

Fixes #2315

## Testing

All changes are covered by new/updated tests that fail without the code changes and pass with them:

- `TestCommand_Run_CustomShellCompleteAcceptsMalformedFlags`: Updated to expect `--undefined` and `--number` flags preserved in args
- `TestCompletionSubcommand`: Added tests for `--<TAB>` and `--partial<TAB>` scenarios
- `TestDefaultCompleteWithFlags`: Updated `flag-suggestion-double-dash-shows-all-flags` to expect flag output
- `Test_checkShellCompleteFlag`: Added `double dash is the token being completed` test case

## Release Notes

```release-note
Fixed shell completion to show flag suggestions when completing `--` or partial flag prefixes like `--prefix`
```
