### PR TITLE
fix: parse flags for help subcommand (#2271)

### DIFF
--- a/command.go
+++ b/command.go
@@ -408,6 +408,12 @@ func (cmd *Command) checkRequiredFlag(f Flag) (bool, string) {
 }
 
 func (cmd *Command) checkAllRequiredFlags() requiredFlagsErr {
+	// The help and completion commands are allowed to run without
+	// enforcement of required flags, since they do not invoke user
+	// actions that depend on those flag values.
+	if cmd.Name == helpName || cmd.isCompletionCommand {
+		return nil
+	}
 	for pCmd := cmd; pCmd != nil; pCmd = pCmd.parent {
 		if err := pCmd.checkRequiredFlags(); err != nil {
 			return err

--- a/command_run.go
+++ b/command_run.go
@@ -141,8 +141,8 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 	var rargs Args = &stringSliceArgs{v: osArgs}
 	var args Args = &stringSliceArgs{rargs.Tail()}
 
-	if cmd.isCompletionCommand || cmd.Name == helpName {
-		tracef("special command detected, skipping pre-parse (cmd=%[1]q)", cmd.Name)
+	if cmd.isCompletionCommand {
+		tracef("completion command detected, skipping pre-parse (cmd=%[1]q)", cmd.Name)
 		cmd.parsedArgs = args
 		return ctx, cmd.Action(ctx, cmd)
 	}

--- a/help_test.go
+++ b/help_test.go
@@ -164,6 +164,35 @@ GLOBAL OPTIONS:
 		"expected output to include usage text")
 }
 
+// Test_HelpCommand_ParsesFlags is a regression test for #2271: flags
+// declared on a user-supplied command named "help" must still be parsed.
+// Previously in v3.6.2 flag pre-parsing was skipped for any command named
+// "help", causing such flags to be silently dropped.
+func Test_HelpCommand_ParsesFlags(t *testing.T) {
+	var parsed string
+
+	cmd := &Command{
+		Name: "app",
+		Commands: []*Command{
+			{
+				Name: "help",
+				Flags: []Flag{
+					&StringFlag{Name: "topic", Aliases: []string{"t"}},
+				},
+				Action: func(_ context.Context, c *Command) error {
+					parsed = c.String("topic")
+					return nil
+				},
+			},
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"app", "help", "--topic", "foo"})
+	require.NoError(t, err)
+	assert.Equal(t, "foo", parsed,
+		"expected --topic flag on help subcommand to be parsed")
+}
+
 func Test_Help_Custom_Flags(t *testing.T) {
 	oldFlag := HelpFlag
 	defer func() {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

PR #2245 introduced a regression in v3.6.2 by short-circuiting flag pre-parsing for any command named \`help\`:

```go
if cmd.isCompletionCommand || cmd.Name == helpName {
    cmd.parsedArgs = args
    return ctx, cmd.Action(ctx, cmd)
}
```

The original goal of #2245 was to let \`help\` and \`completion\` run without tripping required-flag enforcement, but skipping pre-parse entirely also drops flags and arguments on user-supplied help commands (#2271) and breaks custom help commands (#2260).

This PR keeps the pre-parse path intact for the help command and instead short-circuits \`checkAllRequiredFlags\` for \`help\` and completion, which was the actual intent. The completion command still bypasses pre-parse as it did before #2245.

- \`command_run.go\`: restore the pre-#2245 condition (\`isCompletionCommand\` only).
- \`command.go\`: exempt \`help\` and completion commands from the required-flag check.

## Which issue(s) this PR fixes:

Fixes #2271

## Testing

Added \`Test_HelpCommand_ParsesFlags\` in \`help_test.go\`, which fails on current main and passes with this change. The existing \`Test_HelpCommand_RequiredFlagsNoDefault\` added in #2245 still passes.

\`\`\`
make lint vet test
\`\`\`

## Release Notes

\`\`\`release-note
Fix v3.6.2 regression where flags and arguments on user-supplied help subcommands were silently dropped.
\`\`\`