### PR TITLE
fix: show BoolWithInverseFlag aliases in help text

### DIFF
--- a/flag_bool_with_inverse.go
+++ b/flag_bool_with_inverse.go
@@ -167,6 +167,9 @@ func (bif *BoolWithInverseFlag) IsVisible() bool {
 //
 // Example for BoolFlag{Name: "env"}
 // --[no-]env	(default: false)
+//
+// Example for BoolFlag{Name: "env", Aliases: []string{"e"}}
+// --[no-]env, -e	(default: false)
 func (bif *BoolWithInverseFlag) String() string {
 	out := FlagStringer(bif)
 
@@ -187,7 +190,21 @@ func (bif *BoolWithInverseFlag) String() string {
 		i = 0
 	}
 
-	return fmt.Sprintf("%s[%s]%s%s", prefix, bif.inversePrefix(), bif.Name, out[i:])
+	var aliasParts []string
+	for _, alias := range bif.Aliases {
+		aPrefix := "--"
+		if len(alias) == 1 {
+			aPrefix = "-"
+		}
+		aliasParts = append(aliasParts, aPrefix+alias)
+	}
+
+	names := fmt.Sprintf("%s[%s]%s", prefix, bif.inversePrefix(), bif.Name)
+	if len(aliasParts) > 0 {
+		names = names + ", " + strings.Join(aliasParts, ", ")
+	}
+
+	return fmt.Sprintf("%s%s", names, out[i:])
 }
 
 // IsBoolFlag returns whether the flag doesnt need to accept args

--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -345,6 +345,7 @@ func TestBoolWithInverseString(t *testing.T) {
 		required      bool
 		usage         string
 		inversePrefix string
+		aliases       []string
 		expected      string
 	}{
 		{
@@ -397,6 +398,27 @@ func TestBoolWithInverseString(t *testing.T) {
 			required: true,
 			expected: "--[no-]env\t",
 		},
+		{
+			testName: "short alias",
+			flagName: "color",
+			required: false,
+			aliases:  []string{"c"},
+			expected: "--[no-]color, -c\t(default: false)",
+		},
+		{
+			testName: "long alias",
+			flagName: "color",
+			required: false,
+			aliases:  []string{"colour"},
+			expected: "--[no-]color, --colour\t(default: false)",
+		},
+		{
+			testName: "multiple aliases",
+			flagName: "color",
+			required: false,
+			aliases:  []string{"c", "colour"},
+			expected: "--[no-]color, -c, --colour\t(default: false)",
+		},
 	}
 
 	for _, tc := range tcs {
@@ -406,6 +428,7 @@ func TestBoolWithInverseString(t *testing.T) {
 				Usage:         tc.usage,
 				Required:      tc.required,
 				InversePrefix: tc.inversePrefix,
+				Aliases:       tc.aliases,
 			}
 
 			require.Equal(t, tc.expected, flag.String())

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -414,6 +414,9 @@ func (bif *BoolWithInverseFlag) String() string
 
     Example for BoolFlag{Name: "env"} --[no-]env (default: false)
 
+    Example for BoolFlag{Name: "env", Aliases: []string{"e"}} --[no-]env,
+    -e (default: false)
+
 func (bif *BoolWithInverseFlag) TakesValue() bool
 
 func (bif *BoolWithInverseFlag) TypeName() string

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -414,6 +414,9 @@ func (bif *BoolWithInverseFlag) String() string
 
     Example for BoolFlag{Name: "env"} --[no-]env (default: false)
 
+    Example for BoolFlag{Name: "env", Aliases: []string{"e"}} --[no-]env,
+    -e (default: false)
+
 func (bif *BoolWithInverseFlag) TakesValue() bool
 
 func (bif *BoolWithInverseFlag) TypeName() string


### PR DESCRIPTION
Aliases defined on `BoolWithInverseFlag` are functional but were not displayed in usage/help output. The `String()` method only rendered `--[no-]<name>` without including any aliases.

### Before
```
--[no-]color	(default: false)
```

### After
```
--[no-]color, -c	(default: false)
--[no-]color, --colour	(default: false)
```

### Changes
- **`flag_bool_with_inverse.go`**: Updated `String()` to append aliases with correct prefix (`-` for single-char, `--` for multi-char)
- **`flag_bool_with_inverse_test.go`**: Added 3 new test cases covering short alias, long alias, and multiple aliases

All existing tests pass, no breaking changes.

Fixes #2216