### PR TITLE
fix(completion): use greedy %% for colon parsing in bash completion template

### DIFF
--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -66,7 +66,7 @@ __%[1]s_bash_autocomplete() {
       local description=""
       
       if [[ "${line}" == *:* ]]; then
-        token="${line%%:*}"
+        token="${line%%%%:*}"
         description="${line#*:}"
       fi
 

--- a/completion_test.go
+++ b/completion_test.go
@@ -158,6 +158,32 @@ func TestCompletionBashAppendsSpace(t *testing.T) {
 	r.Contains(output, "complete -o bashdefault -o default -F __myapp_bash_autocomplete myapp")
 }
 
+func TestCompletionBashGreedyColonParsing(t *testing.T) {
+	// Regression test: the bash completion template uses fmt.Sprintf, so
+	// literal "%" in the template must be escaped as "%%". The token
+	// extraction must use the greedy ${line%%:*} (double %%) to split on
+	// the *first* colon. A single % would use ${line%:*} which splits on
+	// the *last* colon, breaking descriptions that contain colons
+	// (e.g. "export:Export configs such as: compose-config").
+
+	cmd := &Command{
+		EnableShellCompletion: true,
+	}
+
+	r := require.New(t)
+
+	bashRender := shellCompletions["bash"]
+	r.NotNil(bashRender, "bash completion renderer should exist")
+
+	output, err := bashRender(cmd, "myapp")
+	r.NoError(err)
+
+	// After fmt.Sprintf, the rendered script must contain ${line%%:*}
+	// (greedy match) not ${line%:*} (non-greedy match).
+	r.Contains(output, `${line%%:*}`, "token extraction should use greedy %% to match first colon")
+	r.NotContains(output, `${line%:*}`, "token extraction must not use non-greedy single % (splits on last colon)")
+}
+
 func TestCompletionFishFormat(t *testing.T) {
 	// Regression test for https://github.com/urfave/cli/issues/2285
 	// Fish completion was broken due to incorrect format specifiers

--- a/completion_test.go
+++ b/completion_test.go
@@ -159,7 +159,8 @@ func TestCompletionBashAppendsSpace(t *testing.T) {
 }
 
 func TestCompletionBashGreedyColonParsing(t *testing.T) {
-	// Regression test: the bash completion template uses fmt.Sprintf, so
+	// Regression test for https://github.com/urfave/cli/issues/2335
+	// The bash completion template uses fmt.Sprintf, so
 	// literal "%" in the template must be escaped as "%%". The token
 	// extraction must use the greedy ${line%%:*} (double %%) to split on
 	// the *first* colon. A single % would use ${line%:*} which splits on


### PR DESCRIPTION
## What type of PR is this?

- bug fix

## What this PR does / why we need it

The bash autocomplete template in `autocomplete/bash_autocomplete` uses `fmt.Sprintf` for rendering. The line that extracts the token from `token:description` format had:

```bash
token="${line%%:*}"
```

Because `fmt.Sprintf` interprets `%%` as an escape for a literal `%`, the rendered output becomes `${line%:*}` (single `%`). In bash, `${line%:*}` removes the **shortest suffix** matching `:*` — i.e. it strips from the **last** colon. This is wrong when descriptions contain colons (e.g. `export:Export configs such as: compose-config`), causing the description text to leak into `compgen -W` and produce spurious completions.

The fix changes `%%` to `%%%%` in the template so that after `fmt.Sprintf`, the rendered script contains `%%` (greedy removal from the **first** colon):

```bash
# template:
token="${line%%%%:*}"
# rendered:
token="${line%%:*}"
```

## Which issue(s) this PR fixes

Fixes #2335

## Testing

Added `TestCompletionBashGreedyColonParsing` regression test that renders the bash completion template and verifies the output contains `${line%%:*}` (greedy) and not `${line%:*}` (non-greedy).

```
$ go test -run TestCompletionBash -v .
=== RUN   TestCompletionBashNoShebang
--- PASS: TestCompletionBashNoShebang (0.00s)
=== RUN   TestCompletionBashGreedyColonParsing
--- PASS: TestCompletionBashGreedyColonParsing (0.00s)
PASS
```

## Release Notes

```release-note
Fixed bash completion producing spurious entries when command descriptions contain colons.
```