### PR TITLE
Fix bash completion spacing

### DIFF
--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -104,4 +104,4 @@ __%[1]s_bash_autocomplete() {
   fi
 }
 
-complete -o bashdefault -o default -o nospace -F __%[1]s_bash_autocomplete %[1]s
+complete -o bashdefault -o default -F __%[1]s_bash_autocomplete %[1]s

--- a/completion_test.go
+++ b/completion_test.go
@@ -137,6 +137,27 @@ func TestCompletionBashNoShebang(t *testing.T) {
 	r.False(strings.HasPrefix(output, "#!"), "bash completion should not start with a shebang")
 }
 
+func TestCompletionBashAppendsSpace(t *testing.T) {
+	// Regression test for https://github.com/urfave/cli/issues/2332
+	// Do not register bash completions with `-o nospace`: after a command or
+	// subcommand completion, Bash should append a space so the next word can be
+	// completed without manually typing one.
+
+	cmd := &Command{
+		EnableShellCompletion: true,
+	}
+
+	r := require.New(t)
+
+	bashRender := shellCompletions["bash"]
+	r.NotNil(bashRender, "bash completion renderer should exist")
+
+	output, err := bashRender(cmd, "myapp")
+	r.NoError(err)
+	r.NotContains(output, "-o nospace", "bash completion should append spaces after completed words")
+	r.Contains(output, "complete -o bashdefault -o default -F __myapp_bash_autocomplete myapp")
+}
+
 func TestCompletionFishFormat(t *testing.T) {
 	// Regression test for https://github.com/urfave/cli/issues/2285
 	// Fish completion was broken due to incorrect format specifiers


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

- Removes `-o nospace` from the generated bash completion registration.
- This lets Bash append its normal trailing space after a command or subcommand completion, so users can continue completing the next word without typing a space manually.
- Adds a regression test that renders the bash completion script and verifies it no longer disables space insertion.

## Which issue(s) this PR fixes:

Fixes #2332

## Testing

- `go test ./... -run 'TestCompletionBash(NoShebang|AppendsSpace)|TestCompletionSubcommand' -count=1`
- `go test ./...`
- `go vet ./...`

## Release Notes

```release-note
Fixed bash completion so completed commands and subcommands append a trailing space.
```
