### PR TITLE
Fix fish custom completion arguments

### DIFF
--- a/autocomplete/fish_autocomplete
+++ b/autocomplete/fish_autocomplete
@@ -6,7 +6,11 @@ function __%[1]s_perform_completion
     # Extract the last arg (partial input)
     set -l lastArg (commandline -ct)
     
-    set -l results ($args[1] $args[2..-1] $lastArg --generate-shell-completion 2> /dev/null)
+    if string match -q -- "-*" $lastArg
+        set results ($args[1] $args[2..-1] $lastArg --generate-shell-completion 2> /dev/null)
+    else
+        set results ($args[1] $args[2..-1] --generate-shell-completion 2> /dev/null)
+    end
 
     # Remove trailing empty lines
     for line in $results[-1..1]

--- a/completion_test.go
+++ b/completion_test.go
@@ -167,6 +167,25 @@ func TestCompletionFishFormat(t *testing.T) {
 	r.Contains(output, "(__myapp_perform_completion)", "completion function should be registered")
 }
 
+func TestCompletionFishOmitsPositionalTokenFromDynamicCompletion(t *testing.T) {
+	cmd := &Command{
+		Name:                  "myapp",
+		EnableShellCompletion: true,
+	}
+
+	r := require.New(t)
+
+	fishRender := shellCompletions["fish"]
+	r.NotNil(fishRender, "fish completion renderer should exist")
+
+	output, err := fishRender(cmd, "myapp")
+	r.NoError(err)
+
+	r.Contains(output, `if string match -q -- "-*" $lastArg`)
+	r.Contains(output, "set results ($args[1] $args[2..-1] $lastArg --generate-shell-completion 2> /dev/null)")
+	r.Contains(output, "set results ($args[1] $args[2..-1] --generate-shell-completion 2> /dev/null)")
+}
+
 func TestCompletionSubcommand(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -305,6 +324,33 @@ func TestCompletionSubcommand(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCompletionSubcommandCustomShellComplete(t *testing.T) {
+	out := &bytes.Buffer{}
+
+	cmd := &Command{
+		EnableShellCompletion: true,
+		Writer:                out,
+		Commands: []*Command{
+			{
+				Name: "index",
+				Commands: []*Command{
+					{
+						Name: "show",
+						ShellComplete: func(ctx context.Context, cmd *Command) {
+							fmt.Fprintln(cmd.Root().Writer, "custom-index")
+						},
+						Action: func(ctx context.Context, cmd *Command) error { return nil },
+					},
+				},
+			},
+		},
+	}
+
+	r := require.New(t)
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", "index", "show", completionFlag}))
+	r.Equal("custom-index\n", out.String())
 }
 
 func TestCompletionInvalidShell(t *testing.T) {

--- a/completion_test.go
+++ b/completion_test.go
@@ -186,6 +186,25 @@ func TestCompletionFishOmitsPositionalTokenFromDynamicCompletion(t *testing.T) {
 	r.Contains(output, "set results ($args[1] $args[2..-1] --generate-shell-completion 2> /dev/null)")
 }
 
+func TestCompletionBashOmitsPositionalTokenFromDynamicCompletion(t *testing.T) {
+	cmd := &Command{
+		Name:                  "myapp",
+		EnableShellCompletion: true,
+	}
+
+	r := require.New(t)
+
+	bashRender := shellCompletions["bash"]
+	r.NotNil(bashRender, "bash completion renderer should exist")
+
+	output, err := bashRender(cmd, "myapp")
+	r.NoError(err)
+
+	r.Contains(output, `if [[ "${current_word}" == "-"* ]]; then`)
+	r.Contains(output, `printf '%s %s --generate-shell-completion' "${words_before_cursor[*]}" "${current_word}"`)
+	r.Contains(output, `printf '%s --generate-shell-completion' "${words_before_cursor[*]}"`)
+}
+
 func TestCompletionSubcommand(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

- Updates the generated fish completion script so it only forwards the current token when that token starts with `-`.
- Makes fish match the bash and zsh behavior for dynamic completions by omitting partial positional tokens from the command invocation.
- Adds completion coverage for the fish script behavior and nested custom subcommand completion dispatch.

## Which issue(s) this PR fixes:

Fixes #2333

## Special notes for your reviewer:

The reported callback checks `NArg()` before printing completions. In fish, the partial positional token was being forwarded before `--generate-shell-completion`, so callbacks like that saw an argument and returned without output.

## Testing

- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./... -run 'TestCompletionFishOmitsPositionalTokenFromDynamicCompletion|TestCompletionSubcommandCustomShellComplete|TestCompletionFishFormat' -count=1`\n- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./...`\n- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache make vet`\n- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache make test`\n- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache make check-binary-size`\n- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache make generate`\n- `PATH=$PWD/.local/bin:$PATH GOMODCACHE=/tmp/urfave-cli-gomodcache GOCACHE=/tmp/urfave-cli-gocache make lint`\n- `PATH=$PWD/.local/bin:$PATH GOMODCACHE=/tmp/urfave-cli-gomodcache GOCACHE=/tmp/urfave-cli-gocache make gfmrun`\n- `PATH=$PWD/.local/bin:$PATH GOMODCACHE=/tmp/urfave-cli-gomodcache GOCACHE=/tmp/urfave-cli-gocache make v3diff`\n- `PATH=$PWD/.local/bin:$PATH GOMODCACHE=/tmp/urfave-cli-gomodcache GOCACHE=/tmp/urfave-cli-gocache make diffcheck`\n- `PATH=$PWD/.local/bin:$PATH GOMODCACHE=/tmp/urfave-cli-gomodcache GOCACHE=/tmp/urfave-cli-gocache golangci-lint run --new-from-rev=upstream/main`\n- `git diff --check`\n\nNote: on macOS arm64, `make ensure-gfmrun` could not download the `gfmrun v1.3.0` release asset because GitHub returned 404, so I installed `gfmrun v1.3.0` from source locally before running `make gfmrun`.\n\n## Release Notes\n\n```release-note\nFixed fish shell completion for custom subcommand completions.\n```