### PR TITLE
docs: clarify boolean flag value syntax

### DIFF
--- a/docs/v3/examples/flags/basics.md
+++ b/docs/v3/examples/flags/basics.md
@@ -78,6 +78,9 @@ $ greet --lang=spanish my-friend
 Hola my-friend
 ```
 
+Boolean flags are the exception: passing a boolean flag without a value sets it to
+`true`. Use the `=` form, such as `--flag=false`, to provide an explicit boolean value.
+
 While the value of any flag can be retrieved using ```command.<flagType>``` sometimes
 it is convenient to have the value of the flag automatically stored in a destination
 variable for a flag. If the `Value` is set for the flag, it will be shown as default,


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

- Clarifies that boolean flags are an exception to the space-separated value syntax.
- Documents that `--flag=false` should be used when passing an explicit boolean value.

## Which issue(s) this PR fixes:

Fixes #2206

## Testing

- `git diff --check`
- `go test ./...`
- `PATH="$PWD/.local/bin:$PATH" go run scripts/build.go gfmrun docs/v3/examples/flags/basics.md`

## Release Notes

```release-note
Clarified boolean flag value syntax in the v3 flags documentation.
```
