### PR TITLE
Issue#2323

### DIFF
--- a/command.go
+++ b/command.go
@@ -137,7 +137,9 @@ type Command struct {
 	// A value of 0 means all arguments are treated as positional (no flag parsing).
 	// A nil value means normal v3 flag parsing behavior (flags can appear anywhere).
 	StopOnNthArg *int `json:"stopOnNthArg"`
-
+	// Additional topics in the help message. Used to print arbitrary help topics
+	// in addition to the default help topics.
+	AdditionalHelpTopics map[string]string `json:"additionalHelpTopics"`
 	// categories contains the categorized commands and is populated on app startup
 	categories CommandCategories
 	// flagCategories contains the categorized flags and is populated on app startup

--- a/command_test.go
+++ b/command_test.go
@@ -4923,6 +4923,7 @@ func TestJSONExportCommand(t *testing.T) {
 		"description": "Description of the application.",
 		"defaultCommand": "",
 		"category": "",
+		"additionalHelpTopics": null,
 		"commands": [
 		  {
 			"name": "config",
@@ -4936,6 +4937,7 @@ func TestJSONExportCommand(t *testing.T) {
 			"description": "",
 			"defaultCommand": "",
 			"category": "",
+			"additionalHelpTopics": null,
 			"commands": [
 			  {
 				"name": "sub-config",
@@ -4950,6 +4952,7 @@ func TestJSONExportCommand(t *testing.T) {
 				"description": "",
 				"defaultCommand": "",
 				"category": "",
+				"additionalHelpTopics": null,
 				"commands": null,
 				"flags": [
 				  {
@@ -5091,6 +5094,7 @@ func TestJSONExportCommand(t *testing.T) {
 			"description": "",
 			"defaultCommand": "",
 			"category": "",
+			"additionalHelpTopics": null,
 			"commands": null,
 			"flags": null,
 			"hideHelp": false,
@@ -5123,6 +5127,7 @@ func TestJSONExportCommand(t *testing.T) {
 			"description": "",
 			"defaultCommand": "",
 			"category": "",
+			"additionalHelpTopics": null,
 			"commands": null,
 			"flags": null,
 			"hideHelp": false,
@@ -5155,6 +5160,7 @@ func TestJSONExportCommand(t *testing.T) {
 			"description": "",
 			"defaultCommand": "",
 			"category": "",
+			"additionalHelpTopics": null,
 			"commands": null,
 			"flags": [
 			  {
@@ -5208,6 +5214,7 @@ func TestJSONExportCommand(t *testing.T) {
 			"description": "",
 			"defaultCommand": "",
 			"category": "",
+			"additionalHelpTopics": null,
 			"commands": [
 			  {
 				"name": "sub-usage",
@@ -5221,6 +5228,7 @@ func TestJSONExportCommand(t *testing.T) {
 				"description": "",
 				"defaultCommand": "",
 				"category": "",
+				"additionalHelpTopics": null,
 				"commands": null,
 				"flags": [
 				  {

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -65,7 +65,9 @@ var CommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{template "usageTemplate" .}}{{if .Category}}
+   {{template "usageTemplate" .}}
+
+{{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{if .Category}}
 
 CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
@@ -115,7 +117,9 @@ var RootCommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}} {{if .VisibleFlags}}[global options]{{end}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}} {{if .VisibleFlags}}[global options]{{end}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}
+
+{{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{ if .Version}}{{if not .HideVersion}}
 
 VERSION:
    {{.Version}}{{end}}{{end}}{{if .Description}}
@@ -158,7 +162,9 @@ var SubcommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}{{if .Category}}
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}
+
+{{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{if .Category}}
 
 CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
@@ -549,6 +555,9 @@ type Command struct {
 	// A value of 0 means all arguments are treated as positional (no flag parsing).
 	// A nil value means normal v3 flag parsing behavior (flags can appear anywhere).
 	StopOnNthArg *int `json:"stopOnNthArg"`
+	// Additional topics in the help message. Used to print arbitrary help topics
+	// in addition to the default help topics.
+	AdditionalHelpTopics map[string]string `json:"additionalHelpTopics"`
 
 	// Has unexported fields.
 }

--- a/help.go
+++ b/help.go
@@ -447,6 +447,10 @@ func DefaultPrintHelpCustom(out io.Writer, templ string, data any, customFuncs m
 		handleTemplateError(err)
 	}
 
+	if _, err := t.New("additionalHelpTopicsTemplate").Parse(additionalHelpTopicsTemplate); err != nil {
+		handleTemplateError(err)
+	}
+
 	tracef("executing template")
 	handleTemplateError(t.Execute(w, data))
 

--- a/help_test.go
+++ b/help_test.go
@@ -2210,7 +2210,8 @@ OPTIONS:
 	for _, test := range tests {
 		actualOut := &bytes.Buffer{}
 		rootCmd.Writer = actualOut
-		rootCmd.Run(buildTestContext(t), test.command)
+		err := rootCmd.Run(buildTestContext(t), test.command)
+		require.NoError(t, err)
 		assert.Equal(t, test.expectedOut, actualOut.String())
 	}
 }

--- a/help_test.go
+++ b/help_test.go
@@ -2144,3 +2144,73 @@ func TestCustomUsageCommandHelp(t *testing.T) {
 	_ = cmd.Run(buildTestContext(t), []string{"app", "help"})
 	assert.Contains(t, out.String(), UsageCommandHelp)
 }
+
+func TestAdditionalHelpTopics(t *testing.T) {
+	expectedRootHelp := `NAME:
+   root - A new cli application
+
+USAGE:
+   root [global options] [command [command options]]
+
+ADDITIONAL-HELP:
+   ADDITIONAL-HELP
+
+COMMANDS:
+   sub      
+   help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --help, -h  show help
+`
+
+	expectedSubHelp := `NAME:
+   root sub
+
+USAGE:
+   root sub [options]
+
+SUB-ADDITIONAL-HELP:
+   SUB-ADDITIONAL-HELP
+
+OPTIONS:
+   --help, -h  show help
+`
+	tests := []struct {
+		name        string
+		expectedOut string
+		command     []string
+	}{
+		{
+			name:        "rootCommandTest",
+			expectedOut: expectedRootHelp,
+			command:     []string{"root", "--help"},
+		},
+		{
+			name:        "subCommandTest",
+			expectedOut: expectedSubHelp,
+			command:     []string{"root", "sub", "--help"},
+		},
+	}
+
+	rootCmd := &Command{
+		Name: "root",
+		Commands: []*Command{
+			{
+				Name: "sub",
+				AdditionalHelpTopics: map[string]string{
+					"SUB-ADDITIONAL-HELP": "SUB-ADDITIONAL-HELP",
+				},
+			},
+		},
+		AdditionalHelpTopics: map[string]string{
+			"ADDITIONAL-HELP": "ADDITIONAL-HELP",
+		},
+	}
+
+	for _, test := range tests {
+		actualOut := &bytes.Buffer{}
+		rootCmd.Writer = actualOut
+		rootCmd.Run(buildTestContext(t), test.command)
+		assert.Equal(t, test.expectedOut, actualOut.String())
+	}
+}

--- a/help_test.go
+++ b/help_test.go
@@ -2096,6 +2096,7 @@ func TestPrintHelpCustomTemplateError(t *testing.T) {
 		&visibleFlagCategoryTemplate,
 		&authorsTemplate,
 		&visibleCommandCategoryTemplate,
+		&additionalHelpTopicsTemplate,
 	}
 
 	oldErrWriter := ErrWriter

--- a/template.go
+++ b/template.go
@@ -82,7 +82,7 @@ var CommandHelpTemplate = `NAME:
 
 USAGE:
    {{template "usageTemplate" .}}
-   
+
 {{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{if .Category}}
 
 CATEGORY:
@@ -106,7 +106,7 @@ var SubcommandHelpTemplate = `NAME:
 
 USAGE:
    {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}
-   
+
 {{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{if .Category}}
 
 CATEGORY:

--- a/template.go
+++ b/template.go
@@ -38,6 +38,12 @@ VERSION:
 
 var copyrightTemplate = `{{wrap .Copyright 3}}`
 
+var additionalHelpTopicsTemplate = `{{range $key, $value := .AdditionalHelpTopics}}
+
+{{$key}}:
+   {{$value}}
+{{- end}}`
+
 // RootCommandHelpTemplate is the text template for the Default help topic.
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
@@ -45,7 +51,9 @@ var RootCommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}} {{if .VisibleFlags}}[global options]{{end}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}} {{if .VisibleFlags}}[global options]{{end}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}
+
+{{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{ if .Version}}{{if not .HideVersion}}
 
 VERSION:
    {{.Version}}{{end}}{{end}}{{if .Description}}
@@ -73,7 +81,9 @@ var CommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{template "usageTemplate" .}}{{if .Category}}
+   {{template "usageTemplate" .}}
+   
+{{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{if .Category}}
 
 CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
@@ -95,7 +105,9 @@ var SubcommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}{{if .Category}}
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}
+   
+{{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{if .Category}}
 
 CATEGORY:
    {{.Category}}{{end}}{{if .Description}}

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -65,7 +65,9 @@ var CommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{template "usageTemplate" .}}{{if .Category}}
+   {{template "usageTemplate" .}}
+
+{{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{if .Category}}
 
 CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
@@ -115,7 +117,9 @@ var RootCommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}} {{if .VisibleFlags}}[global options]{{end}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}} {{if .VisibleFlags}}[global options]{{end}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}
+
+{{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{ if .Version}}{{if not .HideVersion}}
 
 VERSION:
    {{.Version}}{{end}}{{end}}{{if .Description}}
@@ -158,7 +162,9 @@ var SubcommandHelpTemplate = `NAME:
    {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}{{if .Category}}
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.FullName}}{{if .VisibleCommands}} [command [command options]]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Arguments}} [arguments...]{{end}}{{end}}{{end}}
+
+{{- if .AdditionalHelpTopics}}{{ template "additionalHelpTopicsTemplate" .}}{{end}}{{if .Category}}
 
 CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
@@ -549,6 +555,9 @@ type Command struct {
 	// A value of 0 means all arguments are treated as positional (no flag parsing).
 	// A nil value means normal v3 flag parsing behavior (flags can appear anywhere).
 	StopOnNthArg *int `json:"stopOnNthArg"`
+	// Additional topics in the help message. Used to print arbitrary help topics
+	// in addition to the default help topics.
+	AdditionalHelpTopics map[string]string `json:"additionalHelpTopics"`
 
 	// Has unexported fields.
 }


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

* This PR introduces an option to include arbitrary help topics to the help message.
* There exists a way to do this for the Root command right now, through the `ExtraInfo` field,
but that requires using a custom template. Its a bit cumbersome to use custom templates from a
users perspective just to print additional help topics.
* Given the use case to have additional help topics seems generic, this PR changes the default
help templates to conditionally render additional help topics.

## Which issue(s) this PR fixes:
Fixes https://github.com/urfave/cli/issues/2323

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

Added unit tests to test additional help topics.

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
The `AdditionalHelpTopics` field can be used to print arbitrary help topics, in addition to the existing
help topics, without the need for a custom help template.
```
