### PR TITLE
Honor env sources on duplicated flags

### DIFF
--- a/command.go
+++ b/command.go
@@ -373,6 +373,22 @@ func (cmd *Command) lFlag(name string) Flag {
 	return nil
 }
 
+func (cmd *Command) hasPersistentFlagOnAncestor(fl Flag) bool {
+	for pCmd := cmd.parent; pCmd != nil; pCmd = pCmd.parent {
+		for _, pFl := range pCmd.allFlags() {
+			if pFl != fl {
+				continue
+			}
+
+			pfl, ok := pFl.(LocalFlag)
+			if ok && !pfl.IsLocal() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (cmd *Command) lookupFlag(name string) Flag {
 	for _, pCmd := range cmd.Lineage() {
 		if f := pCmd.lFlag(name); f != nil {

--- a/command_run.go
+++ b/command_run.go
@@ -142,6 +142,9 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 	var args Args = &stringSliceArgs{rargs.Tail()}
 
 	for _, f := range cmd.allFlags() {
+		if cmd.hasPersistentFlagOnAncestor(f) {
+			continue
+		}
 		if err := f.PreParse(); err != nil {
 			return ctx, err
 		}

--- a/command_test.go
+++ b/command_test.go
@@ -3387,6 +3387,48 @@ func TestPersistentFlagIsSet(t *testing.T) {
 	require.True(t, resultIsSet)
 }
 
+func TestDuplicatePersistentFlagUsesEnvSource(t *testing.T) {
+	t.Setenv("APP_RESULT", "from-env")
+
+	resultFlag := &StringFlag{
+		Name:     "result",
+		Sources:  EnvVars("APP_RESULT"),
+		Required: true,
+	}
+
+	var beforeResult string
+	var actionResult string
+	app := &Command{
+		Name: "root",
+		Flags: []Flag{
+			resultFlag,
+		},
+		Before: func(_ context.Context, cmd *Command) (context.Context, error) {
+			beforeResult = cmd.String("result")
+			return nil, nil
+		},
+		Commands: []*Command{
+			{
+				Name: "sub",
+				Flags: []Flag{
+					resultFlag,
+				},
+				Action: func(_ context.Context, cmd *Command) error {
+					actionResult = cmd.String("result")
+					return nil
+				},
+			},
+		},
+	}
+
+	err := app.Run(context.Background(), []string{"root", "sub"})
+	require.NoError(t, err)
+	require.Equal(t, "from-env", beforeResult)
+	require.Equal(t, "from-env", actionResult)
+	require.True(t, app.IsSet("result"))
+	require.True(t, app.Command("sub").IsSet("result"))
+}
+
 func TestRequiredFlagDelayed(t *testing.T) {
 	sf := &StringFlag{
 		Name:     "result",


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

- Preserves env-source values when the same persistent flag instance is registered on an ancestor command and a subcommand.
- Skips re-preparing a shared persistent flag instance on descendant commands so the value loaded during the parent parse is not reset.
- Adds regression coverage for duplicated persistent flag env sources.

## Which issue(s) this PR fixes:

Fixes #2217

## Special notes for your reviewer:

The main behavior to review is the exact flag-instance check for inherited persistent flags.

## Testing

- go test ./... -run TestDuplicatePersistentFlagUsesEnvSource -count=1 -v
- go test ./... -run "TestPersistentFlag|TestDuplicatePersistentFlagUsesEnvSource|TestRequiredPersistentFlag|TestCommand_IsSet_fromEnv|TestCheckRequiredFlags" -count=1 -v
- go test ./... -count=1

## Release Notes

```release-note
Fixed env-source values being reset when the same persistent flag instance is registered on a parent command and subcommand.
```
