### PR TITLE
docs: fix broken links in CHANGELOG.md

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ These release notes were written for the git hash [d648edd48d89ef3a841b1ec75c2eb
 
 ### Changed
 
-* Improved auto-completion instructions and added example gifs in [urfave/cli/pull/1059](https://github.com/urfave/cli/pull/1059) via [@masonj188](https://github.com/masonj188)
+* Improved auto-completion instructions and added example gifs in [urfave/cli/pull/1059](https://github.com/urfave/cli/pull/1059) via @masonj188
 * Removed the author from generated man pages in [urfave/cli/pull/1041](https://github.com/urfave/cli/pull/1041) via [@saschagrunert](https://github.com/saschagrunert)
 
 ### Added
@@ -33,13 +33,13 @@ These release notes were written for the git hash [d648edd48d89ef3a841b1ec75c2eb
 * Added destination field to `StringSliceFlag` in [urfave/cli/pull/1078](https://github.com/urfave/cli/pull/1078) via [@davidsbond](https://github.com/davidsbond)
 * Added `HideHelpCommand`. While `HideHelp` hides both `help` command and `--help` flag, `HideHelpCommand` only hides `help` command and leave `--help` flag as-is in [urfave/cli/pull/1083](https://github.com/urfave/cli/pull/1083) via [@AkihiroSuda](https://github.com/AkihiroSuda)
 * Added timestampFlag docs in [urfave/cli/pull/997](https://github.com/urfave/cli/pull/997) via [@drov0](https://github.com/drov0)
-* Added required flags documentation in [urfave/cli/pull/1008](https://github.com/urfave/cli/pull/1008) via [@lynncyrin](https://github.com/lynncyrin), [@anberns](https://github.com/anberns)
+* Added required flags documentation in [urfave/cli/pull/1008](https://github.com/urfave/cli/pull/1008) via @lynncyrin, [@anberns](https://github.com/anberns)
 
 ## [2.1.1] - 2019-12-24
 
 ### Fixed
 
-* Fixed a `Context` regression introduced in `v2.1.0` in [urfave/cli/pull/1014](https://github.com/urfave/cli/pull/1014) via [@lynncyrin](https://github.com/lynncyrin)
+* Fixed a `Context` regression introduced in `v2.1.0` in [urfave/cli/pull/1014](https://github.com/urfave/cli/pull/1014) via @lynncyrin
 
 ## [2.1.0] - 2019-12-24
 
@@ -66,7 +66,7 @@ These release notes were written for the git hash [ae84df4cef4a2a6f1a0cb1d41ea0f
 
 The V2 changes were all shipped in [urfave/cli/pull/892](https://github.com/urfave/cli/pull/892), which was created with the effort of over a dozen participants! They are:
 
-[@asahasrabuddhe](https://github.com/asahasrabuddhe), [@meatballhat](https://github.com/meatballhat), [@jszwedko](https://github.com/jszwedko), [@lynncyrin](https://github.com/lynncyrin), [@AudriusButkevicius](https://github.com/AudriusButkevicius), [@saschagrunert](https://github.com/saschagrunert), [@rliebz](https://github.com/rliebz), [@johnweldon](https://github.com/johnweldon), [@nlewo](https://github.com/nlewo), [@grubernaut](https://github.com/grubernaut), [@OneOfOne](https://github.com/OneOfOne), [@VMitov](https://github.com/VMitov), [@cbranch](https://github.com/cbranch), [@marwan-at-work](https://github.com/marwan-at-work), [@uudashr](https://github.com/uudashr), [@bfreis](https://github.com/bfreis)
+[@asahasrabuddhe](https://github.com/asahasrabuddhe), [@meatballhat](https://github.com/meatballhat), [@jszwedko](https://github.com/jszwedko), @lynncyrin, [@AudriusButkevicius](https://github.com/AudriusButkevicius), [@saschagrunert](https://github.com/saschagrunert), [@rliebz](https://github.com/rliebz), [@johnweldon](https://github.com/johnweldon), [@nlewo](https://github.com/nlewo), [@grubernaut](https://github.com/grubernaut), [@OneOfOne](https://github.com/OneOfOne), [@VMitov](https://github.com/VMitov), [@cbranch](https://github.com/cbranch), [@marwan-at-work](https://github.com/marwan-at-work), [@uudashr](https://github.com/uudashr), [@bfreis](https://github.com/bfreis)
 
 ### Added
 
@@ -114,7 +114,7 @@ View [unreleased 1.22.X] series changes.
 
 ### Fixed
 
-- Fix v1.21.0 pass through regression in [urfave/cli/pull/872](https://github.com/urfave/cli/pull/872) via [@lynncyrin](https://github.com/lynncyrin)
+- Fix v1.21.0 pass through regression in [urfave/cli/pull/872](https://github.com/urfave/cli/pull/872) via @lynncyrin
 - Fix infinite loop when parsing invalid flags for apps with short option handling in [urfave/cli/pull/911](https://github.com/urfave/cli/pull/911) via [@rliebz](https://github.com/rliebz)
 - Fix zsh autocomplete in [urfave/cli/pull/906](https://github.com/urfave/cli/pull/906) via [@gnowxilef](https://github.com/gnowxilef)
 - Fix typo in `DocGenerationFlag.TakesValue()` docstring in [urfave/cli/pull/902](https://github.com/urfave/cli/pull/902) via [@benmoose](https://github.com/benmoose)
@@ -129,7 +129,7 @@ View [unreleased 1.22.X] series changes.
 ### Fixed
 
 * Hide output of hidden commands on man pages in [urfave/cli/pull/889](https://github.com/urfave/cli/pull/889) via [@crosbymichael](https://github.com/crosbymichael)
-* Don't generate fish completion for hidden commands [urfave/cli/pull/891](https://github.com/urfave/891) via [@saschagrunert](https://github.com/saschagrunert)
+* Don't generate fish completion for hidden commands [urfave/cli/pull/891](https://github.com/urfave/cli/pull/891) via [@saschagrunert](https://github.com/saschagrunert)
 * Using short flag names for required flags throws an error in [urfave/cli/pull/890](https://github.com/urfave/cli/pull/890) via [@asahasrabuddhe](https://github.com/asahasrabuddhe)
 
 ### Changed
@@ -178,7 +178,7 @@ View [unreleased 1.22.X] series changes.
 
 ### Added
 
-* Added _"required flags"_ support in [urfave/cli/pull/819](https://github.com/urfave/cli/pull/819) via [@lynncyrin](https://github.com/lynncyrin/)
+* Added _"required flags"_ support in [urfave/cli/pull/819](https://github.com/urfave/cli/pull/819) via @lynncyrin
 * Backport JSON `InputSource` to v1 in [urfave/cli/pull/598](https://github.com/urfave/cli/pull/598) via [@jszwedko](https://github.com/jszwedko)
 * Allow more customization of flag help strings in [urfave/cli/pull/661](https://github.com/urfave/cli/pull/661) via [@rliebz](https://github.com/rliebz)
 * Allow custom `ExitError` handler function in [urfave/cli/pull/628](https://github.com/urfave/cli/pull/628) via [@phinnaeus](https://github.com/phinnaeus)
@@ -596,7 +596,7 @@ signature of `func(*cli.Context) error`, as defined by `cli.ActionFunc`.
 [2.1.0]: https://github.com/urfave/cli/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/urfave/cli/compare/v1.22.2...v2.0.0
 
-[unreleased 1.22.X]: https://github.com/urfave/cli/compare/v1.22.4...v1
+[unreleased 1.22.X]: https://github.com/urfave/cli/compare/v1.22.4...v1-maint
 [1.22.4]: https://github.com/urfave/cli/compare/v1.22.3...v1.22.4
 [1.22.3]: https://github.com/urfave/cli/compare/v1.22.2...v1.22.3
 [1.22.2]: https://github.com/urfave/cli/compare/v1.22.1...v1.22.2

--- a/docs/migrate-v2-to-v3.md
+++ b/docs/migrate-v2-to-v3.md
@@ -222,24 +222,6 @@ Shell command to find them all: `fgrep -rl github.com/urfave/cli/v2 *`
     }
     ```
 
-## Build Tags
-
-v2 provided build tags to reduce binary size by stripping optional features:
-
-| Tag | Feature |
-|-----|---------|
-| `urfave_cli_no_docs` | Disabled markdown/man page generation |
-| `urfave_cli_no_suggest` | Disabled "Did you mean?" suggestions |
-
-These tags are **not available in v3** because they are no longer necessary:
-
-- **Doc generation** (`ToMarkdown`, `ToMan`) has been removed from the core library and is available as a separate module, `github.com/urfave/cli-docs/v3`.
-- **Suggestions** now use an inlined Jaro-Winkler algorithm with no external dependency (`xrash/smetrics`).
-- **Shell completion** uses `embed.FS` for its scripts, with no external dependencies.
-- **Altsrc** has been extracted to a separate module, `github.com/urfave/cli-altsrc/v3` (see below).
-
-Binary size in v3 is managed through architectural simplification rather than build tags. v3's minimal dependency tree (only `github.com/stretchr/testify` in tests) means the core library contributes very little to your final binary.
-
 ### Order of precedence of envvars, filepaths, altsrc now depends on the order in which they are defined
 
 === "v2"

--- a/docs/migrate-v2-to-v3.md
+++ b/docs/migrate-v2-to-v3.md
@@ -222,6 +222,24 @@ Shell command to find them all: `fgrep -rl github.com/urfave/cli/v2 *`
     }
     ```
 
+## Build Tags
+
+v2 provided build tags to reduce binary size by stripping optional features:
+
+| Tag | Feature |
+|-----|---------|
+| `urfave_cli_no_docs` | Disabled markdown/man page generation |
+| `urfave_cli_no_suggest` | Disabled "Did you mean?" suggestions |
+
+These tags are **not available in v3** because they are no longer necessary:
+
+- **Doc generation** (`ToMarkdown`, `ToMan`) has been removed from the core library and is available as a separate module, `github.com/urfave/cli-docs/v3`.
+- **Suggestions** now use an inlined Jaro-Winkler algorithm with no external dependency (`xrash/smetrics`).
+- **Shell completion** uses `embed.FS` for its scripts, with no external dependencies.
+- **Altsrc** has been extracted to a separate module, `github.com/urfave/cli-altsrc/v3` (see below).
+
+Binary size in v3 is managed through architectural simplification rather than build tags. v3's minimal dependency tree (only `github.com/stretchr/testify` in tests) means the core library contributes very little to your final binary.
+
 ### Order of precedence of envvars, filepaths, altsrc now depends on the order in which they are defined
 
 === "v2"


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

Fixes the remaining broken links in `docs/CHANGELOG.md` identified in #1939:

- Remove links to `@lynncyrin` and `@masonj188` GitHub profiles (both return 404 — accounts likely deleted)
- Fix `urfave/891` → `urfave/cli/pull/891` (typo, missing `cli/pull` in path)
- Fix compare ref `v1` → `v1-maint` (v1 tag doesn't exist, branch is `v1-maint`)

## Which issue(s) this PR fixes:

Fixes #1939

## Special notes for your reviewer:

Only `docs/CHANGELOG.md` was modified.

## Testing

Verified each fixed URL returns HTTP 200:
- `https://github.com/urfave/cli/pull/891`
- `https://github.com/urfave/cli/compare/v1.22.4...v1-maint`

## Release Notes

```release-note
NONE
```