### PR TITLE
fix: show GLOBAL OPTIONS in SubcommandHelpTemplate

### DIFF
--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -170,7 +170,9 @@ COMMANDS:{{template "visibleCommandTemplate" .}}{{end}}{{if .VisibleFlagCategori
 
 OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
 
-OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}{{if .VisiblePersistentFlags}}
+
+GLOBAL OPTIONS:{{template "visiblePersistentFlagTemplate" .}}{{end}}
 `
     SubcommandHelpTemplate is the text template for the subcommand help topic.
     cli.go uses text/template to render templates. You can render custom help

--- a/template.go
+++ b/template.go
@@ -107,7 +107,9 @@ COMMANDS:{{template "visibleCommandTemplate" .}}{{end}}{{if .VisibleFlagCategori
 
 OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
 
-OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}{{if .VisiblePersistentFlags}}
+
+GLOBAL OPTIONS:{{template "visiblePersistentFlagTemplate" .}}{{end}}
 `
 
 var FishCompletionTemplate = `# {{ .Command.Name }} fish shell completion

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -170,7 +170,9 @@ COMMANDS:{{template "visibleCommandTemplate" .}}{{end}}{{if .VisibleFlagCategori
 
 OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
 
-OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}{{if .VisiblePersistentFlags}}
+
+GLOBAL OPTIONS:{{template "visiblePersistentFlagTemplate" .}}{{end}}
 `
     SubcommandHelpTemplate is the text template for the subcommand help topic.
     cli.go uses text/template to render templates. You can render custom help


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Adds the `VisiblePersistentFlags` / `GLOBAL OPTIONS` section to `SubcommandHelpTemplate`, matching what `CommandHelpTemplate` already has.

When a subcommand has its own subcommands, `DefaultShowSubcommandHelp` uses `SubcommandHelpTemplate` to display help. This template was missing the GLOBAL OPTIONS section, so persistent flags (flags defined on parent commands) were not shown.

This affected the `subcommand --help` case when the subcommand also has subcommands, AND the `subcommand` (with no args) help case.

## Which issue(s) this PR fixes:

Fixes #2076

## Special notes for your reviewer:

Only `template.go` was modified — the `SubcommandHelpTemplate` var.

## Release Notes

```release-note
Subcommand help now correctly displays GLOBAL OPTIONS (persistent flags)
when a subcommand has its own subcommands.
```