### PR TITLE
fix: resolve remaining help invocation inconsistencies

### DIFF
--- a/command.go
+++ b/command.go
@@ -163,6 +163,8 @@ type Command struct {
 	globaVersionFlagAdded bool
 	// whether this is a completion command
 	isCompletionCommand bool
+	// whether this is the built-in help command
+	builtInHelp bool
 }
 
 // FullName returns the full name of the command.
@@ -430,7 +432,7 @@ func (cmd *Command) checkAllRequiredFlags() requiredFlagsErr {
 	// The help and completion commands are allowed to run without
 	// enforcement of required flags, since they do not invoke user
 	// actions that depend on those flag values.
-	if cmd.Name == helpName || cmd.isCompletionCommand {
+	if cmd.builtInHelp || cmd.isCompletionCommand {
 		return nil
 	}
 	for pCmd := cmd; pCmd != nil; pCmd = pCmd.parent {

--- a/command_run.go
+++ b/command_run.go
@@ -189,7 +189,7 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 				}
 			} else {
 				tracef("running ShowCommandHelp with %[1]q", cmd.Name)
-				if err := ShowCommandHelp(ctx, cmd, cmd.Name); err != nil {
+				if err := ShowCommandHelp(ctx, cmd.parent, cmd.Name); err != nil {
 					tracef("SILENTLY IGNORING ERROR running ShowCommandHelp with %[1]q %[2]v", cmd.Name, err)
 				}
 			}
@@ -243,7 +243,14 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 				if cmd.OnUsageError != nil {
 					err = cmd.OnUsageError(ctx, cmd, err, cmd.parent != nil)
 				} else {
-					_ = ShowSubcommandHelp(cmd)
+					fmt.Fprintf(cmd.Root().ErrWriter, "Incorrect Usage: %s\n\n", err.Error())
+					if cmd.parent == nil {
+						_ = ShowRootCommandHelp(cmd)
+					} else {
+						if err := ShowCommandHelp(ctx, cmd.parent, cmd.Name); err != nil {
+							_ = ShowSubcommandHelp(cmd)
+						}
+					}
 				}
 				return ctx, err
 			}
@@ -334,7 +341,14 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 		if cmd.OnUsageError != nil {
 			err = cmd.OnUsageError(ctx, cmd, err, cmd.parent != nil)
 		} else {
-			_ = ShowSubcommandHelp(cmd)
+			fmt.Fprintf(cmd.Root().ErrWriter, "Incorrect Usage: %s\n\n", err.Error())
+			if cmd.parent == nil {
+				_ = ShowRootCommandHelp(cmd)
+			} else {
+				if err := ShowCommandHelp(ctx, cmd.parent, cmd.Name); err != nil {
+					_ = ShowSubcommandHelp(cmd)
+				}
+			}
 		}
 		return ctx, err
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -1966,6 +1966,112 @@ func TestRequiredFlagCommandRunBehavior(t *testing.T) {
 	}
 }
 
+func TestCommand_IncorrectUsageOnRequiredFlagsViaRun(t *testing.T) {
+	t.Run("root command missing required flag", func(t *testing.T) {
+		r := require.New(t)
+		var buf bytes.Buffer
+		var errBuf bytes.Buffer
+
+		cmd := &Command{
+			Writer:    &buf,
+			ErrWriter: &errBuf,
+			Flags: []Flag{
+				&StringFlag{Name: "requiredFlag", Required: true},
+			},
+		}
+
+		_ = cmd.Run(buildTestContext(t), []string{"command"})
+		r.Contains(errBuf.String(), "Incorrect Usage")
+		r.Contains(buf.String(), "NAME:")
+		r.Contains(buf.String(), "command")
+	})
+
+	t.Run("subcommand missing required flag", func(t *testing.T) {
+		r := require.New(t)
+		var buf bytes.Buffer
+		var errBuf bytes.Buffer
+
+		cmd := &Command{
+			Writer:    &buf,
+			ErrWriter: &errBuf,
+			Commands: []*Command{
+				{
+					Name: "sub",
+					Flags: []Flag{
+						&StringFlag{Name: "requiredFlag", Required: true},
+					},
+					Action: func(ctx context.Context, cmd *Command) error {
+						return nil
+					},
+				},
+			},
+		}
+
+		_ = cmd.Run(buildTestContext(t), []string{"command", "sub"})
+		r.Contains(errBuf.String(), "Incorrect Usage")
+		r.Contains(buf.String(), "NAME:")
+		r.Contains(buf.String(), "sub")
+	})
+}
+
+func TestCommand_IncorrectUsageOnMutuallyExclusiveFlagsViaRun(t *testing.T) {
+	t.Run("root command with mutex violation", func(t *testing.T) {
+		r := require.New(t)
+		var buf bytes.Buffer
+		var errBuf bytes.Buffer
+
+		cmd := &Command{
+			Writer:    &buf,
+			ErrWriter: &errBuf,
+			MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
+				{
+					Flags: [][]Flag{
+						{&StringFlag{Name: "foo1"}},
+						{&StringFlag{Name: "foo2"}},
+					},
+				},
+			},
+		}
+
+		_ = cmd.Run(buildTestContext(t), []string{"command", "--foo1", "v1", "--foo2", "v2"})
+		r.Contains(errBuf.String(), "Incorrect Usage")
+		r.Contains(buf.String(), "NAME:")
+		r.Contains(buf.String(), "command")
+	})
+
+	t.Run("subcommand with mutex violation", func(t *testing.T) {
+		r := require.New(t)
+		var buf bytes.Buffer
+		var errBuf bytes.Buffer
+
+		cmd := &Command{
+			Writer:    &buf,
+			ErrWriter: &errBuf,
+			Action: func(ctx context.Context, cmd *Command) error {
+				return nil
+			},
+			Commands: []*Command{
+				{
+					Name: "sub",
+					MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
+						{
+							Flags: [][]Flag{
+								{&StringFlag{Name: "foo1"}},
+								{&StringFlag{Name: "foo2"}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_ = cmd.Run(buildTestContext(t), []string{"command", "sub", "--foo1", "v1", "--foo2", "v2"})
+		r.Contains(errBuf.String(), "Incorrect Usage")
+		r.Contains(buf.String(), "NAME:")
+		r.Contains(buf.String(), "sub")
+	})
+}
+
 func TestCommandHelpPrinter(t *testing.T) {
 	oldPrinter := HelpPrinter
 	defer func() {

--- a/command_test.go
+++ b/command_test.go
@@ -2072,6 +2072,77 @@ func TestCommand_IncorrectUsageOnMutuallyExclusiveFlagsViaRun(t *testing.T) {
 	})
 }
 
+func TestCommand_IncorrectUsageOnSubcommandWithFailingShowCommandHelp(t *testing.T) {
+	t.Run("required flags fallback to ShowSubcommandHelp", func(t *testing.T) {
+		oldShowCommandHelp := ShowCommandHelp
+		defer func() { ShowCommandHelp = oldShowCommandHelp }()
+		ShowCommandHelp = func(_ context.Context, _ *Command, _ string) error {
+			return errors.New("forced error")
+		}
+
+		r := require.New(t)
+		var buf bytes.Buffer
+		var errBuf bytes.Buffer
+
+		cmd := &Command{
+			Writer:    &buf,
+			ErrWriter: &errBuf,
+			Commands: []*Command{
+				{
+					Name: "sub",
+					Flags: []Flag{
+						&StringFlag{Name: "requiredFlag", Required: true},
+					},
+					Action: func(ctx context.Context, cmd *Command) error {
+						return nil
+					},
+				},
+			},
+		}
+
+		_ = cmd.Run(buildTestContext(t), []string{"command", "sub"})
+		r.Contains(errBuf.String(), "Incorrect Usage")
+		r.Contains(buf.String(), "sub")
+	})
+
+	t.Run("mutex flags fallback to ShowSubcommandHelp", func(t *testing.T) {
+		oldShowCommandHelp := ShowCommandHelp
+		defer func() { ShowCommandHelp = oldShowCommandHelp }()
+		ShowCommandHelp = func(_ context.Context, _ *Command, _ string) error {
+			return errors.New("forced error")
+		}
+
+		r := require.New(t)
+		var buf bytes.Buffer
+		var errBuf bytes.Buffer
+
+		cmd := &Command{
+			Writer:    &buf,
+			ErrWriter: &errBuf,
+			Action: func(ctx context.Context, cmd *Command) error {
+				return nil
+			},
+			Commands: []*Command{
+				{
+					Name: "sub",
+					MutuallyExclusiveFlags: []MutuallyExclusiveFlags{
+						{
+							Flags: [][]Flag{
+								{&StringFlag{Name: "foo1"}},
+								{&StringFlag{Name: "foo2"}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_ = cmd.Run(buildTestContext(t), []string{"command", "sub", "--foo1", "v1", "--foo2", "v2"})
+		r.Contains(errBuf.String(), "Incorrect Usage")
+		r.Contains(buf.String(), "sub")
+	})
+}
+
 func TestCommandHelpPrinter(t *testing.T) {
 	oldPrinter := HelpPrinter
 	defer func() {

--- a/help.go
+++ b/help.go
@@ -65,11 +65,12 @@ var ArgsUsageCommandHelp = "[command]"
 
 func buildHelpCommand(withAction bool) *Command {
 	cmd := &Command{
-		Name:      helpName,
-		Aliases:   []string{helpAlias},
-		Usage:     UsageCommandHelp,
-		ArgsUsage: ArgsUsageCommandHelp,
-		HideHelp:  true,
+		Name:       helpName,
+		Aliases:    []string{helpAlias},
+		Usage:      UsageCommandHelp,
+		ArgsUsage:  ArgsUsageCommandHelp,
+		HideHelp:   true,
+		builtInHelp: true,
 	}
 
 	if withAction {
@@ -100,7 +101,7 @@ func helpCommandAction(ctx context.Context, cmd *Command) error {
 	//     to
 	// $ app foo
 	// which will then be handled as case 3
-	if cmd.parent != nil && (cmd.HasName(helpName) || cmd.HasName(helpAlias)) {
+	if cmd.parent != nil && cmd.builtInHelp {
 		tracef("setting cmd to cmd.parent")
 		cmd = cmd.parent
 	}

--- a/help.go
+++ b/help.go
@@ -65,11 +65,11 @@ var ArgsUsageCommandHelp = "[command]"
 
 func buildHelpCommand(withAction bool) *Command {
 	cmd := &Command{
-		Name:       helpName,
-		Aliases:    []string{helpAlias},
-		Usage:      UsageCommandHelp,
-		ArgsUsage:  ArgsUsageCommandHelp,
-		HideHelp:   true,
+		Name:        helpName,
+		Aliases:     []string{helpAlias},
+		Usage:       UsageCommandHelp,
+		ArgsUsage:   ArgsUsageCommandHelp,
+		HideHelp:    true,
 		builtInHelp: true,
 	}
 


### PR DESCRIPTION
## What type of PR is this?
- bug
- cleanup

## What this PR does / why we need it:

Fixes four remaining help invocation inconsistencies:

1. **Built-in help command identity** — Added `builtInHelp` field to distinguish the built-in help command from user-defined commands named "help" or "h", preventing `helpCommandAction` from incorrectly matching user commands.

2. **"Incorrect Usage" prefix for required flags / mutually exclusive errors** — Parse errors printed the prefix but required flag and mutually exclusive errors did not. Now consistent.

3. **Wrong help template for leaf commands on error** — Required flag / mutex error paths used `ShowSubcommandHelp` which always uses `SubcommandHelpTemplate`, even for leaf commands. Now use `ShowCommandHelp(ctx, cmd.parent, cmd.Name)` which correctly selects `CommandHelpTemplate` (with OPTIONS) for leaf commands.

4. **Parse error help lookup was broken for subcommands** — `ShowCommandHelp(ctx, cmd, cmd.Name)` searched cmd in its own Commands (always failing). Fixed to `ShowCommandHelp(ctx, cmd.parent, cmd.Name)`.

5. **checkAllRequiredFlags** uses `cmd.builtInHelp` instead of fragile `cmd.Name == helpName` check.

## Which issue(s) this PR fixes:
Related to #2126

## Testing
All existing tests pass.

```release-note
Help output for required flag and mutually exclusive flag errors now shows the correct template and includes the "Incorrect Usage" prefix.
```