### PR TITLE
fix: skip After hook when help is displayed on subcommand

### DIFF
--- a/command_run.go
+++ b/command_run.go
@@ -9,6 +9,8 @@ import (
 	"unicode"
 )
 
+type helpShownKey struct{}
+
 func (cmd *Command) parseArgsFromStdin() ([]string, error) {
 	type state int
 	const (
@@ -176,6 +178,7 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 
 		cmd.isInError = true
 		if cmd.checkHelp() {
+			ctx = context.WithValue(ctx, helpShownKey{}, true)
 			if cmd.parent == nil {
 				_ = ShowRootCommandHelp(cmd)
 			} else {
@@ -210,6 +213,7 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 	}
 
 	if cmd.checkHelp() {
+		ctx = context.WithValue(ctx, helpShownKey{}, true)
 		return ctx, helpCommandAction(ctx, cmd)
 	} else {
 		tracef("no help is wanted (cmd=%[1]q)", cmd.Name)
@@ -234,6 +238,9 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 
 	if cmd.After != nil && !cmd.Root().shellCompletion {
 		defer func() {
+			if ctx.Value(helpShownKey{}) != nil {
+				return
+			}
 			if err := cmd.After(ctx, cmd); err != nil {
 				err = cmd.handleExitCoder(ctx, err)
 

--- a/command_test.go
+++ b/command_test.go
@@ -1810,6 +1810,50 @@ func TestCommand_AfterFunc(t *testing.T) {
 	assert.Equal(t, 0, counts.SubCommand, "Subcommand not executed when expected")
 }
 
+func TestCommand_AfterNotCalledOnSubcommandHelp(t *testing.T) {
+	var afterCalled bool
+	cmd := &Command{
+		After: func(_ context.Context, _ *Command) error {
+			afterCalled = true
+			return nil
+		},
+		Commands: []*Command{
+			{
+				Name: "sub",
+				Action: func(context.Context, *Command) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"app", "sub", "--help"})
+	require.NoError(t, err)
+	assert.False(t, afterCalled, "After should not be called when --help is passed to subcommand")
+}
+
+func TestCommand_AfterStillCalledOnNormalSubcommand(t *testing.T) {
+	var afterCalled bool
+	cmd := &Command{
+		After: func(_ context.Context, _ *Command) error {
+			afterCalled = true
+			return nil
+		},
+		Commands: []*Command{
+			{
+				Name: "sub",
+				Action: func(context.Context, *Command) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"app", "sub"})
+	require.NoError(t, err)
+	assert.True(t, afterCalled, "After should be called on normal subcommand execution")
+}
+
 func TestCommandNoHelpFlag(t *testing.T) {
 	oldFlag := HelpFlag
 	defer func() {
@@ -2431,7 +2475,6 @@ func TestCommand_HelpFlagTakesPrecedenceOverParseErrors(t *testing.T) {
 		r.Contains(buf.String(), "foo")
 		r.NotContains(errBuf.String(), "Incorrect Usage")
 	})
-<<<<<<< HEAD
 
 	t.Run("subcommand with bad flag shows Incorrect Usage and help", func(t *testing.T) {
 		r := require.New(t)

--- a/command_test.go
+++ b/command_test.go
@@ -2431,6 +2431,7 @@ func TestCommand_HelpFlagTakesPrecedenceOverParseErrors(t *testing.T) {
 		r.Contains(buf.String(), "foo")
 		r.NotContains(errBuf.String(), "Incorrect Usage")
 	})
+<<<<<<< HEAD
 
 	t.Run("subcommand with bad flag shows Incorrect Usage and help", func(t *testing.T) {
 		r := require.New(t)


### PR DESCRIPTION
## Summary

Fixes #2250 — when `--help` is passed to a subcommand, the parent command's `After` hook was firing even though the parent's `Before` hook was never called. This violates the expected invariant that `After` should only be called when `Before` was also called.

## Root Cause

In `command_run.go`, the `After` hook is registered as a deferred call at line 227, before the subcommand dispatch (line 298) and the `Before` chain (line 312). When a subcommand receives `--help`, the subcommand's `run()` returns early at the help check (line 205), never reaching the `Before` chain. The parent's deferred `After` then fires without the corresponding `Before`.

## Fix

Track help invocation via a `helpShownKey` in the context. When `--help` is detected (both in the success path and the parse-error-then-help path), set the key in the context before returning. The deferred `After` hook checks this key and returns early if help was the reason for early exit.

## Tests Added

- `TestCommand_AfterNotCalledOnSubcommandHelp` — verifies `After` is NOT called when `app sub --help` is used
- `TestCommand_AfterStillCalledOnNormalSubcommand` — verifies `After` IS called for normal `app sub` execution