### PR TITLE
fix: align gfmrun example counter with actual runnable count

### DIFF
--- a/docs/v3/binary-size.md
+++ b/docs/v3/binary-size.md
@@ -3,7 +3,7 @@
 Go removes unreachable code during compilation, so the first step is to
 measure the binary you ship instead of assuming a specific feature is expensive.
 
-```sh
+```sh-session
 go build -trimpath -o myapp ./cmd/myapp
 ls -lh myapp
 ```
@@ -11,14 +11,14 @@ ls -lh myapp
 For a release-style build, combine reproducible paths with stripped symbol and
 debug information:
 
-```sh
+```sh-session
 go build -trimpath -ldflags="-s -w" -o myapp ./cmd/myapp
 ls -lh myapp
 ```
 
 Use the Go toolchain to inspect what is in the binary:
 
-```sh
+```sh-session
 go version -m myapp
 go tool nm -size myapp | sort -nr | head -40
 ```

--- a/docs/v3/path-and-walk.md
+++ b/docs/v3/path-and-walk.md
@@ -26,21 +26,23 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
+	"strings"
 
 	"github.com/urfave/cli/v3"
 )
 
 func main() {
-	subSubCmd := &cli.Command{Name: "bottom", Action: func(context.Context, *cli.Command) error { return nil }}
-	subCmd := &cli.Command{Name: "mid", Subcommands: []*cli.Command{subSubCmd}, Action: func(context.Context, *cli.Command) error { return nil }}
-	cmd := &cli.Command{
-		Name: "top",
-		Subcommands: []*cli.Command{subCmd},
+	subSubCmd := &cli.Command{
+		Name: "bottom",
 		Action: func(ctx context.Context, c *cli.Command) error {
 			fmt.Println(strings.Join(c.Path(), " "))
 			return nil
 		},
+	}
+	subCmd := &cli.Command{Name: "mid", Commands: []*cli.Command{subSubCmd}, Action: func(context.Context, *cli.Command) error { return nil }}
+	cmd := &cli.Command{
+		Name:     "top",
+		Commands: []*cli.Command{subCmd},
 	}
 
 	cmd.Run(context.Background(), []string{"top", "mid", "bottom"})
@@ -66,17 +68,16 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/urfave/cli/v3"
 )
 
 func main() {
 	subSubCmd := &cli.Command{Name: "bottom", Action: func(context.Context, *cli.Command) error { return nil }}
-	subCmd := &cli.Command{Name: "mid", Subcommands: []*cli.Command{subSubCmd}, Action: func(context.Context, *cli.Command) error { return nil }}
+	subCmd := &cli.Command{Name: "mid", Commands: []*cli.Command{subSubCmd}, Action: func(context.Context, *cli.Command) error { return nil }}
 	cmd := &cli.Command{
 		Name: "top",
-		Subcommands: []*cli.Command{subCmd},
+		Commands: []*cli.Command{subCmd},
 		Action: func(ctx context.Context, c *cli.Command) error { return nil },
 	}
 
@@ -105,19 +106,19 @@ Return a non-nil error from the walk function to stop traversal early.
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/urfave/cli/v3"
 )
 
 func main() {
 	subSubCmd := &cli.Command{Name: "bottom", Action: func(context.Context, *cli.Command) error { return nil }}
-	subCmd := &cli.Command{Name: "mid", Subcommands: []*cli.Command{subSubCmd}, Action: func(context.Context, *cli.Command) error { return nil }}
+	subCmd := &cli.Command{Name: "mid", Commands: []*cli.Command{subSubCmd}, Action: func(context.Context, *cli.Command) error { return nil }}
 	cmd := &cli.Command{
 		Name: "top",
-		Subcommands: []*cli.Command{subCmd},
+		Commands: []*cli.Command{subCmd},
 		Action: func(ctx context.Context, c *cli.Command) error { return nil },
 	}
 

--- a/scripts/build.go
+++ b/scripts/build.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -362,6 +363,9 @@ func GfmrunActionFunc(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	var counter int
+	inGoBlock := false
+	goHasPkgMain := false
+	fenceRe := regexp.MustCompile("^(`{3,}|~{3,})")
 
 	for _, src := range sources {
 		file, err := os.Open(src)
@@ -372,7 +376,33 @@ func GfmrunActionFunc(ctx context.Context, cmd *cli.Command) error {
 
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
-			if strings.Contains(scanner.Text(), "package main") {
+			line := scanner.Text()
+			fenceMatch := fenceRe.FindString(line)
+			if fenceMatch == "" {
+				if inGoBlock && strings.HasPrefix(line, "package main") {
+					goHasPkgMain = true
+				}
+				continue
+			}
+
+			lang := strings.TrimSpace(line[len(fenceMatch):])
+
+			if inGoBlock {
+				if goHasPkgMain {
+					counter++
+				}
+				inGoBlock = false
+				goHasPkgMain = false
+				continue
+			}
+
+			switch lang {
+			case "go":
+				inGoBlock = true
+				goHasPkgMain = false
+			case "sh":
+				counter++
+			case "bash":
 				counter++
 			}
 		}


### PR DESCRIPTION
Replaces the naive `strings.Contains(line, "package main")` counter with a proper code-fence parser that mirrors gfmrun's own logic:

- Count `go` blocks only when their first code line is `package main`
- Count `sh` and `bash` blocks exactly (not `sh-session`)
- Changes informational `sh` examples in `binary-size.md` to `sh-session` (they reference `./cmd/myapp` which does not exist in CI)
- Fixes code examples in `path-and-walk.md` (broken imports, missing `context`, wrong `Subcommands` field name)

Closes #2362