### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/docs/v1/examples/generated-help-text.md
+++ b/docs/v1/examples/generated-help-text.md
@@ -63,7 +63,7 @@ VERSION:
 `
 
   // EXAMPLE: Replace the `HelpPrinter` func
-  cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+  cli.HelpPrinter = func(w io.Writer, templ string, data any) {
     fmt.Println("Ha HA.  I pwnd the help!!1")
   }
 

--- a/docs/v1/examples/version-flag.md
+++ b/docs/v1/examples/version-flag.md
@@ -110,7 +110,7 @@ func init() {
   cli.BashCompletionFlag = cli.BoolFlag{Name: "compgen", Hidden: true}
   cli.VersionFlag = cli.BoolFlag{Name: "print-version, V"}
 
-  cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+  cli.HelpPrinter = func(w io.Writer, templ string, data any) {
     fmt.Fprintf(w, "best of luck to you\n")
   }
   cli.VersionPrinter = func(c *cli.Context) {
@@ -345,7 +345,7 @@ func main() {
     app.ErrWriter = &hexWriter{}
   }
 
-  app.Metadata = map[string]interface{}{
+  app.Metadata = map[string]any{
     "layers":     "many",
     "explicable": false,
     "whatever-values": 19.99,

--- a/docs/v2/examples/full-api-example.md
+++ b/docs/v2/examples/full-api-example.md
@@ -34,7 +34,7 @@ func init() {
 	cli.HelpFlag = &cli.BoolFlag{Name: "halp"}
 	cli.VersionFlag = &cli.BoolFlag{Name: "print-version", Aliases: []string{"V"}}
 
-	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+	cli.HelpPrinter = func(w io.Writer, templ string, data any) {
 		fmt.Fprintf(w, "best of luck to you\n")
 	}
 	cli.VersionPrinter = func(cCtx *cli.Context) {
@@ -242,7 +242,7 @@ func main() {
 			fmt.Printf("made it!\n")
 			return ec
 		},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"layers":          "many",
 			"explicable":      false,
 			"whatever-values": 19.99,

--- a/docs/v2/examples/generated-help-text.md
+++ b/docs/v2/examples/generated-help-text.md
@@ -64,7 +64,7 @@ VERSION:
 `
 
 	// EXAMPLE: Replace the `HelpPrinter` func
-	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+	cli.HelpPrinter = func(w io.Writer, templ string, data any) {
 		fmt.Println("Ha HA.  I pwnd the help!!1")
 	}
 

--- a/docs/v3/examples/full-api-example.md
+++ b/docs/v3/examples/full-api-example.md
@@ -35,7 +35,7 @@ func init() {
 	cli.HelpFlag = &cli.BoolFlag{Name: "halp"}
 	cli.VersionFlag = &cli.BoolFlag{Name: "print-version", Aliases: []string{"V"}}
 
-	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+	cli.HelpPrinter = func(w io.Writer, templ string, data any) {
 		fmt.Fprintf(w, "best of luck to you\n")
 	}
 	cli.VersionPrinter = func(cmd *cli.Command) {
@@ -216,7 +216,7 @@ func main() {
 			fmt.Printf("made it!\n")
 			return ec
 		},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"layers":          "many",
 			"explicable":      false,
 			"whatever-values": 19.99,

--- a/docs/v3/examples/help/generated-help-text.md
+++ b/docs/v3/examples/help/generated-help-text.md
@@ -64,7 +64,7 @@ VERSION:
 `
 
 	// EXAMPLE: Replace the `HelpPrinter` func
-	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+	cli.HelpPrinter = func(w io.Writer, templ string, data any) {
 		fmt.Println("Ha HA.  I pwnd the help!!1")
 	}
 

--- a/help_test.go
+++ b/help_test.go
@@ -520,7 +520,7 @@ func TestShowCommandHelp_HelpPrinter(t *testing.T) {
 		/*{
 			name:     "standard-command",
 			template: "",
-			printer: func(w io.Writer, templ string, data interface{}) {
+			printer: func(w io.Writer, templ string, data any) {
 				fmt.Fprint(w, "yo")
 			},
 			command:      "my-command",
@@ -530,9 +530,9 @@ func TestShowCommandHelp_HelpPrinter(t *testing.T) {
 		{
 			name:     "custom-template-command",
 			template: "{{doublecho .Name}}",
-			printer: func(w io.Writer, templ string, data interface{}) {
+			printer: func(w io.Writer, templ string, data any) {
 				// Pass a custom function to ensure it gets used
-				fm := map[string]interface{}{"doublecho": doublecho}
+				fm := map[string]any{"doublecho": doublecho}
 				HelpPrinterCustom(w, templ, data, fm)
 			},
 			command:      "my-command",


### PR DESCRIPTION
Replace `interface{}` with `any` (available since Go 1.18).

Changes made in 7 files:
- `help_test.go`
- `docs/v1/examples/generated-help-text.md`
- `docs/v1/examples/version-flag.md`
- `docs/v2/examples/full-api-example.md`
- `docs/v2/examples/generated-help-text.md`
- `docs/v3/examples/full-api-example.md`
- `docs/v3/examples/help/generated-help-text.md`