### PR TITLE
fix: keep completion subcommand order deterministic in help output

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -20,6 +20,12 @@ var (
 	//go:embed autocomplete
 	autoCompleteFS embed.FS
 
+	// completionShells defines the order in which the shell completion
+	// subcommands appear in help output. Iterating shellCompletions directly
+	// would use Go's randomized map order, making the listing nondeterministic.
+	// Keep this in sync with shellCompletions.
+	completionShells = []string{"bash", "zsh", "fish", "pwsh"}
+
 	shellCompletions = map[string]renderCompletion{
 		"bash": func(c *Command, appName string) (string, error) {
 			b, err := autoCompleteFS.ReadFile("autocomplete/bash_autocomplete")
@@ -65,8 +71,8 @@ func buildCompletionCommand(appName string) *Command {
 		isCompletionCommand: true,
 	}
 
-	for shell, render := range shellCompletions {
-		cmd.Commands = append(cmd.Commands, buildShellCompletionSubcommand(shell, render, appName))
+	for _, shell := range completionShells {
+		cmd.Commands = append(cmd.Commands, buildShellCompletionSubcommand(shell, shellCompletions[shell], appName))
 	}
 
 	return cmd

--- a/completion_test.go
+++ b/completion_test.go
@@ -519,6 +519,9 @@ func TestCompletionShellRenderError(t *testing.T) {
 		}
 		return "something", nil
 	}
+	// buildCompletionCommand only turns shells listed in completionShells into
+	// subcommands, so register the injected shell there too (restoring the
+	// original slice afterward) for it to be reachable.
 	defer func(orig []string) { completionShells = orig }(completionShells)
 	completionShells = append(completionShells, unknownShellName)
 	defer func() {
@@ -549,6 +552,9 @@ func TestCompletionShellWriteError(t *testing.T) {
 	shellCompletions[shellName] = func(c *Command, appName string) (string, error) {
 		return "something", nil
 	}
+	// buildCompletionCommand only turns shells listed in completionShells into
+	// subcommands, so register the injected shell there too (restoring the
+	// original slice afterward) for it to be reachable.
 	defer func(orig []string) { completionShells = orig }(completionShells)
 	completionShells = append(completionShells, shellName)
 	defer func() {

--- a/completion_test.go
+++ b/completion_test.go
@@ -118,6 +118,31 @@ func TestCompletionShell(t *testing.T) {
 	}
 }
 
+func TestCompletionSubcommandOrder(t *testing.T) {
+	// The completion subcommands must appear in a deterministic order so that
+	// help output (and docs generated from it) does not change between runs.
+	// Previously they were built by iterating a map, whose order Go randomizes.
+	want := []string{"bash", "zsh", "fish", "pwsh"}
+
+	// Build several times to guard against intra-process variation.
+	for range 10 {
+		cmd := buildCompletionCommand("foo")
+
+		got := make([]string, 0, len(cmd.Commands))
+		for _, sub := range cmd.Commands {
+			got = append(got, sub.Name)
+		}
+
+		assert.Equal(t, want, got)
+	}
+
+	// Every shell in shellCompletions must be represented in the ordered list.
+	assert.Len(t, completionShells, len(shellCompletions))
+	for shell := range shellCompletions {
+		assert.Contains(t, completionShells, shell)
+	}
+}
+
 func TestCompletionBashNoShebang(t *testing.T) {
 	// Regression test for https://github.com/urfave/cli/issues/2259
 	// Bash completion scripts are sourced, not executed, so they must not
@@ -494,6 +519,8 @@ func TestCompletionShellRenderError(t *testing.T) {
 		}
 		return "something", nil
 	}
+	defer func(orig []string) { completionShells = orig }(completionShells)
+	completionShells = append(completionShells, unknownShellName)
 	defer func() {
 		delete(shellCompletions, unknownShellName)
 	}()
@@ -522,6 +549,8 @@ func TestCompletionShellWriteError(t *testing.T) {
 	shellCompletions[shellName] = func(c *Command, appName string) (string, error) {
 		return "something", nil
 	}
+	defer func(orig []string) { completionShells = orig }(completionShells)
+	completionShells = append(completionShells, shellName)
 	defer func() {
 		delete(shellCompletions, shellName)
 	}()


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The `completion` command exposes each shell as its own subcommand (`bash`, `zsh`, `fish`, `pwsh`), introduced in #2279 (released in v3.9.1). The subcommands were generated by ranging over the `shellCompletions` map in `buildCompletionCommand`:

```go
for shell, render := range shellCompletions {
    cmd.Commands = append(cmd.Commands, buildShellCompletionSubcommand(shell, render, appName))
}
```

Go randomizes map iteration order per process, so the order of these subcommands — and therefore the `COMMANDS:` section of `completion --help` — changed between runs. This breaks downstream projects that generate documentation from `--help` output and commit it via CI: the generated docs flip-flop depending on which run produced them, creating spurious diffs and noise commits. Real-world impact: https://github.com/suzuki-shunsuke/ghtkn/pull/454

Changes:

- `completion.go`: add `completionShells = []string{"bash", "zsh", "fish", "pwsh"}`, an explicitly ordered list of the supported shells, and iterate it (looking the renderer up in `shellCompletions`) instead of ranging over the map. The map stays as the renderer registry; the slice fixes the display order. The order is now deterministic on every run.
- `completion_test.go`: add `TestCompletionSubcommandOrder`, which asserts the subcommand order is always `bash, zsh, fish, pwsh` and that every shell in `shellCompletions` is also present in `completionShells` (so the two cannot silently drift). `TestCompletionShellRenderError` and `TestCompletionShellWriteError` inject a custom shell into `shellCompletions`; they now also register it in `completionShells` (with restore) so the injected shell still becomes a subcommand.

## Which issue(s) this PR fixes:

Fixes #2373

## Special notes for your reviewer:

The display order is fixed to `bash, zsh, fish, pwsh`. If you would prefer alphabetical order instead, that is a one-line change to `completionShells`.

## Testing

- `go test ./...` passes.
- The completion tests are stable across repeated `go test` invocations (separate processes), where the subcommand order previously varied.

## Release Notes

```release-note
Fix non-deterministic ordering of `completion` shell subcommands in help output; they now always appear as bash, zsh, fish, pwsh.
```
