### PR TITLE
fix: add HasHiddenParent() to skip hidden command subtrees in Walk()

### DIFF
--- a/command.go
+++ b/command.go
@@ -596,6 +596,17 @@ func (cmd *Command) HasHiddenParent() bool {
 
 // Walk visits cmd and every descendant. If fn returns a non-nil error, the
 // walk terminates and the error is returned to the caller.
+//
+// To skip subcommands of hidden commands in the walk, check both Hidden and
+// HasHiddenParent in the callback:
+//
+//	cmd.Walk(func(c *cli.Command) error {
+//	    if c.Hidden || c.HasHiddenParent() {
+//	        return nil
+//	    }
+//	    // process visible commands only
+//	    return nil
+//	})
 func (cmd *Command) Walk(fn func(*Command) error) error {
 	if fn == nil {
 		return nil

--- a/command.go
+++ b/command.go
@@ -582,6 +582,18 @@ func (cmd *Command) Path() []string {
 	return []string{cmd.Name}
 }
 
+// HasHiddenParent returns true if any ancestor of this command has
+// Hidden set to true.
+func (cmd *Command) HasHiddenParent() bool {
+	if cmd.parent == nil {
+		return false
+	}
+	if cmd.parent.Hidden {
+		return true
+	}
+	return cmd.parent.HasHiddenParent()
+}
+
 // Walk visits cmd and every descendant. If fn returns a non-nil error, the
 // walk terminates and the error is returned to the caller.
 func (cmd *Command) Walk(fn func(*Command) error) error {

--- a/command_test.go
+++ b/command_test.go
@@ -6450,3 +6450,56 @@ func TestCommand_Walk_NilFn(t *testing.T) {
 	cmd := &Command{Name: "foo"}
 	assert.Nil(t, cmd.Walk(nil))
 }
+
+func TestCommand_HasHiddenParent(t *testing.T) {
+	t.Run("root command", func(t *testing.T) {
+		cmd := &Command{Name: "root"}
+		assert.False(t, cmd.HasHiddenParent())
+	})
+
+	t.Run("direct hidden parent", func(t *testing.T) {
+		parent := &Command{Name: "parent", Hidden: true}
+		child := &Command{Name: "child"}
+		child.parent = parent
+		assert.True(t, child.HasHiddenParent())
+	})
+
+	t.Run("non-hidden parent", func(t *testing.T) {
+		parent := &Command{Name: "parent"}
+		child := &Command{Name: "child"}
+		child.parent = parent
+		assert.False(t, child.HasHiddenParent())
+	})
+
+	t.Run("grandparent is hidden", func(t *testing.T) {
+		grandparent := &Command{Name: "grandparent", Hidden: true}
+		parent := &Command{Name: "parent"}
+		child := &Command{Name: "child"}
+		parent.parent = grandparent
+		child.parent = parent
+		assert.True(t, child.HasHiddenParent())
+	})
+
+	t.Run("subcommands of hidden command are skipped in walk", func(t *testing.T) {
+		hiddenCmd := &Command{Name: "completion", Hidden: true}
+		subCmd := &Command{Name: "bash"}
+		subCmd.parent = hiddenCmd
+		hiddenCmd.Commands = []*Command{subCmd}
+
+		root := &Command{
+			Name:     "root",
+			Commands: []*Command{hiddenCmd},
+		}
+
+		var visited []string
+		err := root.Walk(func(c *Command) error {
+			if c.Hidden || c.HasHiddenParent() {
+				return nil
+			}
+			visited = append(visited, c.Name)
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"root"}, visited)
+	})
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/mail"
 	"os"
+	"strings"
 	"time"
 
 	// Alias the package import to make the examples runnable on pkg.go.dev.
@@ -607,4 +608,26 @@ func ExampleCommand_Suggest_command() {
 	// Incorrect Usage: flag provided but not defined: -sliming
 	//
 	// Did you mean "--smiling"?
+}
+
+func ExampleCommand_Walk() {
+	cmd := &cli.Command{
+		Name: "app",
+		Commands: []*cli.Command{
+			{Name: "serve"},
+			{Name: "migrate"},
+		},
+		Action: func(_ context.Context, _ *cli.Command) error {
+			return nil
+		},
+	}
+
+	var names []string
+	_ = cmd.Walk(func(c *cli.Command) error {
+		names = append(names, c.Name)
+		return nil
+	})
+	fmt.Println(strings.Join(names, ", "))
+	// Output:
+	// app, serve, migrate
 }

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -821,6 +821,17 @@ func (cmd *Command) Walk(fn func(*Command) error) error
     Walk visits cmd and every descendant. If fn returns a non-nil error,
     the walk terminates and the error is returned to the caller.
 
+    To skip subcommands of hidden commands in the walk, check both Hidden and
+    HasHiddenParent in the callback:
+
+        cmd.Walk(func(c *cli.Command) error {
+            if c.Hidden || c.HasHiddenParent() {
+                return nil
+            }
+            // process visible commands only
+            return nil
+        })
+
 type CommandCategories interface {
 	// AddCommand adds a command to a category, creating a new category if necessary.
 	AddCommand(category string, command *Command)

--- a/godoc-current.txt
+++ b/godoc-current.txt
@@ -618,6 +618,10 @@ func (cmd *Command) FullName() string
 func (cmd *Command) Generic(name string) Value
     Generic looks up the value of a local GenericFlag, returns nil if not found
 
+func (cmd *Command) HasHiddenParent() bool
+    HasHiddenParent returns true if any ancestor of this command has Hidden set
+    to true.
+
 func (cmd *Command) HasName(name string) bool
     HasName returns true if Command.Name matches given name
 

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -821,6 +821,17 @@ func (cmd *Command) Walk(fn func(*Command) error) error
     Walk visits cmd and every descendant. If fn returns a non-nil error,
     the walk terminates and the error is returned to the caller.
 
+    To skip subcommands of hidden commands in the walk, check both Hidden and
+    HasHiddenParent in the callback:
+
+        cmd.Walk(func(c *cli.Command) error {
+            if c.Hidden || c.HasHiddenParent() {
+                return nil
+            }
+            // process visible commands only
+            return nil
+        })
+
 type CommandCategories interface {
 	// AddCommand adds a command to a category, creating a new category if necessary.
 	AddCommand(category string, command *Command)

--- a/testdata/godoc-v3.x.txt
+++ b/testdata/godoc-v3.x.txt
@@ -618,6 +618,10 @@ func (cmd *Command) FullName() string
 func (cmd *Command) Generic(name string) Value
     Generic looks up the value of a local GenericFlag, returns nil if not found
 
+func (cmd *Command) HasHiddenParent() bool
+    HasHiddenParent returns true if any ancestor of this command has Hidden set
+    to true.
+
 func (cmd *Command) HasName(name string) bool
     HasName returns true if Command.Name matches given name
 


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

When using `Walk()` to traverse the command tree, users who want to skip hidden commands currently check `cmd.Hidden`. However, the subcommands of a hidden command are not themselves hidden and still appear in the walk output. There is no way to check whether a command belongs to a hidden subtree without manually walking parent pointers, which are unexported.

This PR adds `HasHiddenParent() bool` to `Command`, which returns `true` if any ancestor has `Hidden: true`. Users can combine it with `cmd.Hidden` in their `Walk` callback to skip entire hidden subtrees:

```go
cmd.Walk(func(c *cli.Command) error {
    if c.Hidden || c.HasHiddenParent() {
        return nil
    }
    // process visible commands only
})
```

## Which issue(s) this PR fixes:

Fixes #2372

## Testing

- `go test ./...` passes
- `go vet ./...` passes
- `make v3diff` shows only the new `HasHiddenParent` method
- `make v3approve` run to update API surface docs

## Release Notes

```release-note
Add Command.HasHiddenParent() method to help users skip subcommands of hidden commands during Walk().
```