### PR TITLE
Escape backslashes in fish completion descriptions

### DIFF
--- a/fish.go
+++ b/fish.go
@@ -216,6 +216,15 @@ func commandAncestry(command *Command) string {
 	return strings.Join(ancestry, "; and ")
 }
 
+// escapeSingleQuotes escapes a string for use inside a fish single-quoted
+// string, such as a `-d '...'` description. Within single quotes fish only
+// recognizes the escape sequences \\ and \', so the backslash must be escaped
+// as well as the single quote. Escaping the quote without escaping the
+// backslash corrupts any description that contains a backslash, and a trailing
+// backslash even leaves the single-quoted string unterminated.
+// See https://fishshell.com/docs/current/language.html
 func escapeSingleQuotes(input string) string {
-	return strings.ReplaceAll(input, `'`, `\'`)
+	return fishSingleQuoteReplacer.Replace(input)
 }
+
+var fishSingleQuoteReplacer = strings.NewReplacer(`\`, `\\`, `'`, `\'`)

--- a/fish_test.go
+++ b/fish_test.go
@@ -41,6 +41,38 @@ func TestFishCompletion(t *testing.T) {
 	expectFileContent(t, "testdata/expected-fish-full.fish", res)
 }
 
+func TestFishCompletionBackslashEscaping(t *testing.T) {
+	// Inside fish single-quoted strings the only escape sequences are \\ and
+	// \', so a backslash in a description must be emitted as \\. An unescaped
+	// backslash silently corrupts the description, and a trailing one turns the
+	// closing quote into an escaped quote, leaving the string unterminated.
+	// Ref: https://fishshell.com/docs/current/language.html
+	cmd := &Command{
+		Name: "greet",
+		Flags: []Flag{
+			&StringFlag{
+				Name:  "path",
+				Usage: `match \d+ then C:\tmp\`,
+			},
+		},
+		Commands: []*Command{
+			{
+				Name:  "win",
+				Usage: `run under C:\sys\`,
+			},
+		},
+	}
+	cmd.setupCommandGraph()
+
+	res, err := cmd.ToFishCompletion()
+	require.NoError(t, err)
+
+	// Both the flag and the subcommand descriptions must have their backslashes
+	// doubled in the generated `-d '...'` tokens.
+	assert.Contains(t, res, `-d 'match \\d+ then C:\\tmp\\'`)
+	assert.Contains(t, res, `-d 'run under C:\\sys\\'`)
+}
+
 func TestFishCompletionShellComplete(t *testing.T) {
 	cmd := buildExtendedTestCommand()
 	cmd.ShellComplete = func(context.Context, *Command) {}


### PR DESCRIPTION
## What type of PR is this?

bug

## What this PR does / why we need it:

`ToFishCompletion` writes flag and command descriptions into fish `-d '...'` tokens and escapes them with `escapeSingleQuotes`. That helper only replaced `'` with `\'` and left backslashes untouched.

Inside a fish single-quoted string the only escape sequences are `\\` and `\'` (https://fishshell.com/docs/current/language.html). An unescaped backslash in a usage string is therefore mis-parsed:

- A trailing backslash turns the closing quote into an escaped quote (`\'`), so the description is never terminated and the rest of the script is swallowed. A usage of `C:\tmp\` was emitted as `-d 'C:\tmp\'`.
- A doubled backslash such as a UNC path `\\server` collapsed down to a single one.

This escapes the backslash as `\\` in addition to the existing single-quote handling.

- `fish.go`: `escapeSingleQuotes` now doubles backslashes as well as escaping single quotes, using a `strings.Replacer`.
- `fish_test.go`: adds `TestFishCompletionBackslashEscaping`, covering a flag and a subcommand whose usage contains backslashes.

Usage strings without backslashes are unaffected, so existing output (including `testdata/expected-fish-full.fish`) is unchanged.

## Which issue(s) this PR fixes:

NONE

## Testing

`go test ./...` passes. The new test fails before the change, where the descriptions are emitted with single, unescaped backslashes, and passes after it.

## Release Notes

```release-note
Fix fish completion so backslashes in flag and command usage descriptions are escaped correctly.
```
