### PR TITLE
fix: avoid executing actions when completing `--` in v2

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1850,6 +1850,36 @@ func TestApp_OrderOfOperations(t *testing.T) {
 	app.Commands = oldCommands
 }
 
+func TestApp_Run_DoubleDashShellCompletionDoesNotExecuteAction(t *testing.T) {
+	origArgv := os.Args
+	t.Cleanup(func() {
+		os.Args = origArgv
+	})
+
+	var output bytes.Buffer
+	actionCalled := false
+
+	app := &App{
+		EnableBashCompletion: true,
+		HideHelp:             true,
+		Writer:               &output,
+		Flags: []Flag{
+			&BoolFlag{Name: "verbose"},
+		},
+		Action: func(c *Context) error {
+			actionCalled = true
+			return nil
+		},
+	}
+
+	os.Args = []string{"command", "--", "--generate-bash-completion"}
+
+	err := app.Run(os.Args)
+	expect(t, err, nil)
+	expect(t, actionCalled, false)
+	expect(t, output.String(), "--verbose\n")
+}
+
 func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 	var subcommandHelpTopics = [][]string{
 		{"command", "foo", "--help"},

--- a/help.go
+++ b/help.go
@@ -447,12 +447,18 @@ func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
 		return false, arguments
 	}
 
-	for _, arg := range arguments {
-		// If arguments include "--", shell completion is disabled
-		// because after "--" only positional arguments are accepted.
-		// https://unix.stackexchange.com/a/11382
+	// If arguments include "--" before the token being completed, shell
+	// completion is disabled because after "--" only positional arguments are
+	// accepted. We only check arguments before the token being completed so
+	// completing "--" itself still works.
+	// https://unix.stackexchange.com/a/11382
+	limit := 0
+	if pos > 1 {
+		limit = pos - 1
+	}
+	for _, arg := range arguments[:limit] {
 		if arg == "--" {
-			return false, arguments
+			return false, arguments[:pos]
 		}
 	}
 

--- a/help.go
+++ b/help.go
@@ -449,16 +449,12 @@ func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
 
 	// If arguments include "--" before the token being completed, shell
 	// completion is disabled because after "--" only positional arguments are
-	// accepted. We only check arguments before the token being completed so
-	// completing "--" itself still works.
+	// accepted. If "--" is itself the token being completed, keep completion
+	// enabled so long-flag suggestions still work.
 	// https://unix.stackexchange.com/a/11382
-	limit := 0
-	if pos > 1 {
-		limit = pos - 1
-	}
-	for _, arg := range arguments[:limit] {
+	for i, arg := range arguments[:pos] {
 		if arg == "--" {
-			return false, arguments[:pos]
+			return i == pos-1, arguments[:pos]
 		}
 	}
 

--- a/help_test.go
+++ b/help_test.go
@@ -1745,7 +1745,16 @@ func Test_checkShellCompleteFlag(t *testing.T) {
 				EnableBashCompletion: true,
 			},
 			wantShellCompletion: false,
-			wantArgs:            []string{"--", "foo", "--generate-bash-completion"},
+			wantArgs:            []string{"--", "foo"},
+		},
+		{
+			name:      "double dash is the token being completed",
+			arguments: []string{"foo", "--", "--generate-bash-completion"},
+			app: &App{
+				EnableBashCompletion: true,
+			},
+			wantShellCompletion: true,
+			wantArgs:            []string{"foo", "--"},
 		},
 		{
 			name:      "--generate-bash-completion",


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Prevents `--generate-bash-completion` from falling back to normal command execution when the user is completing after `--` in v2.

The change keeps the existing v2 behavior that disables completion after a positional separator that already appeared earlier, but trims the completion flag before normal dispatch so the command action is not executed accidentally.

It also preserves completing `--` itself, which allows the shell script to request long-flag suggestions without running the action.

## Which issue(s) this PR fixes:

Fixes #1993

## Special notes for your reviewer:

I kept this intentionally minimal for `v2-maint`:

- no shell script changes
- no behavior change for arguments after an earlier `--`
- added regression coverage for both the helper and `App.Run`

## Testing

Added regression tests for:

- `checkShellCompleteFlag` when `--` is the token being completed
- `checkShellCompleteFlag` when `--` already appeared before completion
- `App.Run` to ensure double-dash completion does not execute the action

## Release Notes

```release-note
Prevent v2 shell completion from executing command actions when completing after `--`.
```
