### PR TITLE
feat: add Parent() accessor to Command

### DIFF
--- a/command.go
+++ b/command.go
@@ -337,6 +337,11 @@ func (cmd *Command) argsWithDefaultCommand(oldArgs Args) Args {
 }
 
 // Root returns the Command at the root of the graph
+// Parent returns the parent command, or nil if this is the root command.
+func (cmd *Command) Parent() *Command {
+	return cmd.parent
+}
+
 func (cmd *Command) Root() *Command {
 	if cmd.parent == nil {
 		return cmd


### PR DESCRIPTION
Fixes #2372

Adds a `Parent()` method to `Command` that returns the parent command, or `nil` for the root command. This allows users to check if a parent is hidden when walking the command tree.

## Usage

```go
cmd.Walk(func(c *cli.Command) error {
    if c.Hidden || (c.Parent() != nil && c.Parent().Hidden) {
        return nil
    }
    // process visible command
    return nil
})
```