### PR TITLE
fix: skip all hidden flags in shell completion, not just bool flags

### DIFF
--- a/help.go
+++ b/help.go
@@ -216,7 +216,7 @@ func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
 	// Trim to handle both "-short" and "--long" flags.
 	cur := strings.TrimLeft(lastArg, "-")
 	for _, flag := range flags {
-		if bflag, ok := flag.(*BoolFlag); ok && bflag.Hidden {
+		if vf, ok := flag.(VisibleFlag); ok && !vf.IsVisible() {
 			continue
 		}
 

--- a/help_test.go
+++ b/help_test.go
@@ -1354,6 +1354,28 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 			expected: "",
 		},
 		{
+			name: "typical-flag-suggestion-hidden-non-bool",
+			cmd: &Command{
+				Flags: []Flag{
+					&StringFlag{Name: "excellent", Hidden: true},
+					&StringFlag{Name: "excitement"},
+				},
+				parent: &Command{
+					Name: "cmd",
+					Flags: []Flag{
+						&BoolFlag{Name: "happiness"},
+						&Int64Flag{Name: "everybody-jump-on"},
+					},
+					Commands: []*Command{
+						{Name: "putz"},
+					},
+				},
+			},
+			argv:     []string{"cmd", "--e", completionFlag},
+			env:      map[string]string{"SHELL": "bash"},
+			expected: "--excitement\n",
+		},
+		{
 			name: "flag-suggestion-double-dash-shows-all-flags",
 			cmd: &Command{
 				Flags: []Flag{


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

`printFlagSuggestions` (used by the default shell-completion handler) is supposed to skip hidden flags, but it only skips hidden `*BoolFlag` values:

```go
if bflag, ok := flag.(*BoolFlag); ok && bflag.Hidden {
    continue
}
```

The type assertion is to the concrete `*BoolFlag` type, so a hidden flag of any other type (`*StringFlag`, `*IntFlag`, `*DurationFlag`, ...) fails the assertion and is emitted into the completion output anyway. That exposes flags the author explicitly marked `Hidden: true` whenever a user hits `<TAB>`.

Repro (hidden `*StringFlag`):

```go
cmd := &cli.Command{
    Name:                  "app",
    EnableShellCompletion: true,
    Commands: []*cli.Command{{
        Name: "sub",
        Flags: []cli.Flag{
            &cli.StringFlag{Name: "secret", Hidden: true},
            &cli.StringFlag{Name: "visible"},
        },
        Action: func(context.Context, *cli.Command) error { return nil },
    }},
}
```

`app sub -<TAB>` prints `--secret` alongside `--visible`, even though `secret` is hidden. A hidden `*BoolFlag` in the same list is correctly omitted.

Changes:

- `help.go`: replace the `*BoolFlag`-specific check with the existing `VisibleFlag` interface (`IsVisible`), which every flag type implements via `FlagBase`. This is the same mechanism `visibleFlags` and the flag-category code already use, so all hidden flags are now skipped regardless of concrete type.

## Which issue(s) this PR fixes:

NONE

## Testing

Added `typical-flag-suggestion-hidden-non-bool` to `TestDefaultCompleteWithFlags`, mirroring the existing `typical-flag-suggestion-hidden-bool` case but with a hidden `*StringFlag`. It fails on `main` (completion emits the hidden flag) and passes with this change. `go test ./...`, `go vet ./...`, and `gofmt` are clean.

## Release Notes

```release-note
Hidden flags of non-boolean types are no longer offered in shell completion (previously only hidden bool flags were skipped).
```
