### PR TITLE
fix: reject duplicate flag names

### DIFF
--- a/command.go
+++ b/command.go
@@ -185,6 +185,19 @@ func (cmd *Command) checkHelp() bool {
 	return HelpFlag != nil && slices.ContainsFunc(HelpFlag.Names(), cmd.Bool)
 }
 
+func (cmd *Command) checkDuplicateFlagNames() error {
+	seen := map[string]struct{}{}
+	for _, fl := range cmd.Flags {
+		for _, name := range fl.Names() {
+			if _, ok := seen[name]; ok {
+				return fmt.Errorf("flag %q defined multiple times", name)
+			}
+			seen[name] = struct{}{}
+		}
+	}
+	return nil
+}
+
 func (cmd *Command) allFlags() []Flag {
 	var flags []Flag
 	flags = append(flags, cmd.Flags...)

--- a/command_run.go
+++ b/command_run.go
@@ -99,6 +99,9 @@ func (cmd *Command) Run(ctx context.Context, osArgs []string) (deferErr error) {
 func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context, deferErr error) {
 	tracef("running with arguments %[1]q (cmd=%[2]q)", osArgs, cmd.Name)
 	cmd.setupDefaults(osArgs)
+	if err := cmd.checkDuplicateFlagNames(); err != nil {
+		return ctx, err
+	}
 
 	// Validate StopOnNthArg
 	if cmd.StopOnNthArg != nil && *cmd.StopOnNthArg < 0 {

--- a/command_setup.go
+++ b/command_setup.go
@@ -250,9 +250,11 @@ func (cmd *Command) ensureHelp() {
 					localHelpFlag = HelpFlag
 				}
 
-				tracef("appending HelpFlag (cmd=%[1]q)", cmd.Name)
-				cmd.appendFlag(localHelpFlag)
-				cmd.globaHelpFlagAdded = true
+				if !flagNamesInUse(cmd.allFlags(), localHelpFlag.Names()) {
+					tracef("appending HelpFlag (cmd=%[1]q)", cmd.Name)
+					cmd.appendFlag(localHelpFlag)
+					cmd.globaHelpFlagAdded = true
+				}
 			} else {
 				tracef("HelpFlag already added, skip (cmd=%[1]q)", cmd.Name)
 			}

--- a/command_test.go
+++ b/command_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/mail"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -3985,6 +3986,70 @@ func TestFlagDuplicates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDuplicateFlagNamesAreRejected(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags []Flag
+	}{
+		{
+			name: "duplicate flag names",
+			flags: []Flag{
+				&BoolFlag{Name: "config"},
+				&StringFlag{Name: "config"},
+			},
+		},
+		{
+			name: "duplicate flag aliases",
+			flags: []Flag{
+				&BoolFlag{Name: "verbose", Aliases: []string{"v"}},
+				&StringFlag{Name: "value", Aliases: []string{"v"}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := &Command{
+				Flags: test.flags,
+				Action: func(context.Context, *Command) error {
+					return nil
+				},
+			}
+
+			err := cmd.Run(buildTestContext(t), []string{"foo"})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "defined multiple times")
+		})
+	}
+}
+
+func TestUserDefinedHelpFlagOverridesBuiltin(t *testing.T) {
+	writer := &bytes.Buffer{}
+	cmd := &Command{
+		Writer: writer,
+		Flags: []Flag{
+			&BoolFlag{Name: "help", Usage: "custom help behavior"},
+		},
+		Action: func(context.Context, *Command) error {
+			return nil
+		},
+	}
+
+	err := cmd.Run(buildTestContext(t), []string{"foo", "--help"})
+	require.NoError(t, err)
+	require.True(t, cmd.Bool("help"))
+
+	var helpFlags int
+	for _, fl := range cmd.Flags {
+		if slices.Contains(fl.Names(), "help") {
+			helpFlags++
+		}
+	}
+	require.Equal(t, 1, helpFlags)
+	require.Contains(t, writer.String(), "--help  custom help behavior")
+	require.NotContains(t, writer.String(), "--help, -h  show help")
 }
 
 func TestShorthandCommand(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

- Rejects genuine duplicate user-defined local flag names and aliases on a command, so ambiguous command configurations fail early.
- Makes built-in help flag installation name-aware: if a user flag already claims `help` or `h`, the auto-added help flag is not appended.
- Keeps the existing name-aware version flag behavior unchanged.

Before this change, a command with a user-defined `&BoolFlag{Name: "help"}` received the built-in help flag too, leaving two flags named `help` and duplicated help output. After this change, the user-defined help flag wins, overriding the help flag continues to work, `--help` still parses without error, and only one `help` flag is present.

## Which issue(s) this PR fixes:

Fixes #2174

## Special notes for your reviewer:

Compatibility note: user-defined overrides of the built-in help flag continue to work. Only configurations where the user's own `Flags` slice contains duplicate names/aliases now return an error during `Run`.

## Testing

- Regression checks: `go test -run "TestDuplicateFlagNamesAreRejected|TestUserDefinedHelpFlagOverridesBuiltin" -count=1 -v` fails on unmodified source (`TestDuplicateFlagNamesAreRejected` gets nil errors; `TestUserDefinedHelpFlagOverridesBuiltin` finds 2 `help` flags) and passes with this fix.
- `go build ./...` ✅
- `go vet ./...` ✅
- `gofmt -l .` ✅ empty
- `go test ./...` ✅
- `go run ./scripts/build.go generate` ✅
- `go run ./scripts/build.go vet` ✅
- `go run ./scripts/build.go check-binary-size` ✅ (`1.8MB` current size; target `1.5MB`–`2.2MB`)
- `go run ./scripts/build.go v3diff` ✅ (with Git `diff` on PATH)

## Release Notes

```release-note
Reject command configurations with duplicate user-defined flag names or aliases.
```