### PR TITLE
fix: request completions with "__complete" so a double dash can't run the command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Set PATH
         run: echo "${GITHUB_WORKSPACE}/.local/bin" >>"${GITHUB_PATH}"
 
+      # The completion scripts are run in these to check what they send. Without
+      # them those tests skip, which is silent: CLI_SHELL_TESTS_REQUIRED below turns
+      # a skip into a failure so that the coverage cannot go away unnoticed.
+      - if: matrix.os == 'ubuntu-24.04'
+        run: sudo apt-get update && sudo apt-get install -y bash-completion zsh fish
+
       - if: matrix.go == 'stable' && matrix.os == 'ubuntu-24.04'
         run: make ensure-goimports
 
@@ -42,6 +48,8 @@ jobs:
 
       - run: make vet
       - run: make test
+        env:
+          CLI_SHELL_TESTS_REQUIRED: ${{ matrix.os == 'ubuntu-24.04' && '1' || '' }}
       - run: make check-binary-size
 
       - if: matrix.go == 'stable' && matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
         run: echo "${GITHUB_WORKSPACE}/.local/bin" >>"${GITHUB_PATH}"
 
       # The completion scripts are run in these to check what they send. Without
-      # them those tests skip, which is silent: CLI_SHELL_TESTS_REQUIRED below turns
-      # a skip into a failure so that the coverage cannot go away unnoticed.
+      # them those tests skip, which is silent: CLI_SHELL_TESTS_REQUIRED below names
+      # them so that a skip is a failure and the coverage cannot go away unnoticed.
       - if: matrix.os == 'ubuntu-24.04'
         run: sudo apt-get update && sudo apt-get install -y bash-completion zsh fish
 
@@ -49,7 +49,10 @@ jobs:
       - run: make vet
       - run: make test
         env:
-          CLI_SHELL_TESTS_REQUIRED: ${{ matrix.os == 'ubuntu-24.04' && '1' || '' }}
+          # The shells installed above, and only those: pwsh comes with the
+          # runner image, so requiring it would turn a change of image into a
+          # failure here.
+          CLI_SHELL_TESTS_REQUIRED: ${{ matrix.os == 'ubuntu-24.04' && 'bash,zsh,fish' || '' }}
       - run: make check-binary-size
 
       - if: matrix.go == 'stable' && matrix.os == 'ubuntu-24.04'

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -12,7 +12,11 @@ __%[1]s_init_completion() {
 }
 
 # Remove one level of shell quoting from a word, the way the shell does before it
-# hands a word to a command, and leave the result in __%[1]s_dequoted.
+# hands a word to a command, and leave the result in __cli_completion_dequoted.
+#
+# The variables here hold no application name, unlike the functions: a name is free to
+# hold a "-" or a ".", which a function name may and a variable name may not. They are
+# declared local by the entry point below, so two applications never share one.
 #
 # Doing it here rather than with eval is what keeps a command line holding $(...) or
 # `...` from being executed by pressing the tab key.
@@ -48,7 +52,7 @@ __%[1]s_dequote() {
     i=$(( i + 1 ))
   done
 
-  __%[1]s_dequoted="${out}"
+  __cli_completion_dequoted="${out}"
 }
 
 # The request names the completion in its first argument, where a "--" typed on the
@@ -68,7 +72,7 @@ __%[1]s_build_completion_request() {
   local i cmd
 
   __%[1]s_dequote "${words[0]}"
-  cmd="${__%[1]s_dequoted}"
+  cmd="${__cli_completion_dequoted}"
   # A command typed as "~/bin/app" has to be run as the path it stands for. eval used
   # to do that as a side effect of re-parsing the line, along with everything else on
   # it; this is the one expansion worth keeping, and it needs nothing evaluated. The
@@ -76,15 +80,15 @@ __%[1]s_build_completion_request() {
   if [[ "${words[0]}" == "~" || "${words[0]}" == "~/"* ]]; then
     cmd="${HOME}${cmd:1}"
   fi
-  __%[1]s_completion_request=("${cmd}" "__complete")
+  __cli_completion_request=("${cmd}" "__complete")
 
   for (( i = 1; i < cword; i++ )); do
     __%[1]s_dequote "${words[i]}"
-    __%[1]s_completion_request+=("${__%[1]s_dequoted}")
+    __cli_completion_request+=("${__cli_completion_dequoted}")
   done
 
   __%[1]s_dequote "${words[cword]-}"
-  __%[1]s_completion_request+=("${__%[1]s_dequoted}")
+  __cli_completion_request+=("${__cli_completion_dequoted}")
 }
 
 # Keep Bash 3 compatibility: associative arrays require Bash 4+, so
@@ -107,8 +111,12 @@ __%[1]s_bash_autocomplete() {
   local words=("${COMP_WORDS[@]}")
 
   if [[ "${words[0]}" != "source" ]]; then
-    local cur opts
+    local cur prev opts
     local cword="${COMP_CWORD}"
+    local __cli_completion_dequoted=""
+    local -a __cli_completion_request=()
+    local -a __cli_completion_tokens=()
+    local -a __cli_completion_descriptions=()
 
     COMPREPLY=()
     cur="${words[$cword]}"
@@ -116,13 +124,10 @@ __%[1]s_bash_autocomplete() {
     __%[1]s_init_completion -n "=:" || return
 
     __%[1]s_build_completion_request
-    opts=$("${__%[1]s_completion_request[@]}" 2>/dev/null)
+    opts=$("${__cli_completion_request[@]}" 2>/dev/null)
 
     # Completion output lines use "token:description" format.
     # Keep token/description in parallel arrays for Bash 3 compatibility.
-    __cli_completion_tokens=()
-    __cli_completion_descriptions=()
-
     local line
     local longest=0
     while IFS=$'\n' read -r line; do

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -11,22 +11,72 @@ __%[1]s_init_completion() {
   fi
 }
 
+# Remove one level of shell quoting from a word, the way the shell does before it
+# hands a word to a command, and leave the result in __%[1]s_dequoted.
+#
+# Doing it here rather than with eval is what keeps a command line holding $(...) or
+# `...` from being executed by pressing the tab key.
+__%[1]s_dequote() {
+  local s="$1" out="" c n quote=""
+  local i=0 len=${#1}
+
+  while (( i < len )); do
+    c="${s:i:1}"
+    if [[ "${quote}" == "'" ]]; then
+      if [[ "${c}" == "'" ]]; then quote=""; else out="${out}${c}"; fi
+    elif [[ "${quote}" == '"' ]]; then
+      if [[ "${c}" == '"' ]]; then
+        quote=""
+      elif [[ "${c}" == "\\" ]]; then
+        i=$(( i + 1 ))
+        n="${s:i:1}"
+        # Inside double quotes a backslash only escapes these.
+        case "${n}" in
+          '"' | "\\" | '$' | '`') out="${out}${n}" ;;
+          *) out="${out}\\${n}" ;;
+        esac
+      else
+        out="${out}${c}"
+      fi
+    else
+      case "${c}" in
+        "'" | '"') quote="${c}" ;;
+        "\\") i=$(( i + 1 )); out="${out}${s:i:1}" ;;
+        *) out="${out}${c}" ;;
+      esac
+    fi
+    i=$(( i + 1 ))
+  done
+
+  __%[1]s_dequoted="${out}"
+}
+
 # The request names the completion in its first argument, where a "--" typed on the
 # command line cannot turn it into a positional argument of whatever the command runs.
 # The word under the cursor is sent as the last argument, empty or not, so that
 # "cmd --<TAB>" and "cmd -- <TAB>" can be told apart.
 #
 # It is built as an array rather than as a string to eval, so that a word holding a
-# space or a quote reaches the command as the single word it is.
+# space reaches the command as the single word it is.
+#
+# The words come from words/cword rather than from COMP_WORDS/COMP_CWORD: bash splits
+# the line on COMP_WORDBREAKS, so "--opt=value" is three words in COMP_WORDS, while
+# __%[1]s_init_completion puts it back together. The candidates are filtered against
+# cur, which comes from there too, so a request built from anything else would ask the
+# command about a different word than the one being completed.
 __%[1]s_build_completion_request() {
-  __cli_completion_request=("${COMP_WORDS[0]}" "__complete")
-
   local i
-  for (( i = 1; i < COMP_CWORD; i++ )); do
-    __cli_completion_request+=("${COMP_WORDS[i]}")
+
+  __%[1]s_dequote "${words[0]}"
+  __%[1]s_completion_request=("${__%[1]s_dequoted}" "__complete")
+
+  for (( i = 1; i < cword; i++ )); do
+    __%[1]s_dequote "${words[i]}"
+    __%[1]s_completion_request+=("${__%[1]s_dequoted}")
   done
 
-  __cli_completion_request+=("${COMP_WORDS[COMP_CWORD]-}")
+  __%[1]s_dequote "${words[cword]-}"
+  __%[1]s_completion_request+=("${__%[1]s_dequoted}")
 }
 
 # Keep Bash 3 compatibility: associative arrays require Bash 4+, so
@@ -58,7 +108,7 @@ __%[1]s_bash_autocomplete() {
     __%[1]s_init_completion -n "=:" || return
 
     __%[1]s_build_completion_request
-    opts=$("${__cli_completion_request[@]}" 2>/dev/null)
+    opts=$("${__%[1]s_completion_request[@]}" 2>/dev/null)
 
     # Completion output lines use "token:description" format.
     # Keep token/description in parallel arrays for Bash 3 compatibility.

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -65,10 +65,18 @@ __%[1]s_dequote() {
 # cur, which comes from there too, so a request built from anything else would ask the
 # command about a different word than the one being completed.
 __%[1]s_build_completion_request() {
-  local i
+  local i cmd
 
   __%[1]s_dequote "${words[0]}"
-  __%[1]s_completion_request=("${__%[1]s_dequoted}" "__complete")
+  cmd="${__%[1]s_dequoted}"
+  # A command typed as "~/bin/app" has to be run as the path it stands for. eval used
+  # to do that as a side effect of re-parsing the line, along with everything else on
+  # it; this is the one expansion worth keeping, and it needs nothing evaluated. The
+  # raw word decides, because a quoted "~" is not a home directory to the shell either.
+  if [[ "${words[0]}" == "~" || "${words[0]}" == "~/"* ]]; then
+    cmd="${HOME}${cmd:1}"
+  fi
+  __%[1]s_completion_request=("${cmd}" "__complete")
 
   for (( i = 1; i < cword; i++ )); do
     __%[1]s_dequote "${words[i]}"

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -11,15 +11,22 @@ __%[1]s_init_completion() {
   fi
 }
 
+# The request names the completion in its first argument, where a "--" typed on the
+# command line cannot turn it into a positional argument of whatever the command runs.
+# The word under the cursor is sent as the last argument, empty or not, so that
+# "cmd --<TAB>" and "cmd -- <TAB>" can be told apart.
+#
+# It is built as an array rather than as a string to eval, so that a word holding a
+# space or a quote reaches the command as the single word it is.
 __%[1]s_build_completion_request() {
-  local -a words_before_cursor=("${COMP_WORDS[@]:0:${COMP_CWORD}}")
-  local current_word="${COMP_WORDS[COMP_CWORD]}"
+  __cli_completion_request=("${COMP_WORDS[0]}" "__complete")
 
-  if [[ "${current_word}" == "-"* ]]; then
-    printf '%%s %%s --generate-shell-completion' "${words_before_cursor[*]}" "${current_word}"
-  else
-    printf '%%s --generate-shell-completion' "${words_before_cursor[*]}"
-  fi
+  local i
+  for (( i = 1; i < COMP_CWORD; i++ )); do
+    __cli_completion_request+=("${COMP_WORDS[i]}")
+  done
+
+  __cli_completion_request+=("${COMP_WORDS[COMP_CWORD]-}")
 }
 
 # Keep Bash 3 compatibility: associative arrays require Bash 4+, so
@@ -44,15 +51,14 @@ __%[1]s_bash_autocomplete() {
   if [[ "${words[0]}" != "source" ]]; then
     local cur opts
     local cword="${COMP_CWORD}"
-    local request_comp
 
     COMPREPLY=()
     cur="${words[$cword]}"
 
     __%[1]s_init_completion -n "=:" || return
 
-    request_comp="$(__%[1]s_build_completion_request)"
-    opts=$(eval "${request_comp}" 2>/dev/null)
+    __%[1]s_build_completion_request
+    opts=$("${__cli_completion_request[@]}" 2>/dev/null)
 
     # Completion output lines use "token:description" format.
     # Keep token/description in parallel arrays for Bash 3 compatibility.

--- a/autocomplete/fish_autocomplete
+++ b/autocomplete/fish_autocomplete
@@ -6,7 +6,11 @@ function __%[1]s_perform_completion
     # Extract the last arg (partial input), with one level of quoting taken off the
     # way the shell would take it off before handing a word to a command. The words
     # before it come tokenized, which does that already.
-    set -l lastArg (string unescape -- (commandline -ct))
+    set -l rawArg (commandline -ct)
+    # string unescape answers with nothing for a word it cannot read, such as one
+    # ending in a lone backslash. The word as typed is a better answer than no word,
+    # which would be read as a fresh one.
+    set -l lastArg (string unescape -- $rawArg; or printf '%%s' $rawArg)
 
     # The request names the completion in its first argument, where a "--" typed on
     # the command line cannot turn it into a positional argument of whatever the

--- a/autocomplete/fish_autocomplete
+++ b/autocomplete/fish_autocomplete
@@ -13,7 +13,16 @@ function __%[1]s_perform_completion
     # command runs. The word under the cursor is sent as the last argument, quoted so
     # that an empty one is still an argument, which tells "cmd --<TAB>" from
     # "cmd -- <TAB>".
-    set results ($args[1] __complete $args[2..-1] "$lastArg" 2> /dev/null)
+    # A command typed as "~/bin/app" has to be run as the path it stands for, which
+    # nothing else here does: the words are taken apart, not evaluated. The word has
+    # been through the tokenizer by now, so a quoted "~" is expanded too, where the
+    # shell would leave it alone.
+    set -l cmd $args[1]
+    if string match -q -- '~' $cmd; or string match -q -- '~/*' $cmd
+        set cmd $HOME(string sub -s 2 -- $cmd)
+    end
+
+    set results ($cmd __complete $args[2..-1] "$lastArg" 2> /dev/null)
 
     # Remove trailing empty lines
     for line in $results[-1..1]

--- a/autocomplete/fish_autocomplete
+++ b/autocomplete/fish_autocomplete
@@ -5,12 +5,13 @@ function __%[1]s_perform_completion
     set -l args (commandline -opc)
     # Extract the last arg (partial input)
     set -l lastArg (commandline -ct)
-    
-    if string match -q -- "-*" $lastArg
-        set results ($args[1] $args[2..-1] $lastArg --generate-shell-completion 2> /dev/null)
-    else
-        set results ($args[1] $args[2..-1] --generate-shell-completion 2> /dev/null)
-    end
+
+    # The request names the completion in its first argument, where a "--" typed on
+    # the command line cannot turn it into a positional argument of whatever the
+    # command runs. The word under the cursor is sent as the last argument, quoted so
+    # that an empty one is still an argument, which tells "cmd --<TAB>" from
+    # "cmd -- <TAB>".
+    set results ($args[1] __complete $args[2..-1] "$lastArg" 2> /dev/null)
 
     # Remove trailing empty lines
     for line in $results[-1..1]

--- a/autocomplete/fish_autocomplete
+++ b/autocomplete/fish_autocomplete
@@ -3,8 +3,10 @@
 function __%[1]s_perform_completion
     # Extract all args except the last one
     set -l args (commandline -opc)
-    # Extract the last arg (partial input)
-    set -l lastArg (commandline -ct)
+    # Extract the last arg (partial input), with one level of quoting taken off the
+    # way the shell would take it off before handing a word to a command. The words
+    # before it come tokenized, which does that already.
+    set -l lastArg (string unescape -- (commandline -ct))
 
     # The request names the completion in its first argument, where a "--" typed on
     # the command line cannot turn it into a positional argument of whatever the

--- a/autocomplete/powershell_autocomplete.ps1
+++ b/autocomplete/powershell_autocomplete.ps1
@@ -3,27 +3,52 @@ $name = $fn -replace "(.*)\.ps1$", '$1'
 Register-ArgumentCompleter -Native -CommandName $name -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
+    # One level of quoting is taken off each word, the way the shell would before
+    # handing it to a command. The value is not expanded: nothing on the command line
+    # is evaluated to answer a completion, so a "$(...)" reaches the command as the
+    # text it is rather than being run by pressing the tab key.
+    function __cliCompletionText($element) {
+        if ($element -is [System.Management.Automation.Language.StringConstantExpressionAst] -or
+            $element -is [System.Management.Automation.Language.ExpandableStringExpressionAst]) {
+            return $element.Value
+        }
+        return $element.Extent.Text
+    }
+
+    $elements = $commandAst.CommandElements
+    if ($elements.Count -eq 0) {
+        return
+    }
+
+    # The command name itself is the shell's to complete, not the command's.
+    if ($cursorPosition -le $elements[0].Extent.EndOffset) {
+        return
+    }
+
     # The request names the completion in its first argument, where a "--" typed on
     # the command line cannot turn it into a positional argument of whatever the
     # command runs. The word under the cursor is sent as the last argument, empty or
     # not, so that "cmd --<TAB>" and "cmd -- <TAB>" can be told apart.
-    $elements = @($commandAst.CommandElements | ForEach-Object { $_.ToString() })
-    $command = $elements[0]
+    #
+    # Which word that is comes from the cursor rather than from a comparison with
+    # $wordToComplete, which PowerShell hands over normalized: an unfinished "hello
+    # arrives here as "hello", matches no element as written, and would be sent both
+    # as a word of its own and as the word being completed. Reading the cursor also
+    # leaves out what follows it, so completing in the middle of a line asks about
+    # the line up to that point.
+    $command = $elements[0].Extent.Text
     $words = @()
-    if ($elements.Count -gt 1) {
-        $words = $elements[1..($elements.Count - 1)]
-    }
-    # Once the word under the cursor has any character it is an element of its own,
-    # so it is dropped here and sent as the last argument instead.
-    if ($wordToComplete -and $words.Count -gt 0 -and $words[-1] -eq $wordToComplete) {
-        if ($words.Count -eq 1) {
-            $words = @()
-        } else {
-            $words = $words[0..($words.Count - 2)]
+    $word = ''
+    for ($i = 1; $i -lt $elements.Count; $i++) {
+        $extent = $elements[$i].Extent
+        if ($cursorPosition -gt $extent.StartOffset -and $cursorPosition -le $extent.EndOffset) {
+            $word = __cliCompletionText $elements[$i]
+        } elseif ($extent.EndOffset -lt $cursorPosition) {
+            $words += __cliCompletionText $elements[$i]
         }
     }
 
-    & $command __complete @words $wordToComplete 2>$null | ForEach-Object {
+    & $command __complete @words $word 2>$null | ForEach-Object {
         $parts = $_.Split(':', 2)
         if ($parts.Count -eq 2) {
             $completion = $parts[0].Trim()

--- a/autocomplete/powershell_autocomplete.ps1
+++ b/autocomplete/powershell_autocomplete.ps1
@@ -54,6 +54,15 @@ Register-ArgumentCompleter -Native -CommandName $name -ScriptBlock {
         }
     }
 
+    # The word being completed is the last argument, empty or not, which needs the
+    # argument passing mode PowerShell 7.3 made the default: before it, on Windows, an
+    # empty argument is dropped on the way to a native command and the request arrives
+    # a word short, which reads as a different command line rather than as an error.
+    # Windows PowerShell 5.1 has no such mode and cannot be helped from here.
+    if (Get-Variable -Name PSNativeCommandArgumentPassing -ErrorAction Ignore) {
+        $PSNativeCommandArgumentPassing = 'Standard'
+    }
+
     & $command __complete @words $word 2>$null | ForEach-Object {
         $parts = $_.Split(':', 2)
         if ($parts.Count -eq 2) {

--- a/autocomplete/powershell_autocomplete.ps1
+++ b/autocomplete/powershell_autocomplete.ps1
@@ -36,7 +36,7 @@ Register-ArgumentCompleter -Native -CommandName $name -ScriptBlock {
     # as a word of its own and as the word being completed. Reading the cursor also
     # leaves out what follows it, so completing in the middle of a line asks about
     # the line up to that point.
-    $command = $elements[0].Extent.Text
+    $command = __cliCompletionText $elements[0]
     $words = @()
     $word = ''
     for ($i = 1; $i -lt $elements.Count; $i++) {

--- a/autocomplete/powershell_autocomplete.ps1
+++ b/autocomplete/powershell_autocomplete.ps1
@@ -1,9 +1,29 @@
 $fn = $($MyInvocation.MyCommand.Name)
 $name = $fn -replace "(.*)\.ps1$", '$1'
 Register-ArgumentCompleter -Native -CommandName $name -ScriptBlock {
-    param($commandName, $wordToComplete, $cursorPosition)
-    $other = "$wordToComplete --generate-shell-completion"
-    Invoke-Expression $other | ForEach-Object {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    # The request names the completion in its first argument, where a "--" typed on
+    # the command line cannot turn it into a positional argument of whatever the
+    # command runs. The word under the cursor is sent as the last argument, empty or
+    # not, so that "cmd --<TAB>" and "cmd -- <TAB>" can be told apart.
+    $elements = @($commandAst.CommandElements | ForEach-Object { $_.ToString() })
+    $command = $elements[0]
+    $words = @()
+    if ($elements.Count -gt 1) {
+        $words = $elements[1..($elements.Count - 1)]
+    }
+    # Once the word under the cursor has any character it is an element of its own,
+    # so it is dropped here and sent as the last argument instead.
+    if ($wordToComplete -and $words.Count -gt 0 -and $words[-1] -eq $wordToComplete) {
+        if ($words.Count -eq 1) {
+            $words = @()
+        } else {
+            $words = $words[0..($words.Count - 2)]
+        }
+    }
+
+    & $command __complete @words $wordToComplete 2>$null | ForEach-Object {
         $parts = $_.Split(':', 2)
         if ($parts.Count -eq 2) {
             $completion = $parts[0].Trim()

--- a/autocomplete/powershell_autocomplete.ps1
+++ b/autocomplete/powershell_autocomplete.ps1
@@ -37,6 +37,12 @@ Register-ArgumentCompleter -Native -CommandName $name -ScriptBlock {
     # leaves out what follows it, so completing in the middle of a line asks about
     # the line up to that point.
     $command = __cliCompletionText $elements[0]
+    # A command typed as "~/bin/app" has to be run as the path it stands for.
+    # Invoke-Expression expanded it as a side effect of re-parsing the whole line,
+    # which is what this no longer does.
+    if ($command -eq '~' -or $command.StartsWith('~/') -or $command.StartsWith('~')) {
+        $command = $HOME + $command.Substring(1)
+    }
     $words = @()
     $word = ''
     for ($i = 1; $i -lt $elements.Count; $i++) {

--- a/autocomplete/powershell_autocomplete.ps1
+++ b/autocomplete/powershell_autocomplete.ps1
@@ -36,13 +36,10 @@ Register-ArgumentCompleter -Native -CommandName $name -ScriptBlock {
     # as a word of its own and as the word being completed. Reading the cursor also
     # leaves out what follows it, so completing in the middle of a line asks about
     # the line up to that point.
+    # A command typed as "~/bin/app" needs nothing done to it here: PowerShell resolves
+    # the tilde when it looks the command up, where the three other shells pass the
+    # word on as written and never find the command.
     $command = __cliCompletionText $elements[0]
-    # A command typed as "~/bin/app" has to be run as the path it stands for.
-    # Invoke-Expression expanded it as a side effect of re-parsing the whole line,
-    # which is what this no longer does.
-    if ($command -eq '~' -or $command.StartsWith('~/') -or $command.StartsWith('~')) {
-        $command = $HOME + $command.Substring(1)
-    }
     $words = @()
     $word = ''
     for ($i = 1; $i -lt $elements.Count; $i++) {

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -13,7 +13,16 @@ _%[1]s() {
 	# (Q) takes one level of quoting off each word, the way the shell would before
 	# handing it to a command, so that a quoted word reaches the command as the word
 	# it is rather than with its quotes.
-	request=("${(@Q)words[1]}" "__complete" "${(@Q)words[2,CURRENT-1]}" "${(@Q)words[CURRENT]}")
+	local raw="${words[CURRENT]}"
+	local current="${(Q)words[CURRENT]}"
+	# A word whose quote is still open has no closing quote to take off with it, so
+	# (Q) leaves it alone. Dropping the opening quote asks the command about the word
+	# being typed rather than about one starting with a quote character, which is what
+	# bash and PowerShell send for the same line.
+	if [[ "$current" == "$raw" && "$raw" == [\"\']* ]]; then
+		current="${current#[\"\']}"
+	fi
+	request=("${(@Q)words[1]}" "__complete" "${(@Q)words[2,CURRENT-1]}" "$current")
 	opts=("${(@f)$("${request[@]}" 2>/dev/null)}")
 
 	if [[ "${opts[1]}" != "" ]]; then

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -22,7 +22,14 @@ _%[1]s() {
 	if [[ "$current" == "$raw" && "$raw" == [\"\']* ]]; then
 		current="${current#[\"\']}"
 	fi
-	request=("${(@Q)words[1]}" "__complete" "${(@Q)words[2,CURRENT-1]}" "$current")
+	# A command typed as "~/bin/app" has to be run as the path it stands for, which
+	# nothing else here does: the words are taken apart, not evaluated. The raw word
+	# decides, because a quoted "~" is not a home directory to the shell either.
+	local cmd="${(Q)words[1]}"
+	if [[ "${words[1]}" == "~" || "${words[1]}" == "~/"* ]]; then
+		cmd="${HOME}${cmd#\~}"
+	fi
+	request=("$cmd" "__complete" "${(@Q)words[2,CURRENT-1]}" "$current")
 	opts=("${(@f)$("${request[@]}" 2>/dev/null)}")
 
 	if [[ "${opts[1]}" != "" ]]; then

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -5,15 +5,13 @@ compdef _%[1]s %[1]s
 
 _%[1]s() {
 	local -a opts # Declare a local array
-	local current
-	current=${words[-1]} # -1 means "the last element"
-	if [[ "$current" == "-"* ]]; then
-		# Current word starts with a hyphen, so complete flags/options
-		opts=("${(@f)$(${words[@]:0:#words[@]-1} ${current} --generate-shell-completion)}")
-	else
-		# Current word does not start with a hyphen, so complete subcommands
-		opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-shell-completion)}")
-	fi
+	local -a request
+	# The request names the completion in its first argument, where a "--" typed on
+	# the command line cannot turn it into a positional argument of whatever the
+	# command runs. The word under the cursor is sent as the last argument, empty or
+	# not, so that "cmd --<TAB>" and "cmd -- <TAB>" can be told apart.
+	request=("${words[1]}" "__complete" "${(@)words[2,CURRENT-1]}" "${words[CURRENT]}")
+	opts=("${(@f)$("${request[@]}")}")
 
 	if [[ "${opts[1]}" != "" ]]; then
 		_describe 'values' opts

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -10,8 +10,11 @@ _%[1]s() {
 	# the command line cannot turn it into a positional argument of whatever the
 	# command runs. The word under the cursor is sent as the last argument, empty or
 	# not, so that "cmd --<TAB>" and "cmd -- <TAB>" can be told apart.
-	request=("${words[1]}" "__complete" "${(@)words[2,CURRENT-1]}" "${words[CURRENT]}")
-	opts=("${(@f)$("${request[@]}")}")
+	# (Q) takes one level of quoting off each word, the way the shell would before
+	# handing it to a command, so that a quoted word reaches the command as the word
+	# it is rather than with its quotes.
+	request=("${(@Q)words[1]}" "__complete" "${(@Q)words[2,CURRENT-1]}" "${(@Q)words[CURRENT]}")
+	opts=("${(@f)$("${request[@]}" 2>/dev/null)}")
 
 	if [[ "${opts[1]}" != "" ]]; then
 		_describe 'values' opts

--- a/command.go
+++ b/command.go
@@ -157,13 +157,11 @@ type Command struct {
 	didSetupDefaults bool
 	// whether in shell completion mode
 	shellCompletion bool
-	// the word the shell is completing, or nil when the request did not carry it,
-	// which is every request in the deprecated form. Only the root command holds it.
-	completionWord *string
-	// whether a "--" precedes the word being completed, which makes that word a
-	// positional argument of whatever the command runs. Only the root command holds
-	// it.
-	completionTerminated bool
+	// what the shell completion request being answered says about the word being
+	// completed, or nil when this run is answering none. Only the root command holds
+	// it, and every run replaces it, so a Command answering several requests never
+	// carries one request's state into the next.
+	completion *completionRequest
 	// whether global help flag was added
 	globaHelpFlagAdded bool
 	// whether global version flag was added

--- a/command.go
+++ b/command.go
@@ -157,6 +157,13 @@ type Command struct {
 	didSetupDefaults bool
 	// whether in shell completion mode
 	shellCompletion bool
+	// the word the shell is completing, or nil when the request did not carry it,
+	// which is every request in the deprecated form. Only the root command holds it.
+	completionWord *string
+	// whether a "--" precedes the word being completed, which makes that word a
+	// positional argument of whatever the command runs. Only the root command holds
+	// it.
+	completionTerminated bool
 	// whether global help flag was added
 	globaHelpFlagAdded bool
 	// whether global version flag was added

--- a/command_run.go
+++ b/command_run.go
@@ -118,20 +118,21 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 				osArgs = append(osArgs, args...)
 			}
 		}
-		// handle the completion flag separately from the flagset since
+		// handle the completion request separately from the flagset since
 		// completion could be attempted after a flag, but before its value was put
 		// on the command line. this causes the flagset to interpret the completion
-		// flag name as the value of the flag before it which is undesirable
+		// request as the value of the flag before it which is undesirable
 		// note that we can only do this because the shell autocomplete function
-		// always appends the completion flag at the end of the command
+		// sends the request in a place the flagset never reaches: the first argument,
+		// or, for a script generated before that change, the last one
 		tracef("checking osArgs %v (cmd=%[2]q)", osArgs, cmd.Name)
-		cmd.shellCompletion, osArgs = checkShellCompleteFlag(cmd, osArgs)
+		cmd.shellCompletion, osArgs = parseShellCompleteRequest(cmd, osArgs)
 
-		tracef("setting cmd.shellCompletion=%[1]v from checkShellCompleteFlag (cmd=%[2]q)", cmd.shellCompletion && cmd.EnableShellCompletion, cmd.Name)
+		tracef("setting cmd.shellCompletion=%[1]v from parseShellCompleteRequest (cmd=%[2]q)", cmd.shellCompletion && cmd.EnableShellCompletion, cmd.Name)
 		cmd.shellCompletion = cmd.EnableShellCompletion && cmd.shellCompletion
 	}
 
-	tracef("using post-checkShellCompleteFlag arguments %[1]q (cmd=%[2]q)", osArgs, cmd.Name)
+	tracef("using post-parseShellCompleteRequest arguments %[1]q (cmd=%[2]q)", osArgs, cmd.Name)
 
 	tracef("setting self as cmd in context (cmd=%[1]q)", cmd.Name)
 	ctx = context.WithValue(ctx, commandContextKey, cmd)

--- a/command_run.go
+++ b/command_run.go
@@ -165,11 +165,17 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 	tracef("using post-parse arguments %[1]q (cmd=%[2]q)", args, cmd.Name)
 
 	if shouldRunCompletion(cmd) {
-		var beforeErr error
-		if ctx, beforeErr = runBefore(ctx, commandChain(cmd)); beforeErr != nil {
-			return ctx, beforeErr
+		// Everything after "--" is a positional argument of whatever the command runs,
+		// so there is no completion to run and nothing to prepare for one: a Before
+		// with a side effect would otherwise fire on every tab key past the
+		// terminator, for an answer that is always empty.
+		if !cmd.Root().completionTerminated() {
+			var beforeErr error
+			if ctx, beforeErr = runBefore(ctx, commandChain(cmd)); beforeErr != nil {
+				return ctx, beforeErr
+			}
+			runCompletion(ctx, cmd)
 		}
-		runCompletion(ctx, cmd)
 		return ctx, nil
 	}
 

--- a/completion.go
+++ b/completion.go
@@ -12,11 +12,11 @@ const (
 
 	// This flag is supposed to only be used by the completion script itself to generate completions on the fly.
 	//
-	// Deprecated: completion scripts name the request with completionCommandRequest
-	// instead. A request appended to the end of the command line is indistinguishable
-	// from a positional argument after "--", which is why it is no longer generated.
-	// It is still understood so that scripts generated before that change keep
-	// working.
+	// What is deprecated is the request form, not this constant: a request appended to
+	// the end of the command line is indistinguishable from a positional argument
+	// after "--", so the scripts name it with completionCommandRequest instead. The
+	// flag is still understood, so that scripts generated before that change keep
+	// working, and this stays as the name they send.
 	completionFlag = "--generate-shell-completion"
 
 	// This argument is supposed to only be used by the completion script itself to

--- a/completion.go
+++ b/completion.go
@@ -11,7 +11,18 @@ const (
 	completionCommandName = "completion"
 
 	// This flag is supposed to only be used by the completion script itself to generate completions on the fly.
+	//
+	// Deprecated: completion scripts name the request with completionCommandRequest
+	// instead. A request appended to the end of the command line is indistinguishable
+	// from a positional argument after "--", which is why it is no longer generated.
+	// It is still understood so that scripts generated before that change keep
+	// working.
 	completionFlag = "--generate-shell-completion"
+
+	// This argument is supposed to only be used by the completion script itself to
+	// generate completions on the fly. It is the first argument of the request, where
+	// "--" cannot turn it into a positional argument.
+	completionCommandRequest = "__complete"
 )
 
 type renderCompletion func(cmd *Command, appName string) (string, error)

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -117,7 +117,7 @@ func TestCompletionScriptsRequest(t *testing.T) {
 			driver := shellDrivers[shell]
 			interpreter, err := exec.LookPath(driver.interpreter)
 			if err != nil {
-				skipMissingShell(t, driver.interpreter+" is not installed")
+				skipMissingShell(t, shell, driver.interpreter+" is not installed")
 			}
 
 			render := shellCompletions[shell]
@@ -160,13 +160,19 @@ func TestCompletionScriptsRequest(t *testing.T) {
 	}
 }
 
-// skipMissingShell skips a shell that is not installed, unless the environment says
-// these tests are expected to run. A skip is silent, and a machine that has none of
-// the four reports the same green as one where every request is right.
-func skipMissingShell(t *testing.T, reason string) {
+// skipMissingShell skips a shell that is not installed, unless it is one the
+// environment names as required. A skip is silent, and a machine that has none of the
+// four reports the same green as one where every request is right, so a run that is
+// meant to cover a shell says which ones and fails when it cannot.
+//
+// The shells are named rather than required as a group, so that a job requiring what
+// it installs is not broken by a shell disappearing from a runner image.
+func skipMissingShell(t *testing.T, shell, reason string) {
 	t.Helper()
-	if os.Getenv("CLI_SHELL_TESTS_REQUIRED") != "" {
-		t.Fatalf("CLI_SHELL_TESTS_REQUIRED is set: %s", reason)
+	for _, required := range strings.Split(os.Getenv("CLI_SHELL_TESTS_REQUIRED"), ",") {
+		if strings.TrimSpace(required) == shell {
+			t.Fatalf("%s is required by CLI_SHELL_TESTS_REQUIRED: %s", shell, reason)
+		}
 	}
 	t.Skip(reason)
 }
@@ -207,7 +213,7 @@ var shellDrivers = map[string]shellDriver{
 					return ". " + p + "\n"
 				}
 			}
-			skipMissingShell(t, "bash-completion is not installed")
+			skipMissingShell(t, "bash", "bash-completion is not installed")
 			return ""
 		},
 		program: func(scriptPath string, tc completionCase) string {

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -1,0 +1,266 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file checks what the generated completion scripts actually send, by running
+// them in the shells they are written for and recording the arguments the command
+// receives. Asserting on the text of a script only says that it was generated; a word
+// the shell splits, quotes or normalizes differently is a difference the text cannot
+// show.
+//
+// Every shell is skipped when it is not installed, so this adds nothing to a machine
+// that has none of them.
+
+// completionCase is a command line, with the cursor at its end unless the line ends
+// in a space, and the arguments the command is expected to receive for it.
+type completionCase struct {
+	name string
+	line string
+	want []string
+}
+
+func completionCases() []completionCase {
+	return []completionCase{
+		{
+			name: "a word being typed",
+			line: "app su",
+			want: []string{"__complete", "su"},
+		},
+		{
+			name: "a fresh word",
+			line: "app sub ",
+			want: []string{"__complete", "sub", ""},
+		},
+		{
+			name: "a flag being typed",
+			line: "app sub --fl",
+			want: []string{"__complete", "sub", "--fl"},
+		},
+		{
+			// COMP_WORDBREAKS holds "=", so bash splits this into three words and has
+			// to put them back together before asking.
+			name: "a flag holding its value",
+			line: "app --opt=va",
+			want: []string{"__complete", "--opt=va"},
+		},
+		{
+			// One level of quoting comes off, the way the shell takes it off before
+			// handing a word to a command.
+			name: "a quoted word",
+			line: `app sub "hello world" `,
+			want: []string{"__complete", "sub", "hello world", ""},
+		},
+		{
+			// The quote is still open, so there is no closing quote to take off with
+			// it. The word is what is being typed, not one starting with a quote.
+			name: "a word whose quote is still open",
+			line: `app sub "hello wo`,
+			want: []string{"__complete", "sub", "hello wo"},
+		},
+		{
+			// Everything after "--" is a positional argument of whatever the command
+			// runs, and the command is asked about it rather than running it.
+			name: "past a double dash",
+			line: "app exec -- git push ",
+			want: []string{"__complete", "exec", "--", "git", "push", ""},
+		},
+		{
+			// Answering a completion must not evaluate the command line. The old
+			// scripts re-parsed it, so a command substitution ran on the tab key.
+			name: "a command substitution",
+			line: "app sub $(touch NOPE) ",
+			want: []string{"__complete", "sub", "$(touch NOPE)", ""},
+		},
+	}
+}
+
+// TestCompletionScriptsRequest runs the generated scripts in the shells they are
+// written for and checks the request each one builds.
+func TestCompletionScriptsRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("driving four shells takes seconds, not milliseconds")
+	}
+
+	t.Parallel()
+
+	for _, shell := range []string{"bash", "zsh", "fish", "pwsh"} {
+		t.Run(shell, func(t *testing.T) {
+			t.Parallel()
+
+			driver := shellDrivers[shell]
+			interpreter, err := exec.LookPath(driver.interpreter)
+			if err != nil {
+				t.Skipf("%s is not installed", driver.interpreter)
+			}
+
+			render := shellCompletions[shell]
+			require.NotNil(t, render)
+			script, err := render(&Command{Name: "app", EnableShellCompletion: true}, "app")
+			require.NoError(t, err)
+
+			for _, tc := range completionCases() {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
+
+					dir := t.TempDir()
+					scriptPath := filepath.Join(dir, "completion."+shell)
+					require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o644))
+
+					argvPath := filepath.Join(dir, "argv")
+					writeCompletionTestApp(t, dir)
+
+					prelude := driver.prelude(t, interpreter)
+					program := driver.program(scriptPath, tc.line)
+
+					cmd := exec.Command(interpreter, driver.args(prelude+program)...)
+					cmd.Dir = dir
+					cmd.Env = append(os.Environ(),
+						"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+						"ARGV_LOG="+argvPath,
+					)
+					out, err := cmd.CombinedOutput()
+					require.NoError(t, err, "driving %s: %s", shell, out)
+
+					got, err := os.ReadFile(argvPath)
+					require.NoError(t, err, "the completion did not run the command: %s", out)
+					assert.Equal(t, tc.want, strings.Split(strings.TrimSuffix(string(got), "\n"), "\n"))
+
+					assert.NoFileExists(t, filepath.Join(dir, "NOPE"),
+						"the command line must not be evaluated to answer a completion")
+				})
+			}
+		})
+	}
+}
+
+// writeCompletionTestApp writes the command the completion scripts ask, which records
+// the arguments it receives and answers with one candidate.
+func writeCompletionTestApp(t *testing.T, dir string) {
+	t.Helper()
+	app := "#!/bin/sh\n: > \"$ARGV_LOG\"\nfor a in \"$@\"; do printf '%s\\n' \"$a\" >> \"$ARGV_LOG\"; done\necho candidate\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app"), []byte(app), 0o755))
+}
+
+// shellDriver runs a completion the way its shell would, without a terminal. Each
+// shell offers its own way in: what they have in common is that the script under test
+// is sourced and the completion for a command line is asked for.
+type shellDriver struct {
+	interpreter string
+	args        func(program string) []string
+	prelude     func(t *testing.T, interpreter string) string
+	program     func(scriptPath, line string) string
+}
+
+var shellDrivers = map[string]shellDriver{
+	"bash": {
+		interpreter: "bash",
+		args:        func(p string) []string { return []string{"-c", p} },
+		// The script calls the word-splitting helpers of bash-completion, so without
+		// it there is nothing to drive.
+		prelude: func(t *testing.T, _ string) string {
+			t.Helper()
+			for _, p := range []string{
+				"/usr/share/bash-completion/bash_completion",
+				"/etc/bash_completion",
+				"/opt/homebrew/share/bash-completion/bash_completion",
+				"/usr/local/share/bash-completion/bash_completion",
+			} {
+				if _, err := os.Stat(p); err == nil {
+					return ". " + p + "\n"
+				}
+			}
+			t.Skip("bash-completion is not installed")
+			return ""
+		},
+		program: func(scriptPath, line string) string {
+			// COMP_WORDS and COMP_CWORD are what bash sets before it calls the
+			// completion function, which is what the script reads.
+			return fmt.Sprintf(`
+. %s
+line=%s
+eval "COMP_WORDS=($line)"
+[ "${line: -1}" = " " ] && COMP_WORDS+=("")
+COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))
+COMP_LINE="$line"
+COMP_POINT=${#line}
+__app_bash_autocomplete
+`, shQuote(scriptPath), shQuote(line))
+		},
+	},
+	"zsh": {
+		interpreter: "zsh",
+		args:        func(p string) []string { return []string{"-f", "-c", p} },
+		prelude:     func(*testing.T, string) string { return "" },
+		// The completion system is not started, so the parts of it the script uses
+		// stand in for it: what is under test is the request the script builds from
+		// words and CURRENT, which zsh fills the same way here.
+		program: func(scriptPath, line string) string {
+			return fmt.Sprintf(`
+compdef() { : }
+_describe() { : }
+_files() { : }
+. %s
+line=%s
+words=("${(z)line}")
+[[ "$line" == *" " ]] && words+=("")
+CURRENT=$#words
+_app
+`, shQuote(scriptPath), shQuote(line))
+		},
+	},
+	"fish": {
+		interpreter: "fish",
+		args:        func(p string) []string { return []string{"-c", p} },
+		prelude:     func(*testing.T, string) string { return "" },
+		// complete -C asks for the completions of a command line, which is the entry
+		// point fish itself uses.
+		program: func(scriptPath, line string) string {
+			return fmt.Sprintf("source %s\ncomplete -C %s\n", fishQuote(scriptPath), fishQuote(line))
+		},
+	},
+	"pwsh": {
+		interpreter: "pwsh",
+		args:        func(p string) []string { return []string{"-NoProfile", "-Command", p} },
+		prelude:     func(*testing.T, string) string { return "" },
+		// The script registers its completer under the name of the file it is in, so
+		// its body is registered directly here. TabExpansion2 is what PowerShell calls
+		// on the tab key.
+		program: func(scriptPath, line string) string {
+			return fmt.Sprintf(`
+$script = Get-Content %s -Raw
+$start = $script.IndexOf('-ScriptBlock {') + '-ScriptBlock {'.Length
+$body = $script.Substring($start, $script.LastIndexOf('}') - $start)
+Register-ArgumentCompleter -Native -CommandName app -ScriptBlock ([scriptblock]::Create($body))
+$line = %s
+$null = TabExpansion2 -inputScript $line -cursorColumn $line.Length
+`, pwshQuote(scriptPath), pwshQuote(line))
+		},
+	},
+}
+
+// shQuote quotes s for bash and zsh.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// fishQuote quotes s for fish.
+func fishQuote(s string) string {
+	return "'" + strings.NewReplacer(`\`, `\\`, "'", `\'`).Replace(s) + "'"
+}
+
+// pwshQuote quotes s for PowerShell.
+func pwshQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -422,3 +422,57 @@ __app_bash_autocomplete
 	require.NoError(t, err, "the completion did not run the command: %s", out)
 	assert.Equal(t, []string{"__complete", "su"}, strings.Split(strings.TrimSuffix(string(got), "\n"), "\n"))
 }
+
+// TestCompletionScriptsSyntax checks that the generated scripts parse, for an app name
+// holding characters a shell reads specially. A name is free to hold a "-" or a "."
+// — docker-compose, golangci-lint — which a function name may hold and a variable name
+// may not, so a script putting the name in a variable breaks for those apps only, and
+// breaks the whole file: sourcing stops at the syntax error, before the completion is
+// registered at all.
+func TestCompletionScriptsSyntax(t *testing.T) {
+	t.Parallel()
+
+	// The syntax check for each shell, given the file to read.
+	checks := map[string]func(string) []string{
+		"bash": func(p string) []string { return []string{"-n", p} },
+		"zsh":  func(p string) []string { return []string{"-n", p} },
+		"fish": func(p string) []string { return []string{"-n", p} },
+		"pwsh": func(p string) []string {
+			return []string{"-NoProfile", "-Command",
+				"$errors = $null; $null = [System.Management.Automation.Language.Parser]::ParseFile(" +
+					pwshQuote(p) + ", [ref]$null, [ref]$errors); if ($errors) { $errors; exit 1 }"}
+		},
+	}
+
+	// A space is left out: the function names have held the app name since long before
+	// this file, and a name holding a space breaks those in bash and zsh whatever the
+	// variables do.
+	for _, name := range []string{"app", "my-app", "my.app"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, shell := range []string{"bash", "zsh", "fish", "pwsh"} {
+				t.Run(shell, func(t *testing.T) {
+					t.Parallel()
+
+					interpreter, err := exec.LookPath(shellDrivers[shell].interpreter)
+					if err != nil {
+						skipMissingShell(t, shell, shellDrivers[shell].interpreter+" is not installed")
+					}
+
+					render := shellCompletions[shell]
+					require.NotNil(t, render)
+					script, err := render(&Command{Name: name, EnableShellCompletion: true}, name)
+					require.NoError(t, err)
+
+					dir := t.TempDir()
+					p := filepath.Join(dir, "completion."+shell)
+					require.NoError(t, os.WriteFile(p, []byte(script), 0o644))
+
+					out, err := exec.Command(interpreter, checks[shell](p)...).CombinedOutput()
+					require.NoError(t, err, "the %s script for %q does not parse: %s", shell, name, out)
+				})
+			}
+		})
+	}
+}

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -34,7 +34,11 @@ type completionCase struct {
 	// script's: these were measured in bash 5.3 with a completion function that dumps
 	// COMP_WORDS.
 	bashWords []string
-	want      []string
+	// pwshLine is line as it would be typed in PowerShell, where it differs. A quoted
+	// command name is only a command there when the call operator says so: "'app' su"
+	// is a string followed by a word, not a command being completed.
+	pwshLine string
+	want     []string
 }
 
 func completionCases() []completionCase {
@@ -90,6 +94,16 @@ func completionCases() []completionCase {
 			want:      []string{"__complete", "exec", "--", "git", "push", ""},
 		},
 		{
+			// The command word is a word like any other: one level of quoting comes
+			// off it too, or the request is sent to a command whose name holds the
+			// quotes.
+			name:      "a quoted command word",
+			line:      "'app' su",
+			bashWords: []string{"'app'", "su"},
+			pwshLine:  "& 'app' su",
+			want:      []string{"__complete", "su"},
+		},
+		{
 			// Answering a completion must not evaluate the command line. The old
 			// scripts re-parsed it, so a command substitution ran on the tab key.
 			name:      "a command substitution",
@@ -98,6 +112,14 @@ func completionCases() []completionCase {
 			want:      []string{"__complete", "sub", "$(touch NOPE)", ""},
 		},
 	}
+}
+
+// pwshCommandLine is the command line to complete in PowerShell.
+func (tc completionCase) pwshCommandLine() string {
+	if tc.pwshLine != "" {
+		return tc.pwshLine
+	}
+	return tc.line
 }
 
 // TestCompletionScriptsRequest runs the generated scripts in the shells they are
@@ -321,7 +343,7 @@ $body = $script.Substring($start, $script.LastIndexOf('}') - $start)
 Register-ArgumentCompleter -Native -CommandName app -ScriptBlock ([scriptblock]::Create($body))
 $line = %s
 $null = TabExpansion2 -inputScript $line -cursorColumn $line.Length
-`, pwshQuote(scriptPath), pwshQuote(tc.line))
+`, pwshQuote(scriptPath), pwshQuote(tc.pwshCommandLine()))
 		},
 	},
 }

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -276,9 +276,12 @@ __app_bash_autocomplete
 		interpreter: "zsh",
 		args:        func(p string) []string { return []string{"-f", "-c", p} },
 		prelude:     func(*testing.T, string) string { return "" },
-		// The completion system is not started, so the parts of it the script uses
-		// stand in for it: what is under test is the request the script builds from
-		// words and CURRENT, which zsh fills the same way here.
+		// The completion system is not started, since driving it needs a pseudo
+		// terminal, so the parts of it the script uses stand in for it and words and
+		// CURRENT are filled with zsh's own tokenizer. That last part is an assumption
+		// rather than something checked: unlike the bash words, which are written out
+		// as measured, these are what (z) makes of the line, which is close to what
+		// the completion system would pass but not known to be identical.
 		program: func(scriptPath string, tc completionCase) string {
 			return fmt.Sprintf(`
 compdef() { : }

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -165,32 +165,90 @@ func TestCompletionScriptsRequest(t *testing.T) {
 					}
 
 					dir := t.TempDir()
-					scriptPath := filepath.Join(dir, "completion."+shell)
-					require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o644))
-
-					argvPath := filepath.Join(dir, "argv")
 					writeCompletionTestApp(t, dir)
 
-					prelude := driver.prelude(t, interpreter)
-					program := driver.program(scriptPath, tc)
-
-					cmd := exec.Command(interpreter, driver.args(prelude+program)...)
-					cmd.Dir = dir
-					cmd.Env = append(os.Environ(),
-						"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
-						"ARGV_LOG="+argvPath,
-					)
-					out, err := cmd.CombinedOutput()
-					require.NoError(t, err, "driving %s: %s", shell, out)
-
-					got, err := os.ReadFile(argvPath)
-					require.NoError(t, err, "the completion did not run the command: %s", out)
-					assert.Equal(t, tc.want, strings.Split(strings.TrimSuffix(string(got), "\n"), "\n"))
+					got := completeInShell(t, shell, interpreter, script, tc, dir, []string{
+						"PATH=" + dir + string(os.PathListSeparator) + os.Getenv("PATH"),
+					})
+					assert.Equal(t, tc.want, got)
 
 					assert.NoFileExists(t, filepath.Join(dir, "NOPE"),
 						"the command line must not be evaluated to answer a completion")
 				})
 			}
+		})
+	}
+}
+
+// completeInShell drives one completion in one shell and returns the arguments the
+// command received. dir is where the command line is completed, and env is added to
+// the environment the shell runs in.
+func completeInShell(t *testing.T, shell, interpreter, script string, tc completionCase, dir string, env []string) []string {
+	t.Helper()
+
+	driver := shellDrivers[shell]
+	scriptPath := filepath.Join(dir, "completion."+shell)
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o644))
+	argvPath := filepath.Join(dir, "argv")
+
+	cmd := exec.Command(interpreter, driver.args(driver.prelude(t, interpreter)+driver.program(scriptPath, tc))...)
+	cmd.Dir = dir
+	cmd.Env = append(append(os.Environ(), "ARGV_LOG="+argvPath), env...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "driving %s: %s", shell, out)
+
+	got, err := os.ReadFile(argvPath)
+	require.NoError(t, err, "the completion did not run the command: %s", out)
+	return strings.Split(strings.TrimSuffix(string(got), "\n"), "\n")
+}
+
+// TestCompletionScriptsTildeCommand checks that a command typed as "~/bin/app" is run
+// as the path it stands for. Only PowerShell resolves a tilde while looking a command
+// up; the other three pass the word on as written, and bash used to have it expanded
+// by the eval this no longer does.
+//
+// The command is reachable through the tilde alone: it is not on PATH, so a shell that
+// passes the word on unchanged finds nothing and the request never arrives.
+func TestCompletionScriptsTildeCommand(t *testing.T) {
+	t.Parallel()
+
+	tc := completionCase{
+		line: "~/bin/app su",
+		// Written with a quoted tilde so that the driver does not expand it: what the
+		// script receives has to be the tilde bash puts in COMP_WORDS.
+		bashWords: []string{"~/bin/app", "su"},
+		want:      []string{"__complete", "su"},
+	}
+
+	for _, shell := range []string{"bash", "zsh", "fish", "pwsh"} {
+		t.Run(shell, func(t *testing.T) {
+			t.Parallel()
+
+			interpreter, err := exec.LookPath(shellDrivers[shell].interpreter)
+			if err != nil {
+				skipMissingShell(t, shell, shellDrivers[shell].interpreter+" is not installed")
+			}
+
+			render := shellCompletions[shell]
+			require.NotNil(t, render)
+			script, err := render(&Command{Name: "app", EnableShellCompletion: true}, "app")
+			require.NoError(t, err)
+
+			home := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(home, "bin"), 0o755))
+			writeCompletionTestApp(t, filepath.Join(home, "bin"))
+
+			// A machine can get its shells from a tool manager that keeps what it
+			// needs under the real home, where moving HOME takes it away and the
+			// shell never starts. Nothing about the script can be learned then.
+			probe := exec.Command(interpreter, shellDrivers[shell].args("exit 0")...)
+			probe.Env = append(os.Environ(), "HOME="+home)
+			if out, err := probe.CombinedOutput(); err != nil {
+				t.Skipf("%s cannot run with HOME moved: %s", shell, out)
+			}
+
+			got := completeInShell(t, shell, interpreter, script, tc, t.TempDir(), []string{"HOME=" + home})
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -372,55 +430,6 @@ func fishQuote(s string) string {
 // pwshQuote quotes s for PowerShell.
 func pwshQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
-}
-
-// TestCompletionBashScriptTildeCommand checks that a command typed as "~/bin/app" is
-// run as the path it stands for. eval expanded it as a side effect of re-parsing the
-// command line, and dropping eval dropped that with it, leaving the completion looking
-// for a command whose name starts with a tilde and finding nothing.
-func TestCompletionBashScriptTildeCommand(t *testing.T) {
-	t.Parallel()
-
-	driver := shellDrivers["bash"]
-	interpreter, err := exec.LookPath(driver.interpreter)
-	if err != nil {
-		skipMissingShell(t, "bash", driver.interpreter+" is not installed")
-	}
-
-	render := shellCompletions["bash"]
-	require.NotNil(t, render)
-	script, err := render(&Command{Name: "app", EnableShellCompletion: true}, "app")
-	require.NoError(t, err)
-
-	home := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(home, "bin"), 0o755))
-	writeCompletionTestApp(t, filepath.Join(home, "bin"))
-
-	dir := t.TempDir()
-	scriptPath := filepath.Join(dir, "completion.bash")
-	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o644))
-	argvPath := filepath.Join(dir, "argv")
-
-	// The word is written with a quoted tilde so that this driver does not expand it:
-	// what the script receives has to be the tilde bash puts in COMP_WORDS.
-	program := fmt.Sprintf(`
-. %s
-COMP_WORDS=('~/bin/app' 'su')
-COMP_CWORD=1
-COMP_LINE='~/bin/app su'
-COMP_POINT=12
-__app_bash_autocomplete
-`, shQuote(scriptPath))
-
-	cmd := exec.Command(interpreter, driver.args(driver.prelude(t, interpreter)+program)...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "HOME="+home, "ARGV_LOG="+argvPath)
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "driving bash: %s", out)
-
-	got, err := os.ReadFile(argvPath)
-	require.NoError(t, err, "the completion did not run the command: %s", out)
-	assert.Equal(t, []string{"__complete", "su"}, strings.Split(strings.TrimSuffix(string(got), "\n"), "\n"))
 }
 
 // TestCompletionScriptsSyntax checks that the generated scripts parse, for an app name

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -221,6 +221,7 @@ var shellDrivers = map[string]shellDriver{
 		// it there is nothing to drive.
 		prelude: func(t *testing.T, interpreter string) string {
 			t.Helper()
+			var unusable []string
 			for _, p := range []string{
 				"/usr/share/bash-completion/bash_completion",
 				"/etc/bash_completion",
@@ -234,13 +235,18 @@ var shellDrivers = map[string]shellDriver{
 				// bash-completion 2.12 and later need bash 4.2, so sourcing it in the
 				// bash macOS ships leaves the helpers undefined and the script with
 				// nothing to call. Ask this bash what it ends up with rather than
-				// assuming that the file is enough.
+				// assuming that the file is enough, and go on looking when the answer
+				// is no: an older one further down the list may still work.
 				usable := exec.Command(interpreter, "-c", ". "+shQuote(p)+
 					" >/dev/null 2>&1; declare -F _comp_initialize >/dev/null 2>&1 || declare -F _get_comp_words_by_ref >/dev/null 2>&1")
 				if err := usable.Run(); err != nil {
-					skipMissingShell(t, "bash", interpreter+" cannot use the bash-completion in "+p)
+					unusable = append(unusable, p)
+					continue
 				}
 				return ". " + p + "\n"
+			}
+			if len(unusable) > 0 {
+				skipMissingShell(t, "bash", interpreter+" cannot use the bash-completion in "+strings.Join(unusable, ", "))
 			}
 			skipMissingShell(t, "bash", "bash-completion is not installed")
 			return ""

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -110,6 +110,8 @@ func TestCompletionScriptsRequest(t *testing.T) {
 	// has all four.
 	t.Parallel()
 
+	checkRequiredShells(t)
+
 	for _, shell := range []string{"bash", "zsh", "fish", "pwsh"} {
 		t.Run(shell, func(t *testing.T) {
 			t.Parallel()
@@ -160,6 +162,22 @@ func TestCompletionScriptsRequest(t *testing.T) {
 	}
 }
 
+// checkRequiredShells fails when CLI_SHELL_TESTS_REQUIRED names a shell this file does
+// not know. The variable is there so that coverage cannot go away quietly, which a
+// typo in it would undo: a name matching nothing requires nothing.
+func checkRequiredShells(t *testing.T) {
+	t.Helper()
+	for _, name := range strings.Split(os.Getenv("CLI_SHELL_TESTS_REQUIRED"), ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := shellDrivers[name]; !ok {
+			t.Fatalf("CLI_SHELL_TESTS_REQUIRED names %q, which is not a shell driven here", name)
+		}
+	}
+}
+
 // skipMissingShell skips a shell that is not installed, unless it is one the
 // environment names as required. A skip is silent, and a machine that has none of the
 // four reports the same green as one where every request is right, so a run that is
@@ -201,7 +219,7 @@ var shellDrivers = map[string]shellDriver{
 		args:        func(p string) []string { return []string{"-c", p} },
 		// The script calls the word-splitting helpers of bash-completion, so without
 		// it there is nothing to drive.
-		prelude: func(t *testing.T, _ string) string {
+		prelude: func(t *testing.T, interpreter string) string {
 			t.Helper()
 			for _, p := range []string{
 				"/usr/share/bash-completion/bash_completion",
@@ -209,9 +227,20 @@ var shellDrivers = map[string]shellDriver{
 				"/opt/homebrew/share/bash-completion/bash_completion",
 				"/usr/local/share/bash-completion/bash_completion",
 			} {
-				if _, err := os.Stat(p); err == nil {
-					return ". " + p + "\n"
+				if _, err := os.Stat(p); err != nil {
+					continue
 				}
+				// Finding the file is not the same as being able to use it:
+				// bash-completion 2.12 and later need bash 4.2, so sourcing it in the
+				// bash macOS ships leaves the helpers undefined and the script with
+				// nothing to call. Ask this bash what it ends up with rather than
+				// assuming that the file is enough.
+				usable := exec.Command(interpreter, "-c", ". "+shQuote(p)+
+					" >/dev/null 2>&1; declare -F _comp_initialize >/dev/null 2>&1 || declare -F _get_comp_words_by_ref >/dev/null 2>&1")
+				if err := usable.Run(); err != nil {
+					skipMissingShell(t, "bash", interpreter+" cannot use the bash-completion in "+p)
+				}
+				return ". " + p + "\n"
 			}
 			skipMissingShell(t, "bash", "bash-completion is not installed")
 			return ""

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -337,3 +337,52 @@ func fishQuote(s string) string {
 func pwshQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
+
+// TestCompletionBashScriptTildeCommand checks that a command typed as "~/bin/app" is
+// run as the path it stands for. eval expanded it as a side effect of re-parsing the
+// command line, and dropping eval dropped that with it, leaving the completion looking
+// for a command whose name starts with a tilde and finding nothing.
+func TestCompletionBashScriptTildeCommand(t *testing.T) {
+	t.Parallel()
+
+	driver := shellDrivers["bash"]
+	interpreter, err := exec.LookPath(driver.interpreter)
+	if err != nil {
+		skipMissingShell(t, "bash", driver.interpreter+" is not installed")
+	}
+
+	render := shellCompletions["bash"]
+	require.NotNil(t, render)
+	script, err := render(&Command{Name: "app", EnableShellCompletion: true}, "app")
+	require.NoError(t, err)
+
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, "bin"), 0o755))
+	writeCompletionTestApp(t, filepath.Join(home, "bin"))
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "completion.bash")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o644))
+	argvPath := filepath.Join(dir, "argv")
+
+	// The word is written with a quoted tilde so that this driver does not expand it:
+	// what the script receives has to be the tilde bash puts in COMP_WORDS.
+	program := fmt.Sprintf(`
+. %s
+COMP_WORDS=('~/bin/app' 'su')
+COMP_CWORD=1
+COMP_LINE='~/bin/app su'
+COMP_POINT=12
+__app_bash_autocomplete
+`, shQuote(scriptPath))
+
+	cmd := exec.Command(interpreter, driver.args(driver.prelude(t, interpreter)+program)...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "HOME="+home, "ARGV_LOG="+argvPath)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "driving bash: %s", out)
+
+	got, err := os.ReadFile(argvPath)
+	require.NoError(t, err, "the completion did not run the command: %s", out)
+	assert.Equal(t, []string{"__complete", "su"}, strings.Split(strings.TrimSuffix(string(got), "\n"), "\n"))
+}

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -37,7 +37,7 @@ type completionCase struct {
 	// bashSkip says why bash is left out of this line, and is empty when it is not.
 	// Leaving bashWords out is not the signal: a case that simply forgot them would
 	// then quietly cover one shell fewer, which is what CLI_SHELL_TESTS_REQUIRED
-	// exists to prevent one directory up.
+	// prevents a level up, for a shell rather than for a case.
 	bashSkip string
 	// pwshLine is line as it would be typed in PowerShell, where it differs. A quoted
 	// command name is only a command there when the call operator says so: "'app' su"

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -438,9 +438,11 @@ func TestCompletionScriptsSyntax(t *testing.T) {
 		"zsh":  func(p string) []string { return []string{"-n", p} },
 		"fish": func(p string) []string { return []string{"-n", p} },
 		"pwsh": func(p string) []string {
-			return []string{"-NoProfile", "-Command",
+			return []string{
+				"-NoProfile", "-Command",
 				"$errors = $null; $null = [System.Management.Automation.Language.Parser]::ParseFile(" +
-					pwshQuote(p) + ", [ref]$null, [ref]$errors); if ($errors) { $errors; exit 1 }"}
+					pwshQuote(p) + ", [ref]$null, [ref]$errors); if ($errors) { $errors; exit 1 }",
+			}
 		},
 	}
 

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -89,10 +89,11 @@ func completionCases() []completionCase {
 // TestCompletionScriptsRequest runs the generated scripts in the shells they are
 // written for and checks the request each one builds.
 func TestCompletionScriptsRequest(t *testing.T) {
-	if testing.Short() {
-		t.Skip("driving four shells takes seconds, not milliseconds")
-	}
-
+	// testing.Short is not read here: tests in this package add flags of their own to
+	// the standard flag set, which leaves testing.Short panicking on a flag set that
+	// has not been parsed. The shells run in parallel and each one skips when it is
+	// not installed, so the cost of leaving it in is a few seconds on a machine that
+	// has all four.
 	t.Parallel()
 
 	for _, shell := range []string{"bash", "zsh", "fish", "pwsh"} {

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -244,7 +244,7 @@ func TestCompletionScriptsTildeCommand(t *testing.T) {
 			probe := exec.Command(interpreter, shellDrivers[shell].args("exit 0")...)
 			probe.Env = append(os.Environ(), "HOME="+home)
 			if out, err := probe.CombinedOutput(); err != nil {
-				t.Skipf("%s cannot run with HOME moved: %s", shell, out)
+				skipMissingShell(t, shell, fmt.Sprintf("%s cannot run with HOME moved: %s", shell, out))
 			}
 
 			got := completeInShell(t, shell, interpreter, script, tc, t.TempDir(), []string{"HOME=" + home})

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -33,6 +33,10 @@ type completionCase struct {
 	// works the words out for itself tests its own idea of that rather than the
 	// script's: these were measured in bash 5.3 with a completion function that dumps
 	// COMP_WORDS.
+	//
+	// It is nil for a line bash never reaches the completion function with, which the
+	// bash run skips: there is no measurement to make, and writing one out by hand is
+	// the guessing this field exists to avoid.
 	bashWords []string
 	// pwshLine is line as it would be typed in PowerShell, where it differs. A quoted
 	// command name is only a command there when the call operator says so: "'app' su"
@@ -97,11 +101,15 @@ func completionCases() []completionCase {
 			// The command word is a word like any other: one level of quoting comes
 			// off it too, or the request is sent to a command whose name holds the
 			// quotes.
-			name:      "a quoted command word",
-			line:      "'app' su",
-			bashWords: []string{"'app'", "su"},
-			pwshLine:  "& 'app' su",
-			want:      []string{"__complete", "su"},
+			//
+			// bash is left out: a command word holding a quote matches no compspec, so
+			// bash completes it as a file name and never calls the function under test
+			// here. Measured the way the words below were, with a completion function
+			// that records having been called.
+			name:     "a quoted command word",
+			line:     "'app' su",
+			pwshLine: "& 'app' su",
+			want:     []string{"__complete", "su"},
 		},
 		{
 			// Answering a completion must not evaluate the command line. The old
@@ -152,6 +160,10 @@ func TestCompletionScriptsRequest(t *testing.T) {
 			for _, tc := range completionCases() {
 				t.Run(tc.name, func(t *testing.T) {
 					t.Parallel()
+
+					if shell == "bash" && tc.bashWords == nil {
+						t.Skip("bash does not reach the completion function for this line")
+					}
 
 					dir := t.TempDir()
 					scriptPath := filepath.Join(dir, "completion."+shell)

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -28,60 +28,74 @@ import (
 type completionCase struct {
 	name string
 	line string
-	want []string
+	// bashWords is what bash puts in COMP_WORDS for line, with the cursor at its end.
+	// Bash splits on COMP_WORDBREAKS and keeps the quoting as typed, and a driver that
+	// works the words out for itself tests its own idea of that rather than the
+	// script's: these were measured in bash 5.3 with a completion function that dumps
+	// COMP_WORDS.
+	bashWords []string
+	want      []string
 }
 
 func completionCases() []completionCase {
 	return []completionCase{
 		{
-			name: "a word being typed",
-			line: "app su",
-			want: []string{"__complete", "su"},
+			name:      "a word being typed",
+			line:      "app su",
+			bashWords: []string{"app", "su"},
+			want:      []string{"__complete", "su"},
 		},
 		{
-			name: "a fresh word",
-			line: "app sub ",
-			want: []string{"__complete", "sub", ""},
+			name:      "a fresh word",
+			line:      "app sub ",
+			bashWords: []string{"app", "sub", ""},
+			want:      []string{"__complete", "sub", ""},
 		},
 		{
-			name: "a flag being typed",
-			line: "app sub --fl",
-			want: []string{"__complete", "sub", "--fl"},
+			name:      "a flag being typed",
+			line:      "app sub --fl",
+			bashWords: []string{"app", "sub", "--fl"},
+			want:      []string{"__complete", "sub", "--fl"},
 		},
 		{
 			// COMP_WORDBREAKS holds "=", so bash splits this into three words and has
 			// to put them back together before asking.
-			name: "a flag holding its value",
-			line: "app --opt=va",
-			want: []string{"__complete", "--opt=va"},
+			name:      "a flag holding its value",
+			line:      "app --opt=va",
+			bashWords: []string{"app", "--opt", "=", "va"},
+			want:      []string{"__complete", "--opt=va"},
 		},
 		{
 			// One level of quoting comes off, the way the shell takes it off before
 			// handing a word to a command.
-			name: "a quoted word",
-			line: `app sub "hello world" `,
-			want: []string{"__complete", "sub", "hello world", ""},
+			name:      "a quoted word",
+			line:      `app sub "hello world" `,
+			bashWords: []string{"app", "sub", `"hello world"`, ""},
+			want:      []string{"__complete", "sub", "hello world", ""},
 		},
 		{
 			// The quote is still open, so there is no closing quote to take off with
 			// it. The word is what is being typed, not one starting with a quote.
-			name: "a word whose quote is still open",
-			line: `app sub "hello wo`,
-			want: []string{"__complete", "sub", "hello wo"},
+			name:      "a word whose quote is still open",
+			line:      `app sub "hello wo`,
+			bashWords: []string{"app", "sub", `"hello wo`},
+			want:      []string{"__complete", "sub", "hello wo"},
 		},
 		{
 			// Everything after "--" is a positional argument of whatever the command
 			// runs, and the command is asked about it rather than running it.
-			name: "past a double dash",
-			line: "app exec -- git push ",
-			want: []string{"__complete", "exec", "--", "git", "push", ""},
+			name:      "past a double dash",
+			line:      "app exec -- git push ",
+			bashWords: []string{"app", "exec", "--", "git", "push", ""},
+			want:      []string{"__complete", "exec", "--", "git", "push", ""},
 		},
 		{
 			// Answering a completion must not evaluate the command line. The old
 			// scripts re-parsed it, so a command substitution ran on the tab key.
-			name: "a command substitution",
-			line: "app sub $(touch NOPE) ",
-			want: []string{"__complete", "sub", "$(touch NOPE)", ""},
+			name:      "a command substitution",
+			line:      "app sub $(touch NOPE) ",
+			bashWords: []string{"app", "sub", "$(touch NOPE)", ""},
+			want:      []string{"__complete", "sub", "$(touch NOPE)", ""},
 		},
 	}
 }
@@ -123,7 +137,7 @@ func TestCompletionScriptsRequest(t *testing.T) {
 					writeCompletionTestApp(t, dir)
 
 					prelude := driver.prelude(t, interpreter)
-					program := driver.program(scriptPath, tc.line)
+					program := driver.program(scriptPath, tc)
 
 					cmd := exec.Command(interpreter, driver.args(prelude+program)...)
 					cmd.Dir = dir
@@ -161,7 +175,7 @@ type shellDriver struct {
 	interpreter string
 	args        func(program string) []string
 	prelude     func(t *testing.T, interpreter string) string
-	program     func(scriptPath, line string) string
+	program     func(scriptPath string, tc completionCase) string
 }
 
 var shellDrivers = map[string]shellDriver{
@@ -185,19 +199,25 @@ var shellDrivers = map[string]shellDriver{
 			t.Skip("bash-completion is not installed")
 			return ""
 		},
-		program: func(scriptPath, line string) string {
+		program: func(scriptPath string, tc completionCase) string {
 			// COMP_WORDS and COMP_CWORD are what bash sets before it calls the
-			// completion function, which is what the script reads.
+			// completion function, which is what the script reads. They are written
+			// out as measured rather than worked out here: quoting them apart or
+			// letting eval build them would test this driver's idea of what bash does
+			// with a command line instead of the script's handling of what bash
+			// actually produces, and eval would run a command substitution on the way.
+			words := make([]string, 0, len(tc.bashWords))
+			for _, w := range tc.bashWords {
+				words = append(words, shQuote(w))
+			}
 			return fmt.Sprintf(`
 . %s
-line=%s
-eval "COMP_WORDS=($line)"
-[ "${line: -1}" = " " ] && COMP_WORDS+=("")
-COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))
-COMP_LINE="$line"
-COMP_POINT=${#line}
+COMP_WORDS=(%s)
+COMP_CWORD=%d
+COMP_LINE=%s
+COMP_POINT=%d
 __app_bash_autocomplete
-`, shQuote(scriptPath), shQuote(line))
+`, shQuote(scriptPath), strings.Join(words, " "), len(tc.bashWords)-1, shQuote(tc.line), len(tc.line))
 		},
 	},
 	"zsh": {
@@ -207,7 +227,7 @@ __app_bash_autocomplete
 		// The completion system is not started, so the parts of it the script uses
 		// stand in for it: what is under test is the request the script builds from
 		// words and CURRENT, which zsh fills the same way here.
-		program: func(scriptPath, line string) string {
+		program: func(scriptPath string, tc completionCase) string {
 			return fmt.Sprintf(`
 compdef() { : }
 _describe() { : }
@@ -218,7 +238,7 @@ words=("${(z)line}")
 [[ "$line" == *" " ]] && words+=("")
 CURRENT=$#words
 _app
-`, shQuote(scriptPath), shQuote(line))
+`, shQuote(scriptPath), shQuote(tc.line))
 		},
 	},
 	"fish": {
@@ -227,8 +247,8 @@ _app
 		prelude:     func(*testing.T, string) string { return "" },
 		// complete -C asks for the completions of a command line, which is the entry
 		// point fish itself uses.
-		program: func(scriptPath, line string) string {
-			return fmt.Sprintf("source %s\ncomplete -C %s\n", fishQuote(scriptPath), fishQuote(line))
+		program: func(scriptPath string, tc completionCase) string {
+			return fmt.Sprintf("source %s\ncomplete -C %s\n", fishQuote(scriptPath), fishQuote(tc.line))
 		},
 	},
 	"pwsh": {
@@ -238,7 +258,7 @@ _app
 		// The script registers its completer under the name of the file it is in, so
 		// its body is registered directly here. TabExpansion2 is what PowerShell calls
 		// on the tab key.
-		program: func(scriptPath, line string) string {
+		program: func(scriptPath string, tc completionCase) string {
 			return fmt.Sprintf(`
 $script = Get-Content %s -Raw
 $start = $script.IndexOf('-ScriptBlock {') + '-ScriptBlock {'.Length
@@ -246,7 +266,7 @@ $body = $script.Substring($start, $script.LastIndexOf('}') - $start)
 Register-ArgumentCompleter -Native -CommandName app -ScriptBlock ([scriptblock]::Create($body))
 $line = %s
 $null = TabExpansion2 -inputScript $line -cursorColumn $line.Length
-`, pwshQuote(scriptPath), pwshQuote(line))
+`, pwshQuote(scriptPath), pwshQuote(tc.line))
 		},
 	},
 }

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -117,7 +117,7 @@ func TestCompletionScriptsRequest(t *testing.T) {
 			driver := shellDrivers[shell]
 			interpreter, err := exec.LookPath(driver.interpreter)
 			if err != nil {
-				t.Skipf("%s is not installed", driver.interpreter)
+				skipMissingShell(t, driver.interpreter+" is not installed")
 			}
 
 			render := shellCompletions[shell]
@@ -160,6 +160,17 @@ func TestCompletionScriptsRequest(t *testing.T) {
 	}
 }
 
+// skipMissingShell skips a shell that is not installed, unless the environment says
+// these tests are expected to run. A skip is silent, and a machine that has none of
+// the four reports the same green as one where every request is right.
+func skipMissingShell(t *testing.T, reason string) {
+	t.Helper()
+	if os.Getenv("CLI_SHELL_TESTS_REQUIRED") != "" {
+		t.Fatalf("CLI_SHELL_TESTS_REQUIRED is set: %s", reason)
+	}
+	t.Skip(reason)
+}
+
 // writeCompletionTestApp writes the command the completion scripts ask, which records
 // the arguments it receives and answers with one candidate.
 func writeCompletionTestApp(t *testing.T, dir string) {
@@ -196,7 +207,7 @@ var shellDrivers = map[string]shellDriver{
 					return ". " + p + "\n"
 				}
 			}
-			t.Skip("bash-completion is not installed")
+			skipMissingShell(t, "bash-completion is not installed")
 			return ""
 		},
 		program: func(scriptPath string, tc completionCase) string {

--- a/completion_shell_test.go
+++ b/completion_shell_test.go
@@ -33,11 +33,12 @@ type completionCase struct {
 	// works the words out for itself tests its own idea of that rather than the
 	// script's: these were measured in bash 5.3 with a completion function that dumps
 	// COMP_WORDS.
-	//
-	// It is nil for a line bash never reaches the completion function with, which the
-	// bash run skips: there is no measurement to make, and writing one out by hand is
-	// the guessing this field exists to avoid.
 	bashWords []string
+	// bashSkip says why bash is left out of this line, and is empty when it is not.
+	// Leaving bashWords out is not the signal: a case that simply forgot them would
+	// then quietly cover one shell fewer, which is what CLI_SHELL_TESTS_REQUIRED
+	// exists to prevent one directory up.
+	bashSkip string
 	// pwshLine is line as it would be typed in PowerShell, where it differs. A quoted
 	// command name is only a command there when the call operator says so: "'app' su"
 	// is a string followed by a word, not a command being completed.
@@ -101,14 +102,12 @@ func completionCases() []completionCase {
 			// The command word is a word like any other: one level of quoting comes
 			// off it too, or the request is sent to a command whose name holds the
 			// quotes.
-			//
-			// bash is left out: a command word holding a quote matches no compspec, so
-			// bash completes it as a file name and never calls the function under test
-			// here. Measured the way the words below were, with a completion function
-			// that records having been called.
 			name:     "a quoted command word",
 			line:     "'app' su",
 			pwshLine: "& 'app' su",
+			// Measured the way the words above were, with a completion function that
+			// records having been called: 'app' su and "app" su never reach it.
+			bashSkip: "a command word holding a quote matches no compspec, so bash completes it as a file name",
 			want:     []string{"__complete", "su"},
 		},
 		{
@@ -161,8 +160,8 @@ func TestCompletionScriptsRequest(t *testing.T) {
 				t.Run(tc.name, func(t *testing.T) {
 					t.Parallel()
 
-					if shell == "bash" && tc.bashWords == nil {
-						t.Skip("bash does not reach the completion function for this line")
+					if shell == "bash" && tc.bashSkip != "" {
+						t.Skip(tc.bashSkip)
 					}
 
 					dir := t.TempDir()

--- a/completion_test.go
+++ b/completion_test.go
@@ -876,3 +876,60 @@ func TestCompletionCustomShellCompleteNotRunPastDoubleDash(t *testing.T) {
 	r.True(ran)
 	r.Equal("custom\n", out.String())
 }
+
+// TestCompletionRequestIgnoredWhenDisabled checks that the request form means nothing
+// to an app that has not enabled shell completion: the first argument reaches it as
+// the positional argument it wrote.
+func TestCompletionRequestIgnoredWhenDisabled(t *testing.T) {
+	var got []string
+	out := &bytes.Buffer{}
+	cmd := &Command{
+		Writer: out,
+		Action: func(_ context.Context, cmd *Command) error {
+			got = cmd.Args().Slice()
+			return nil
+		},
+	}
+
+	r := require.New(t)
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "bar"}))
+	r.Equal([]string{completionCommandRequest, "bar"}, got)
+	r.Empty(out.String())
+}
+
+// TestCompletionRequestNestedSubcommand checks that a request is answered by the
+// command it names however deep that is, rather than by the one above it.
+func TestCompletionRequestNestedSubcommand(t *testing.T) {
+	out := &bytes.Buffer{}
+	cmd := &Command{
+		EnableShellCompletion: true,
+		Writer:                out,
+		Commands: []*Command{
+			{
+				Name: "one",
+				Commands: []*Command{
+					{
+						Name:   "two",
+						Flags:  []Flag{&BoolFlag{Name: "deep"}},
+						Action: func(context.Context, *Command) error { return nil },
+					},
+				},
+			},
+		},
+	}
+
+	r := require.New(t)
+
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "one", ""}))
+	r.Equal("two\nhelp:Shows a list of commands or help for one command\n", out.String())
+
+	out.Reset()
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "one", "two", "-"}))
+	r.Equal("--deep\n--help:show help\n", out.String())
+
+	// The word being completed is a flag of the command it follows, even with a
+	// positional argument in between, which the arguments alone could not say.
+	out.Reset()
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "one", "two", "arg", "--de"}))
+	r.Equal("--deep\n", out.String())
+}

--- a/completion_test.go
+++ b/completion_test.go
@@ -259,7 +259,7 @@ func TestCompletionFishSendsTokenBeingCompleted(t *testing.T) {
 	output, err := fishRender(cmd, "myapp")
 	r.NoError(err)
 
-	r.Contains(output, `set -l lastArg (string unescape -- (commandline -ct))`)
+	r.Contains(output, `set -l lastArg (string unescape -- $rawArg; or printf '%s' $rawArg)`)
 	r.Contains(output, `set results ($cmd __complete $args[2..-1] "$lastArg" 2> /dev/null)`)
 	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
 }
@@ -327,6 +327,8 @@ func TestCompletionPowershellSendsTokenBeingCompleted(t *testing.T) {
 	r.NoError(err)
 
 	r.Contains(output, `& $command __complete @words $word 2>$null`)
+	r.Contains(output, `$PSNativeCommandArgumentPassing = 'Standard'`,
+		"an empty word has to survive the way to the command")
 	r.Contains(output, `if ($cursorPosition -gt $extent.StartOffset -and $cursorPosition -le $extent.EndOffset) {`,
 		"the word being completed must come from the cursor, not from a comparison with $wordToComplete")
 	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")

--- a/completion_test.go
+++ b/completion_test.go
@@ -282,7 +282,7 @@ func TestCompletionBashSendsTokenBeingCompleted(t *testing.T) {
 	output, err := bashRender(cmd, "myapp")
 	r.NoError(err)
 
-	r.Contains(output, `__myapp_completion_request=("${__myapp_dequoted}" "__complete")`)
+	r.Contains(output, `__myapp_completion_request=("${cmd}" "__complete")`)
 	r.Contains(output, `__myapp_dequote "${words[cword]-}"`)
 	r.Contains(output, `opts=$("${__myapp_completion_request[@]}" 2>/dev/null)`)
 	r.Contains(output, `for (( i = 1; i < cword; i++ )); do`,

--- a/completion_test.go
+++ b/completion_test.go
@@ -324,7 +324,9 @@ func TestCompletionPowershellSendsTokenBeingCompleted(t *testing.T) {
 	output, err := pwshRender(cmd, "myapp")
 	r.NoError(err)
 
-	r.Contains(output, `& $command __complete @words $wordToComplete 2>$null`)
+	r.Contains(output, `& $command __complete @words $word 2>$null`)
+	r.Contains(output, `if ($cursorPosition -gt $extent.StartOffset -and $cursorPosition -le $extent.EndOffset) {`,
+		"the word being completed must come from the cursor, not from a comparison with $wordToComplete")
 	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
 }
 

--- a/completion_test.go
+++ b/completion_test.go
@@ -282,6 +282,7 @@ func TestCompletionBashSendsTokenBeingCompleted(t *testing.T) {
 	output, err := bashRender(cmd, "myapp")
 	r.NoError(err)
 
+	r.Contains(output, `__myapp_dequote "${words[0]}"`)
 	r.Contains(output, `__myapp_completion_request=("${cmd}" "__complete")`)
 	r.Contains(output, `__myapp_dequote "${words[cword]-}"`)
 	r.Contains(output, `opts=$("${__myapp_completion_request[@]}" 2>/dev/null)`)

--- a/completion_test.go
+++ b/completion_test.go
@@ -798,3 +798,41 @@ func TestCompletionRequestKeepsArgsShape(t *testing.T) {
 		})
 	}
 }
+
+// TestCompletionRequestStateIsPerRun checks that a Command answering several requests
+// carries no state from one into the next. A shell runs one request per process, but
+// a test, a REPL or an embedded use answers several through the same Command.
+func TestCompletionRequestStateIsPerRun(t *testing.T) {
+	out := &bytes.Buffer{}
+	cmd := &Command{
+		EnableShellCompletion: true,
+		Writer:                out,
+		Commands: []*Command{
+			{
+				Name:   "exec",
+				Flags:  []Flag{&BoolFlag{Name: "excitement"}},
+				Action: func(context.Context, *Command) error { return nil },
+			},
+		},
+	}
+
+	r := require.New(t)
+
+	// A request past a "--" gets no suggestion, and records that.
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "exec", "--", "git", "pu"}))
+	r.Empty(out.String())
+
+	// The next request is a different one, and is answered on its own terms.
+	out.Reset()
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "exec", "-"}))
+	r.Equal("--excitement\n--help:show help\n", out.String())
+
+	// The same holds for a request in the deprecated form, which says nothing about
+	// the word being completed and so must not read what an earlier one said.
+	out.Reset()
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "exec", "--", "git", "pu"}))
+	r.Empty(out.String())
+	out.Reset()
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", "exec", "-", completionFlag}))
+	r.Equal("--excitement\n--help:show help\n", out.String())
+}

--- a/completion_test.go
+++ b/completion_test.go
@@ -304,7 +304,7 @@ func TestCompletionZshSendsTokenBeingCompleted(t *testing.T) {
 	output, err := zshRender(cmd, "myapp")
 	r.NoError(err)
 
-	r.Contains(output, `request=("${(@Q)words[1]}" "__complete" "${(@Q)words[2,CURRENT-1]}" "${(@Q)words[CURRENT]}")`)
+	r.Contains(output, `request=("${(@Q)words[1]}" "__complete" "${(@Q)words[2,CURRENT-1]}" "$current")`)
 	r.Contains(output, `opts=("${(@f)$("${request[@]}" 2>/dev/null)}")`,
 		"a command writing to stderr must not break the prompt")
 	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")

--- a/completion_test.go
+++ b/completion_test.go
@@ -283,9 +283,11 @@ func TestCompletionBashSendsTokenBeingCompleted(t *testing.T) {
 	r.NoError(err)
 
 	r.Contains(output, `__myapp_dequote "${words[0]}"`)
-	r.Contains(output, `__myapp_completion_request=("${cmd}" "__complete")`)
+	r.Contains(output, `__cli_completion_request=("${cmd}" "__complete")`)
+	r.NotContains(output, "__myapp_completion_request",
+		"an app name belongs in a function name, which may hold a \"-\", not in a variable name")
 	r.Contains(output, `__myapp_dequote "${words[cword]-}"`)
-	r.Contains(output, `opts=$("${__myapp_completion_request[@]}" 2>/dev/null)`)
+	r.Contains(output, `opts=$("${__cli_completion_request[@]}" 2>/dev/null)`)
 	r.Contains(output, `for (( i = 1; i < cword; i++ )); do`,
 		"the request must come from the words __myapp_init_completion reassembled, not from COMP_WORDS")
 	r.NotContains(output, `eval "`, "the request must not go through eval")

--- a/completion_test.go
+++ b/completion_test.go
@@ -933,3 +933,35 @@ func TestCompletionRequestNestedSubcommand(t *testing.T) {
 	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "one", "two", "arg", "--de"}))
 	r.Equal("--deep\n", out.String())
 }
+
+// TestCompletionBeforeNotRunPastDoubleDash checks that a Before is not run for a
+// request past a "--": there is no completion to prepare for, since the words there
+// belong to whatever the command runs, and a Before with a side effect would fire on
+// every tab key for an answer that is always empty.
+func TestCompletionBeforeNotRunPastDoubleDash(t *testing.T) {
+	ran := 0
+	out := &bytes.Buffer{}
+	cmd := &Command{
+		EnableShellCompletion: true,
+		Writer:                out,
+		Before: func(ctx context.Context, _ *Command) (context.Context, error) {
+			ran++
+			return ctx, nil
+		},
+		Commands: []*Command{
+			{
+				Name:   "exec",
+				Action: func(context.Context, *Command) error { return nil },
+			},
+		},
+	}
+
+	r := require.New(t)
+
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "exec", "--", "git", "pu"}))
+	r.Zero(ran, "Before must not run for a request past a double dash")
+	r.Empty(out.String())
+
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "exec", "pu"}))
+	r.Equal(1, ran, "Before still runs for a request the command answers")
+}

--- a/completion_test.go
+++ b/completion_test.go
@@ -259,6 +259,7 @@ func TestCompletionFishSendsTokenBeingCompleted(t *testing.T) {
 	output, err := fishRender(cmd, "myapp")
 	r.NoError(err)
 
+	r.Contains(output, `set -l lastArg (string unescape -- (commandline -ct))`)
 	r.Contains(output, `set results ($args[1] __complete $args[2..-1] "$lastArg" 2> /dev/null)`)
 	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
 }

--- a/completion_test.go
+++ b/completion_test.go
@@ -836,3 +836,36 @@ func TestCompletionRequestStateIsPerRun(t *testing.T) {
 	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", "exec", "-", completionFlag}))
 	r.Equal("--excitement\n--help:show help\n", out.String())
 }
+
+// TestCompletionCustomShellCompleteNotRunPastDoubleDash checks that a command
+// carrying a ShellComplete of its own suggests nothing past a "--" without having to
+// know about "--": the words there are positional arguments of whatever it runs.
+func TestCompletionCustomShellCompleteNotRunPastDoubleDash(t *testing.T) {
+	ran := false
+	out := &bytes.Buffer{}
+	cmd := &Command{
+		EnableShellCompletion: true,
+		Writer:                out,
+		Commands: []*Command{
+			{
+				Name: "exec",
+				ShellComplete: func(_ context.Context, cmd *Command) {
+					ran = true
+					fmt.Fprintln(cmd.Root().Writer, "custom")
+				},
+				Action: func(context.Context, *Command) error { return nil },
+			},
+		},
+	}
+
+	r := require.New(t)
+
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "exec", "--", "git", "pu"}))
+	r.False(ran, "the completion func must not run past a double dash")
+	r.Empty(out.String())
+
+	// It is the "--" that stops it, not the command.
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", completionCommandRequest, "exec", "pu"}))
+	r.True(ran)
+	r.Equal("custom\n", out.String())
+}

--- a/completion_test.go
+++ b/completion_test.go
@@ -242,7 +242,10 @@ func TestCompletionFishFormat(t *testing.T) {
 	r.Contains(output, "(__myapp_perform_completion)", "completion function should be registered")
 }
 
-func TestCompletionFishOmitsPositionalTokenFromDynamicCompletion(t *testing.T) {
+func TestCompletionFishSendsTokenBeingCompleted(t *testing.T) {
+	// The word under the cursor is part of the request, quoted so that an empty one
+	// is still an argument: without it, "cmd --<TAB>" and "cmd -- <TAB>" would reach
+	// the command as the same request.
 	cmd := &Command{
 		Name:                  "myapp",
 		EnableShellCompletion: true,
@@ -256,12 +259,15 @@ func TestCompletionFishOmitsPositionalTokenFromDynamicCompletion(t *testing.T) {
 	output, err := fishRender(cmd, "myapp")
 	r.NoError(err)
 
-	r.Contains(output, `if string match -q -- "-*" $lastArg`)
-	r.Contains(output, "set results ($args[1] $args[2..-1] $lastArg --generate-shell-completion 2> /dev/null)")
-	r.Contains(output, "set results ($args[1] $args[2..-1] --generate-shell-completion 2> /dev/null)")
+	r.Contains(output, `set results ($args[1] __complete $args[2..-1] "$lastArg" 2> /dev/null)`)
+	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
 }
 
-func TestCompletionBashOmitsPositionalTokenFromDynamicCompletion(t *testing.T) {
+func TestCompletionBashSendsTokenBeingCompleted(t *testing.T) {
+	// The word under the cursor is part of the request, empty or not: without it,
+	// "cmd --<TAB>" and "cmd -- <TAB>" would reach the command as the same request.
+	// The request is an array rather than a string to eval, so a word holding a space
+	// or a quote reaches the command as the single word it is.
 	cmd := &Command{
 		Name:                  "myapp",
 		EnableShellCompletion: true,
@@ -275,9 +281,47 @@ func TestCompletionBashOmitsPositionalTokenFromDynamicCompletion(t *testing.T) {
 	output, err := bashRender(cmd, "myapp")
 	r.NoError(err)
 
-	r.Contains(output, `if [[ "${current_word}" == "-"* ]]; then`)
-	r.Contains(output, `printf '%s %s --generate-shell-completion' "${words_before_cursor[*]}" "${current_word}"`)
-	r.Contains(output, `printf '%s --generate-shell-completion' "${words_before_cursor[*]}"`)
+	r.Contains(output, `__cli_completion_request=("${COMP_WORDS[0]}" "__complete")`)
+	r.Contains(output, `__cli_completion_request+=("${COMP_WORDS[COMP_CWORD]-}")`)
+	r.Contains(output, `opts=$("${__cli_completion_request[@]}" 2>/dev/null)`)
+	r.NotContains(output, `eval "`, "the request must not go through eval")
+	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
+}
+
+func TestCompletionZshSendsTokenBeingCompleted(t *testing.T) {
+	cmd := &Command{
+		Name:                  "myapp",
+		EnableShellCompletion: true,
+	}
+
+	r := require.New(t)
+
+	zshRender := shellCompletions["zsh"]
+	r.NotNil(zshRender, "zsh completion renderer should exist")
+
+	output, err := zshRender(cmd, "myapp")
+	r.NoError(err)
+
+	r.Contains(output, `request=("${words[1]}" "__complete" "${(@)words[2,CURRENT-1]}" "${words[CURRENT]}")`)
+	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
+}
+
+func TestCompletionPowershellSendsTokenBeingCompleted(t *testing.T) {
+	cmd := &Command{
+		Name:                  "myapp",
+		EnableShellCompletion: true,
+	}
+
+	r := require.New(t)
+
+	pwshRender := shellCompletions["pwsh"]
+	r.NotNil(pwshRender, "pwsh completion renderer should exist")
+
+	output, err := pwshRender(cmd, "myapp")
+	r.NoError(err)
+
+	r.Contains(output, `& $command __complete @words $wordToComplete 2>$null`)
+	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
 }
 
 func TestCompletionSubcommand(t *testing.T) {
@@ -568,4 +612,189 @@ func TestCompletionShellWriteError(t *testing.T) {
 
 	err := cmd.Run(buildTestContext(t), []string{"foo", completionCommandName, shellName})
 	assert.ErrorContains(t, err, "writer error")
+}
+
+// TestCompletionRequestNeverRunsAction is the regression test for
+// https://github.com/urfave/cli/issues/1993: a shell asking for completions must
+// never run the command, whatever the command line holds. A request appended to the
+// end of the command line cannot promise that, because "--" turns it into a
+// positional argument that a wrapper command is entitled to pass on, which is what
+// https://github.com/urfave/cli/issues/1932 asked for.
+func TestCompletionRequestNeverRunsAction(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "plain",
+			args: []string{"foo", completionCommandRequest, "exec", ""},
+		},
+		{
+			name: "after a double dash",
+			args: []string{"foo", completionCommandRequest, "exec", "--", "rm", "-rf"},
+		},
+		{
+			name: "completing the double dash",
+			args: []string{"foo", completionCommandRequest, "exec", "--"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ran := false
+			out := &bytes.Buffer{}
+			cmd := &Command{
+				EnableShellCompletion: true,
+				Writer:                out,
+				Commands: []*Command{
+					{
+						Name:            "exec",
+						SkipFlagParsing: true,
+						Action: func(context.Context, *Command) error {
+							ran = true
+							return nil
+						},
+					},
+				},
+			}
+
+			r := require.New(t)
+			r.NoError(cmd.Run(buildTestContext(t), tc.args))
+			r.False(ran, "the action must not run for a completion request")
+		})
+	}
+}
+
+// TestCompletionRequestAfterDoubleDash checks that the words after a "--" get no
+// suggestion: they are positional arguments of whatever the command runs, so this
+// command's flags and subcommands are no answer to them. The "--" being completed is
+// not one of them.
+func TestCompletionRequestAfterDoubleDash(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			// The completion is for the word after "exec", which has no subcommand of
+			// its own to offer beyond the built-in help.
+			name:     "before the double dash",
+			args:     []string{"foo", completionCommandRequest, "exec", ""},
+			expected: "help:Shows a list of commands or help for one command\n",
+		},
+		{
+			name:     "the double dash itself",
+			args:     []string{"foo", completionCommandRequest, "exec", "--"},
+			expected: "--excitement\n--help:show help\n",
+		},
+		{
+			name:     "after the double dash",
+			args:     []string{"foo", completionCommandRequest, "exec", "--", "git", "pu"},
+			expected: "",
+		},
+		{
+			name:     "a flag after the double dash",
+			args:     []string{"foo", completionCommandRequest, "exec", "--", "git", "--ver"},
+			expected: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			cmd := &Command{
+				EnableShellCompletion: true,
+				Writer:                out,
+				Commands: []*Command{
+					{
+						Name:   "exec",
+						Flags:  []Flag{&BoolFlag{Name: "excitement"}},
+						Action: func(context.Context, *Command) error { return nil },
+					},
+				},
+			}
+
+			r := require.New(t)
+			r.NoError(cmd.Run(buildTestContext(t), tc.args))
+			r.Equal(tc.expected, out.String())
+		})
+	}
+}
+
+// TestCompletionDeprecatedRequestPassedOnAfterDoubleDash is the regression test for
+// https://github.com/urfave/cli/issues/1932: after a "--", the deprecated request
+// form is a positional argument, so a wrapper command passes it on to whatever it
+// runs instead of answering it. That command, run by the wrapper, is the one the
+// shell was asking about.
+func TestCompletionDeprecatedRequestPassedOnAfterDoubleDash(t *testing.T) {
+	var got []string
+	out := &bytes.Buffer{}
+	cmd := &Command{
+		EnableShellCompletion: true,
+		Writer:                out,
+		Commands: []*Command{
+			{
+				Name:            "exec",
+				SkipFlagParsing: true,
+				Action: func(_ context.Context, cmd *Command) error {
+					got = cmd.Args().Slice()
+					return nil
+				},
+			},
+		},
+	}
+
+	r := require.New(t)
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", "exec", "--", "child", completionFlag}))
+	r.Equal([]string{"--", "child", completionFlag}, got)
+	r.Empty(out.String(), "the wrapper must not answer a request meant for what it runs")
+}
+
+// TestCompletionRequestKeepsArgsShape checks that a ShellComplete function sees the
+// same cmd.Args() under both request forms: the word being completed is part of them
+// when it starts with "-", and left out otherwise.
+func TestCompletionRequestKeepsArgsShape(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "deprecated form completing a flag",
+			args:     []string{"foo", "sub", "arg", "-", completionFlag},
+			expected: "[arg -]\n",
+		},
+		{
+			name:     "request completing a flag",
+			args:     []string{"foo", completionCommandRequest, "sub", "arg", "-"},
+			expected: "[arg -]\n",
+		},
+		{
+			name:     "deprecated form completing a word",
+			args:     []string{"foo", "sub", "arg", completionFlag},
+			expected: "[arg]\n",
+		},
+		{
+			name:     "request completing a word",
+			args:     []string{"foo", completionCommandRequest, "sub", "arg", "wor"},
+			expected: "[arg]\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			cmd := &Command{
+				EnableShellCompletion: true,
+				Writer:                out,
+				Commands: []*Command{
+					{
+						Name: "sub",
+						ShellComplete: func(_ context.Context, cmd *Command) {
+							fmt.Fprintf(cmd.Root().Writer, "%v\n", cmd.Args().Slice())
+						},
+						Action: func(context.Context, *Command) error { return nil },
+					},
+				},
+			}
+
+			r := require.New(t)
+			r.NoError(cmd.Run(buildTestContext(t), tc.args))
+			r.Equal(tc.expected, out.String())
+		})
+	}
 }

--- a/completion_test.go
+++ b/completion_test.go
@@ -304,7 +304,9 @@ func TestCompletionZshSendsTokenBeingCompleted(t *testing.T) {
 	output, err := zshRender(cmd, "myapp")
 	r.NoError(err)
 
-	r.Contains(output, `request=("${words[1]}" "__complete" "${(@)words[2,CURRENT-1]}" "${words[CURRENT]}")`)
+	r.Contains(output, `request=("${(@Q)words[1]}" "__complete" "${(@Q)words[2,CURRENT-1]}" "${(@Q)words[CURRENT]}")`)
+	r.Contains(output, `opts=("${(@f)$("${request[@]}" 2>/dev/null)}")`,
+		"a command writing to stderr must not break the prompt")
 	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
 }
 

--- a/completion_test.go
+++ b/completion_test.go
@@ -260,7 +260,7 @@ func TestCompletionFishSendsTokenBeingCompleted(t *testing.T) {
 	r.NoError(err)
 
 	r.Contains(output, `set -l lastArg (string unescape -- (commandline -ct))`)
-	r.Contains(output, `set results ($args[1] __complete $args[2..-1] "$lastArg" 2> /dev/null)`)
+	r.Contains(output, `set results ($cmd __complete $args[2..-1] "$lastArg" 2> /dev/null)`)
 	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
 }
 
@@ -306,7 +306,7 @@ func TestCompletionZshSendsTokenBeingCompleted(t *testing.T) {
 	output, err := zshRender(cmd, "myapp")
 	r.NoError(err)
 
-	r.Contains(output, `request=("${(@Q)words[1]}" "__complete" "${(@Q)words[2,CURRENT-1]}" "$current")`)
+	r.Contains(output, `request=("$cmd" "__complete" "${(@Q)words[2,CURRENT-1]}" "$current")`)
 	r.Contains(output, `opts=("${(@f)$("${request[@]}" 2>/dev/null)}")`,
 		"a command writing to stderr must not break the prompt")
 	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")

--- a/completion_test.go
+++ b/completion_test.go
@@ -281,9 +281,11 @@ func TestCompletionBashSendsTokenBeingCompleted(t *testing.T) {
 	output, err := bashRender(cmd, "myapp")
 	r.NoError(err)
 
-	r.Contains(output, `__cli_completion_request=("${COMP_WORDS[0]}" "__complete")`)
-	r.Contains(output, `__cli_completion_request+=("${COMP_WORDS[COMP_CWORD]-}")`)
-	r.Contains(output, `opts=$("${__cli_completion_request[@]}" 2>/dev/null)`)
+	r.Contains(output, `__myapp_completion_request=("${__myapp_dequoted}" "__complete")`)
+	r.Contains(output, `__myapp_dequote "${words[cword]-}"`)
+	r.Contains(output, `opts=$("${__myapp_completion_request[@]}" 2>/dev/null)`)
+	r.Contains(output, `for (( i = 1; i < cword; i++ )); do`,
+		"the request must come from the words __myapp_init_completion reassembled, not from COMP_WORDS")
 	r.NotContains(output, `eval "`, "the request must not go through eval")
 	r.NotContains(output, completionFlag, "the deprecated request form must not be generated")
 }

--- a/docs/v3/examples/completions/customizations.md
+++ b/docs/v3/examples/completions/customizations.md
@@ -105,11 +105,12 @@ func main() {
 }
 ```
 
-#### Customization
+#### The completion request
 
 Setting `cli.EnableShellCompletion` makes the app answer a completion request, which the
 generated scripts send as a `__complete` first argument followed by the words typed so far and
-the word being completed:
+the word being completed. That name is fixed: unlike the flag it replaces, an app cannot rename it,
+since the completion script and the app have to agree on it.
 
 <!-- {
   "args": ["__complete", ""],

--- a/docs/v3/examples/completions/customizations.md
+++ b/docs/v3/examples/completions/customizations.md
@@ -107,11 +107,12 @@ func main() {
 
 #### Customization
 
-The default shell completion flag (`--generate-shell-completion`) is defined as
-`cli.EnableShellCompletion`, and may be redefined if desired, e.g.:
+Setting `cli.EnableShellCompletion` makes the app answer a completion request, which the
+generated scripts send as a `__complete` first argument followed by the words typed so far and
+the word being completed:
 
 <!-- {
-  "args": ["&#45;&#45;generate&#45;shell&#45;completion"],
+  "args": ["__complete", ""],
 	"output": "wat\nhelp:Shows a list of commands or help for one command\n"
 } -->
 ```go

--- a/docs/v3/examples/completions/customizations.md
+++ b/docs/v3/examples/completions/customizations.md
@@ -109,8 +109,8 @@ func main() {
 
 Setting `cli.EnableShellCompletion` makes the app answer a completion request, which the
 generated scripts send as a `__complete` first argument followed by the words typed so far and
-the word being completed. That name is fixed: unlike the flag it replaces, an app cannot rename it,
-since the completion script and the app have to agree on it.
+the word being completed. That name is fixed: an app cannot rename it, since the completion script
+and the app have to agree on it.
 
 <!-- {
   "args": ["__complete", ""],

--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -133,6 +133,20 @@ that wraps another one therefore cannot hand its completions on: `myapp exec -- 
 nothing rather than what `git` would offer. What it does do is leave your app's action alone, which
 is what a shell asking for completions needs.
 
+#### What the shells cannot answer
+
+Two command lines have no answer, whichever shell you use.
+
+A word after a `--` that a flag took as its value is read as a word after a terminator, so
+`myapp --separator -- <TAB>` offers nothing. Which flags take a value is known once the flags are
+parsed, and the request is read before that.
+
+Windows PowerShell 5.1 drops an empty argument on the way to a native command, and PowerShell 7.0
+to 7.2 does the same on Windows unless `$PSNativeCommandArgumentPassing` is `Standard`, which the
+generated script sets where it can. Without it the word being completed goes missing from the
+request and the command answers as though the line ended a word earlier. PowerShell 7.3 and later
+need nothing.
+
 #### Regenerate the script after upgrading
 
 Completion scripts generated before urfave/cli asked for completions with `__complete` end their request

--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -147,8 +147,9 @@ longer turn it into a positional argument.
 Until the script is regenerated, pressing tab on such a line runs your app. Nothing rejects the
 request: after a `--` the flag is a positional argument, so it is passed to your action along with
 everything else on the line and the run completes as though you had pressed enter. Declaring how
-many arguments a command takes does not stop it either, since an argument too many is not an error
-here; only your own action can turn it down. A command that
+many arguments a command takes does not stop it either: an argument too many is not an error here.
+What the flag runs into is up to your app — a typed argument list rejects it as the number it is
+not, and an action that checks what it was given can turn it down — so do not count on any of it. A command that
 passes its arguments on hands the flag to what it runs, which is what makes it the right reading for
 a wrapper, and the wrong one for a tab key. Regenerating the script is what separates the two.
 

--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -144,9 +144,10 @@ belongs to whatever the app runs rather than to the app itself, and the app runs
 resolves that: `__complete` is the first argument, where a `--` typed later on the command line can no
 longer turn it into a positional argument.
 
-Until the script is regenerated, pressing tab on such a line runs your app. Nothing rejects the
-request: after a `--` the flag is a positional argument, so it is passed to your action along with
-everything else on the line and the run completes as though you had pressed enter. A command that
+Until the script is regenerated, pressing tab on such a line runs your app. Nothing about the flag
+rejects the request: after a `--` it is a positional argument, so it is passed to your action along
+with everything else on the line and the run usually completes as though you had pressed enter. A
+command declaring how many arguments it takes is the exception, and rejects the extra one. A command that
 passes its arguments on hands the flag to what it runs, which is what makes it the right reading for
 a wrapper, and the wrong one for a tab key. Regenerating the script is what separates the two.
 

--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -144,10 +144,11 @@ belongs to whatever the app runs rather than to the app itself, and the app runs
 resolves that: `__complete` is the first argument, where a `--` typed later on the command line can no
 longer turn it into a positional argument.
 
-Until the script is regenerated, pressing tab on such a line runs your app. Nothing about the flag
-rejects the request: after a `--` it is a positional argument, so it is passed to your action along
-with everything else on the line and the run usually completes as though you had pressed enter. A
-command declaring how many arguments it takes is the exception, and rejects the extra one. A command that
+Until the script is regenerated, pressing tab on such a line runs your app. Nothing rejects the
+request: after a `--` the flag is a positional argument, so it is passed to your action along with
+everything else on the line and the run completes as though you had pressed enter. Declaring how
+many arguments a command takes does not stop it either, since an argument too many is not an error
+here; only your own action can turn it down. A command that
 passes its arguments on hands the flag to what it runs, which is what makes it the right reading for
 a wrapper, and the wrong one for a tab key. Regenerating the script is what separates the two.
 

--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -125,6 +125,14 @@ are read as the command line being completed. An app that takes free-form positi
 therefore cannot receive `__complete` as its first one. An app that declares a command of that name
 keeps it, and stops being completable in exchange.
 
+#### Nothing is completed after a `--`
+
+The words after a `--` are positional arguments of whatever your app runs with them, so urfave/cli
+answers a request for one with no candidates and does not run your `ShellComplete` at all. A command
+that wraps another one therefore cannot hand its completions on: `myapp exec -- git pu<TAB>` offers
+nothing rather than what `git` would offer. What it does do is leave your app's action alone, which
+is what a shell asking for completions needs.
+
 #### Regenerate the script after upgrading
 
 Completion scripts generated before urfave/cli asked for completions with `__complete` end their request

--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -117,6 +117,14 @@ The procedure for other shells is similar to bash though the specific paths for 
 shells may vary. Some of the sections below detail the setup need for other shells as
 well as examples in those shells.
 
+#### `__complete` is reserved
+
+Setting `EnableShellCompletion` reserves `__complete` as the first argument of your app: a run
+starting with it is answered as a completion request rather than passed on, and the words after it
+are read as the command line being completed. An app that takes free-form positional arguments
+therefore cannot receive `__complete` as its first one. An app that declares a command of that name
+keeps it, and stops being completable in exchange.
+
 #### Regenerate the script after upgrading
 
 Completion scripts generated before urfave/cli asked for completions with `__complete` end their request
@@ -127,6 +135,10 @@ belongs to whatever the app runs rather than to the app itself, and the app runs
 [#1993](https://github.com/urfave/cli/issues/1993)). Regenerating the script and sourcing it again is what
 resolves that: `__complete` is the first argument, where a `--` typed later on the command line can no
 longer turn it into a positional argument.
+
+Until the script is regenerated, pressing tab on such a line runs the app with the request left on it
+as a positional argument, which usually ends in an `Incorrect Usage` message rather than in the run
+completing quietly.
 
 #### Default auto-completion
 

--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -144,9 +144,11 @@ belongs to whatever the app runs rather than to the app itself, and the app runs
 resolves that: `__complete` is the first argument, where a `--` typed later on the command line can no
 longer turn it into a positional argument.
 
-Until the script is regenerated, pressing tab on such a line runs the app with the request left on it
-as a positional argument, which usually ends in an `Incorrect Usage` message rather than in the run
-completing quietly.
+Until the script is regenerated, pressing tab on such a line runs your app. Nothing rejects the
+request: after a `--` the flag is a positional argument, so it is passed to your action along with
+everything else on the line and the run completes as though you had pressed enter. A command that
+passes its arguments on hands the flag to what it runs, which is what makes it the right reading for
+a wrapper, and the wrong one for a tab key. Regenerating the script is what separates the two.
 
 #### Default auto-completion
 

--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -7,7 +7,9 @@ search:
 
 The urfave/cli v3 library supports programmable completion for apps utilizing its framework. This means
 that the completion is generated dynamically at runtime by invoking the app itself with a special hidden
-flag. The urfave/cli searches for this flag and activates a different flow for command paths than regular flow
+first argument, `__complete`, followed by the words typed so far and, as the last argument, the word being
+completed. The urfave/cli searches for that argument and activates a different flow for command paths than
+regular flow.
 The following shells are supported
 
  - bash
@@ -114,6 +116,17 @@ $ source <(greet completion bash)
 The procedure for other shells is similar to bash though the specific paths for each of the 
 shells may vary. Some of the sections below detail the setup need for other shells as
 well as examples in those shells.
+
+#### Regenerate the script after upgrading
+
+Completion scripts generated before urfave/cli asked for completions with `__complete` end their request
+with a `--generate-shell-completion` flag instead. Those scripts keep working, but a command line holding
+a `--` cannot be answered through them: after `--` only positional arguments are accepted, so the flag
+belongs to whatever the app runs rather than to the app itself, and the app runs instead of completing
+(see [#1932](https://github.com/urfave/cli/issues/1932) and
+[#1993](https://github.com/urfave/cli/issues/1993)). Regenerating the script and sourcing it again is what
+resolves that: `__complete` is the first argument, where a `--` typed later on the command line can no
+longer turn it into a positional argument.
 
 #### Default auto-completion
 

--- a/docs/v3/examples/completions/shell-completions.md
+++ b/docs/v3/examples/completions/shell-completions.md
@@ -144,12 +144,12 @@ belongs to whatever the app runs rather than to the app itself, and the app runs
 resolves that: `__complete` is the first argument, where a `--` typed later on the command line can no
 longer turn it into a positional argument.
 
-Until the script is regenerated, pressing tab on such a line runs your app. Nothing rejects the
-request: after a `--` the flag is a positional argument, so it is passed to your action along with
-everything else on the line and the run completes as though you had pressed enter. Declaring how
-many arguments a command takes does not stop it either: an argument too many is not an error here.
-What the flag runs into is up to your app — a typed argument list rejects it as the number it is
-not, and an action that checks what it was given can turn it down — so do not count on any of it. A command that
+Until the script is regenerated, pressing tab on such a line runs your app. The flag is not what
+stops it: after a `--` it is a positional argument, so it reaches your action along with everything
+else on the line. Whether the run gets that far is up to your app. Declaring how many arguments a
+command takes does not decide it, since an argument too many is not an error here; a typed argument
+list rejects the flag as the number it is not, and an action that looks at what it was given can
+turn it down. None of that is something to rely on to catch a tab key. A command that
 passes its arguments on hands the flag to what it runs, which is what makes it the right reading for
 a wrapper, and the wrong one for a tab key. Regenerating the script is what separates the two.
 

--- a/help.go
+++ b/help.go
@@ -255,11 +255,28 @@ func DefaultCompleteWithFlags(ctx context.Context, cmd *Command) {
 	} else {
 		tracef("running default complete with os.Args flags[%v]", args)
 	}
-	argsLen := len(args)
+
+	if cmd == nil {
+		return
+	}
+
+	// Everything after "--" is a positional argument of whatever the command runs, so
+	// this command's flags and subcommands are no answer to it.
+	// https://unix.stackexchange.com/a/11382
+	if cmd.Root().completionTerminated {
+		tracef("not suggesting past a \"--\" on command %[1]q", cmd.Name)
+		return
+	}
+
 	lastArg := ""
-	// parent command will have --generate-shell-completion so we need
-	// to account for that
-	if argsLen > 1 {
+	if word := cmd.Root().completionWord; word != nil {
+		// The request says which word is being completed, so there is nothing to work
+		// out from the position of the arguments.
+		lastArg = *word
+	} else if argsLen := len(args); argsLen > 1 {
+		// A request in the deprecated form leaves the word out unless it starts with
+		// "-", and the parent command still has completionFlag on it, so the word is
+		// looked for one before the end.
 		lastArg = args[argsLen-2]
 	} else if argsLen > 0 {
 		lastArg = args[argsLen-1]
@@ -275,11 +292,8 @@ func DefaultCompleteWithFlags(ctx context.Context, cmd *Command) {
 		return
 	}
 
-	if cmd != nil {
-		tracef("printing command suggestions on command %[1]q", cmd.Name)
-		printCommandSuggestions(cmd.Commands, cmd.Root().Writer)
-		return
-	}
+	tracef("printing command suggestions on command %[1]q", cmd.Name)
+	printCommandSuggestions(cmd.Commands, cmd.Root().Writer)
 }
 
 // ShowCommandHelpAndExit exits with code after showing help via ShowCommandHelp.
@@ -471,9 +485,40 @@ func checkVersion(cmd *Command) bool {
 	return cmd.versionFlag != nil && cmd.versionFlag.IsSet()
 }
 
-func checkShellCompleteFlag(c *Command, arguments []string) (bool, []string) {
+// parseShellCompleteRequest reports whether arguments are a shell completion request
+// and returns the arguments to parse. What the request says about the word being
+// completed is recorded on c, which is the root command.
+//
+// Two request forms are understood. The current one names the request up front:
+//
+//	<cmd> __complete <word>... <word being completed>
+//
+// The completion scripts send every word before the cursor, then the word under the
+// cursor, which is the empty string when the cursor sits on a fresh word. Naming the
+// request in the first argument is what keeps it out of reach of "--": everything
+// after that terminator is a positional argument, so a request appended at the end of
+// the command line cannot be told apart from a positional argument that happens to
+// look like one. See the deprecated form below for what that ambiguity costs.
+//
+// The deprecated form appends completionFlag to the command line. Scripts generated
+// before this change still use it, so it keeps working, with one caveat it cannot
+// escape: a command line holding "--" is answered as an ordinary run rather than as a
+// completion, because after "--" the flag is a positional argument that belongs to
+// whatever the command runs. That is what a wrapper command needs (see
+// https://github.com/urfave/cli/issues/1932), and it is why a shell that appends the
+// flag after a "--" runs the command instead of completing it (see
+// https://github.com/urfave/cli/issues/1993). Regenerating the completion script and
+// sourcing it again resolves that in favor of completing, since the request is then
+// no longer something a command line can imitate.
+func parseShellCompleteRequest(c *Command, arguments []string) (bool, []string) {
 	if (c.parent == nil && !c.EnableShellCompletion) || (c.parent != nil && !c.Root().shellCompletion) {
 		return false, arguments
+	}
+
+	// A command of that name, if the app happens to have one, is what was asked for:
+	// the request form is understood only where it shadows nothing.
+	if len(arguments) > 1 && arguments[1] == completionCommandRequest && c.Command(completionCommandRequest) == nil {
+		return true, c.parseCompletionRequest(arguments)
 	}
 
 	pos := len(arguments) - 1
@@ -483,16 +528,50 @@ func checkShellCompleteFlag(c *Command, arguments []string) (bool, []string) {
 		return false, arguments
 	}
 
-	// If arguments include "--" before the token being completed, shell completion
-	// is disabled because after "--" only positional arguments are accepted.
+	// The word being completed is at position pos-1, immediately before
+	// completionFlag, so only the arguments before that position are checked and
+	// completing "--" itself still works.
 	// https://unix.stackexchange.com/a/11382
-	// Note: The token being completed is at position pos-1 (immediately before completionFlag).
-	// We only check arguments before that position, so completing "--" itself still works.
 	if pos >= 1 && slices.Contains(arguments[:pos-1], "--") {
-		return false, arguments[:pos]
+		// The flag is a positional argument here, so it is left in place for the
+		// command to pass on, and the command runs.
+		return false, arguments
 	}
 
+	// This request form does not say which word is being completed, so nothing is
+	// recorded and DefaultCompleteWithFlags works it out from the arguments.
 	return true, arguments[:pos]
+}
+
+// parseCompletionRequest records what a request naming completionCommandRequest says
+// about the word being completed, and returns the arguments to parse.
+//
+// The word is kept in those arguments when it starts with "-", and dropped from them
+// otherwise, which is the shape the deprecated request form produced. A ShellComplete
+// function reading cmd.Args() therefore sees the same thing under both forms.
+func (cmd *Command) parseCompletionRequest(arguments []string) []string {
+	// arguments[0] is the program, arguments[1] is completionCommandRequest, and the
+	// word being completed is last. A request holding neither, which no script sends,
+	// is read as an empty word on an empty command line.
+	var words []string
+	word := ""
+	if len(arguments) > 2 {
+		words = arguments[2 : len(arguments)-1]
+		word = arguments[len(arguments)-1]
+	}
+	cmd.completionWord = &word
+	// Everything after a "--" is a positional argument of whatever the command runs,
+	// so this command has no suggestion for it. A "--" being completed is not one:
+	// it is the word itself, and flags still answer it.
+	cmd.completionTerminated = slices.Contains(words, "--")
+
+	args := make([]string, 0, len(arguments)-1)
+	args = append(args, arguments[0])
+	args = append(args, words...)
+	if strings.HasPrefix(word, "-") {
+		args = append(args, word)
+	}
+	return args
 }
 
 func shouldRunCompletion(cmd *Command) bool {

--- a/help.go
+++ b/help.go
@@ -606,18 +606,19 @@ func shouldRunCompletion(cmd *Command) bool {
 	return true
 }
 
-func runCompletion(ctx context.Context, cmd *Command) {
-	// Everything after "--" is a positional argument of whatever the command runs, so
-	// this command has no suggestion for it. Answering with nothing here rather than
-	// in the completion func applies that to every command, including one carrying a
-	// ShellComplete of its own, which would otherwise have to know about "--" itself
-	// to keep the promise the terminator makes.
-	// https://unix.stackexchange.com/a/11382
-	if req := cmd.Root().completion; req != nil && req.terminated {
-		tracef("not suggesting past a \"--\" on command %[1]q", cmd.Name)
-		return
-	}
+// completionTerminated reports whether the completion request being answered has a
+// "--" before the word being completed. The words there are positional arguments of
+// whatever the command runs, so this command has no suggestion for them, and its
+// completion func is not run at all: keeping that here rather than in the func
+// applies it to every command, including one carrying a ShellComplete of its own,
+// which would otherwise have to know about a "--" the parsed arguments no longer show.
+// https://unix.stackexchange.com/a/11382
+func (cmd *Command) completionTerminated() bool {
+	req := cmd.Root().completion
+	return req != nil && req.terminated
+}
 
+func runCompletion(ctx context.Context, cmd *Command) {
 	if cmd.ShellComplete != nil {
 		tracef("running shell completion func for command %[1]q", cmd.Name)
 		cmd.ShellComplete(ctx, cmd)

--- a/help.go
+++ b/help.go
@@ -260,18 +260,8 @@ func DefaultCompleteWithFlags(ctx context.Context, cmd *Command) {
 		return
 	}
 
-	req := cmd.Root().completion
-
-	// Everything after "--" is a positional argument of whatever the command runs, so
-	// this command's flags and subcommands are no answer to it.
-	// https://unix.stackexchange.com/a/11382
-	if req != nil && req.terminated {
-		tracef("not suggesting past a \"--\" on command %[1]q", cmd.Name)
-		return
-	}
-
 	lastArg := ""
-	if req != nil && req.wordKnown {
+	if req := cmd.Root().completion; req != nil && req.wordKnown {
 		// The request says which word is being completed, so there is nothing to work
 		// out from the position of the arguments.
 		lastArg = req.word
@@ -617,6 +607,17 @@ func shouldRunCompletion(cmd *Command) bool {
 }
 
 func runCompletion(ctx context.Context, cmd *Command) {
+	// Everything after "--" is a positional argument of whatever the command runs, so
+	// this command has no suggestion for it. Answering with nothing here rather than
+	// in the completion func applies that to every command, including one carrying a
+	// ShellComplete of its own, which would otherwise have to know about "--" itself
+	// to keep the promise the terminator makes.
+	// https://unix.stackexchange.com/a/11382
+	if req := cmd.Root().completion; req != nil && req.terminated {
+		tracef("not suggesting past a \"--\" on command %[1]q", cmd.Name)
+		return
+	}
+
 	if cmd.ShellComplete != nil {
 		tracef("running shell completion func for command %[1]q", cmd.Name)
 		cmd.ShellComplete(ctx, cmd)

--- a/help.go
+++ b/help.go
@@ -487,6 +487,12 @@ type completionRequest struct {
 	// terminated says whether a "--" precedes the word, which makes that word a
 	// positional argument of whatever the command runs rather than one this command
 	// has any suggestion for.
+	//
+	// A "--" a flag takes as its value counts here too, and is not one: telling them
+	// apart needs to know which flags take a value, which is known after the flags are
+	// parsed, and this is read before. Completing "app --sep -- s" therefore offers
+	// nothing. Erring this way costs a suggestion; erring the other way runs the
+	// command on the tab key.
 	terminated bool
 }
 

--- a/help.go
+++ b/help.go
@@ -260,19 +260,21 @@ func DefaultCompleteWithFlags(ctx context.Context, cmd *Command) {
 		return
 	}
 
+	req := cmd.Root().completion
+
 	// Everything after "--" is a positional argument of whatever the command runs, so
 	// this command's flags and subcommands are no answer to it.
 	// https://unix.stackexchange.com/a/11382
-	if cmd.Root().completionTerminated {
+	if req != nil && req.terminated {
 		tracef("not suggesting past a \"--\" on command %[1]q", cmd.Name)
 		return
 	}
 
 	lastArg := ""
-	if word := cmd.Root().completionWord; word != nil {
+	if req != nil && req.wordKnown {
 		// The request says which word is being completed, so there is nothing to work
 		// out from the position of the arguments.
-		lastArg = *word
+		lastArg = req.word
 	} else if argsLen := len(args); argsLen > 1 {
 		// A request in the deprecated form leaves the word out unless it starts with
 		// "-", and the parent command still has completionFlag on it, so the word is
@@ -485,6 +487,19 @@ func checkVersion(cmd *Command) bool {
 	return cmd.versionFlag != nil && cmd.versionFlag.IsSet()
 }
 
+// completionRequest is what a shell completion request says about the word being
+// completed.
+type completionRequest struct {
+	// word is the word the shell is completing. wordKnown says whether the request
+	// carried it: the deprecated request form does not.
+	word      string
+	wordKnown bool
+	// terminated says whether a "--" precedes the word, which makes that word a
+	// positional argument of whatever the command runs rather than one this command
+	// has any suggestion for.
+	terminated bool
+}
+
 // parseShellCompleteRequest reports whether arguments are a shell completion request
 // and returns the arguments to parse. What the request says about the word being
 // completed is recorded on c, which is the root command.
@@ -511,6 +526,9 @@ func checkVersion(cmd *Command) bool {
 // sourcing it again resolves that in favor of completing, since the request is then
 // no longer something a command line can imitate.
 func parseShellCompleteRequest(c *Command, arguments []string) (bool, []string) {
+	// Whatever the previous run of this Command recorded says nothing about this one.
+	c.completion = nil
+
 	if (c.parent == nil && !c.EnableShellCompletion) || (c.parent != nil && !c.Root().shellCompletion) {
 		return false, arguments
 	}
@@ -538,8 +556,9 @@ func parseShellCompleteRequest(c *Command, arguments []string) (bool, []string) 
 		return false, arguments
 	}
 
-	// This request form does not say which word is being completed, so nothing is
-	// recorded and DefaultCompleteWithFlags works it out from the arguments.
+	// This request form does not say which word is being completed, so
+	// DefaultCompleteWithFlags works it out from the arguments.
+	c.completion = &completionRequest{}
 	return true, arguments[:pos]
 }
 
@@ -559,11 +578,14 @@ func (cmd *Command) parseCompletionRequest(arguments []string) []string {
 		words = arguments[2 : len(arguments)-1]
 		word = arguments[len(arguments)-1]
 	}
-	cmd.completionWord = &word
-	// Everything after a "--" is a positional argument of whatever the command runs,
-	// so this command has no suggestion for it. A "--" being completed is not one:
-	// it is the word itself, and flags still answer it.
-	cmd.completionTerminated = slices.Contains(words, "--")
+	cmd.completion = &completionRequest{
+		word:      word,
+		wordKnown: true,
+		// Everything after a "--" is a positional argument of whatever the command
+		// runs. A "--" being completed is not one: it is the word itself, and flags
+		// still answer it.
+		terminated: slices.Contains(words, "--"),
+	}
 
 	args := make([]string, 0, len(arguments)-1)
 	args = append(args, arguments[0])

--- a/help_test.go
+++ b/help_test.go
@@ -2042,13 +2042,13 @@ func Test_parseShellCompleteRequest(t *testing.T) {
 			shellCompletion, args := parseShellCompleteRequest(tt.cmd, tt.arguments)
 			assert.Equal(t, tt.wantShellCompletion, shellCompletion)
 			assert.Equal(t, tt.wantArgs, args)
-			gotWord := ""
-			if tt.cmd.completionWord != nil {
-				gotWord = *tt.cmd.completionWord
+			gotWord, gotWordSet, gotTerminated := "", false, false
+			if req := tt.cmd.completion; req != nil {
+				gotWord, gotWordSet, gotTerminated = req.word, req.wordKnown, req.terminated
 			}
-			assert.Equal(t, tt.wantWordSet, tt.cmd.completionWord != nil)
+			assert.Equal(t, tt.wantWordSet, gotWordSet)
 			assert.Equal(t, tt.wantWord, gotWord)
-			assert.Equal(t, tt.wantTerminated, tt.cmd.completionTerminated)
+			assert.Equal(t, tt.wantTerminated, gotTerminated)
 		})
 	}
 }

--- a/help_test.go
+++ b/help_test.go
@@ -1884,7 +1884,7 @@ GLOBAL OPTIONS:
 `, output.String())
 }
 
-func Test_checkShellCompleteFlag(t *testing.T) {
+func Test_parseShellCompleteRequest(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name                string
@@ -1892,6 +1892,9 @@ func Test_checkShellCompleteFlag(t *testing.T) {
 		arguments           []string
 		wantShellCompletion bool
 		wantArgs            []string
+		wantWord            string
+		wantWordSet         bool
+		wantTerminated      bool
 	}{
 		{
 			name:                "disable-shell-completion",
@@ -1919,13 +1922,15 @@ func Test_checkShellCompleteFlag(t *testing.T) {
 			wantArgs:            []string{"foo"},
 		},
 		{
+			// The flag is a positional argument of whatever the command runs, so it
+			// stays in place and the command runs.
 			name:      "arguments include double dash",
 			arguments: []string{"--", "foo", completionFlag},
 			cmd: &Command{
 				EnableShellCompletion: true,
 			},
 			wantShellCompletion: false,
-			wantArgs:            []string{"--", "foo"},
+			wantArgs:            []string{"--", "foo", completionFlag},
 		},
 		{
 			name:      "shell completion",
@@ -1945,15 +1950,105 @@ func Test_checkShellCompleteFlag(t *testing.T) {
 			wantShellCompletion: true,
 			wantArgs:            []string{"foo", "--"},
 		},
+		{
+			// The deprecated request form says nothing about the word being completed,
+			// which DefaultCompleteWithFlags then works out from the arguments.
+			name:      "deprecated form records no word",
+			arguments: []string{"prog", "sub", "-", completionFlag},
+			cmd: &Command{
+				EnableShellCompletion: true,
+			},
+			wantShellCompletion: true,
+			wantArgs:            []string{"prog", "sub", "-"},
+		},
+		{
+			name:      "request names the completion",
+			arguments: []string{"prog", completionCommandRequest, "sub", ""},
+			cmd: &Command{
+				EnableShellCompletion: true,
+			},
+			wantShellCompletion: true,
+			wantArgs:            []string{"prog", "sub"},
+			wantWordSet:         true,
+		},
+		{
+			// A word starting with "-" stays in the arguments, which is the shape the
+			// deprecated form produced, so a ShellComplete function sees no difference.
+			name:      "request names the completion of a flag",
+			arguments: []string{"prog", completionCommandRequest, "sub", "--fl"},
+			cmd: &Command{
+				EnableShellCompletion: true,
+			},
+			wantShellCompletion: true,
+			wantArgs:            []string{"prog", "sub", "--fl"},
+			wantWord:            "--fl",
+			wantWordSet:         true,
+		},
+		{
+			// The word being completed is a positional argument of whatever the
+			// command runs, which this command has no suggestion for. It must still be
+			// a completion, or the command would run.
+			name:      "request names the completion after a double dash",
+			arguments: []string{"prog", completionCommandRequest, "exec", "--", "git", "pu"},
+			cmd: &Command{
+				EnableShellCompletion: true,
+			},
+			wantShellCompletion: true,
+			wantArgs:            []string{"prog", "exec", "--", "git"},
+			wantWord:            "pu",
+			wantWordSet:         true,
+			wantTerminated:      true,
+		},
+		{
+			// The "--" is the word being completed here, not a terminator, so flags
+			// still answer it.
+			name:      "request names the completion of a double dash",
+			arguments: []string{"prog", completionCommandRequest, "exec", "--"},
+			cmd: &Command{
+				EnableShellCompletion: true,
+			},
+			wantShellCompletion: true,
+			wantArgs:            []string{"prog", "exec", "--"},
+			wantWord:            "--",
+			wantWordSet:         true,
+		},
+		{
+			name:      "request without a word being completed",
+			arguments: []string{"prog", completionCommandRequest},
+			cmd: &Command{
+				EnableShellCompletion: true,
+			},
+			wantShellCompletion: true,
+			wantArgs:            []string{"prog"},
+			wantWordSet:         true,
+		},
+		{
+			// The request form shadows nothing: a command of that name is what was
+			// asked for.
+			name:      "a command of the same name wins",
+			arguments: []string{"prog", completionCommandRequest, "sub", ""},
+			cmd: &Command{
+				EnableShellCompletion: true,
+				Commands:              []*Command{{Name: completionCommandRequest}},
+			},
+			wantShellCompletion: false,
+			wantArgs:            []string{"prog", completionCommandRequest, "sub", ""},
+		},
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			shellCompletion, args := checkShellCompleteFlag(tt.cmd, tt.arguments)
+			shellCompletion, args := parseShellCompleteRequest(tt.cmd, tt.arguments)
 			assert.Equal(t, tt.wantShellCompletion, shellCompletion)
 			assert.Equal(t, tt.wantArgs, args)
+			gotWord := ""
+			if tt.cmd.completionWord != nil {
+				gotWord = *tt.cmd.completionWord
+			}
+			assert.Equal(t, tt.wantWordSet, tt.cmd.completionWord != nil)
+			assert.Equal(t, tt.wantWord, gotWord)
+			assert.Equal(t, tt.wantTerminated, tt.cmd.completionTerminated)
 		})
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

A completion request appended to the end of the command line cannot be told apart from a positional argument that happens to look like one, and after `--` that is exactly what it is. Both readings are required, and they contradict each other:

```console
$ aqua exec -- foo --generate-shell-completion   # pass it on to foo (#1932)
$ aqua exec -- foo <TAB>                         # complete, run nothing (#1993)
```

The shell sends the same argv either way, so no reading of that argv can serve both. #1932 was fixed by choosing the first reading, which is why #1993 is still open: on a command line holding `--`, pressing tab runs the command. With today's `main` (`v3.10.1-10-gc6f4cf7e`), typing `app exec -- git push origin main<TAB>` runs `git push origin`.

This PR moves the request to where `--` cannot reach it — the first argument:

```
<cmd> __complete <word>... <word being completed>
```

- `completion.go`: adds `completionCommandRequest` (`__complete`) and marks `completionFlag` deprecated.
- `help.go`: `checkShellCompleteFlag` becomes `parseShellCompleteRequest`. It understands both forms and records, on the root command, the word being completed and whether a `--` precedes it. Every run replaces that record, so a `Command` answering several requests carries nothing from one into the next. An app declaring a command named `__complete` keeps it, and stops being completable in exchange.
- `help.go`: nothing is suggested past a `--`, since those words are positional arguments of whatever the command runs. The rule lives in `runCompletion` rather than in `DefaultCompleteWithFlags`, so a command carrying a `ShellComplete` of its own keeps it without having to know about a `--` it cannot see. Suggesting nothing is not the same as declining the request: the run is still a completion, so the action never executes. Where the request names the word being completed, that word is used instead of guessing it from the position of the arguments.
- `help.go`: the deprecated form no longer strips the flag off a command line holding `--`. Leaving it in place is what #1932 asked for, and #2316 regressed it by returning `arguments[:pos]` while declining the request.
- `command.go`, `command_run.go`: the root command holds one `*completionRequest`, replaced by every run, and the call site. A `Before` is not run for a request past a `--` either: there is nothing to prepare for a completion that is not going to happen.
- `autocomplete/*`: all four scripts send the new request, including the word under the cursor, empty or not. That word was guesswork until now, because the scripts sent it only when it started with `-`, which is why `cmd --<TAB>` and `cmd -- <TAB>` arrived as the same request.
- `autocomplete/bash_autocomplete`: builds the request as an array and runs it directly instead of `eval`ing a joined string, so a word holding a space reaches the command as the single word it is, and a line holding a `$(...)` is no longer executed by pressing the tab key. The words come from the `words`/`cword` that `_init_completion` reassembles rather than from `COMP_WORDS`, which splits `--opt=value` into three on `COMP_WORDBREAKS` while the candidates are filtered against the whole of it. A command typed as `~/bin/app` is still run as the path it stands for: `eval` expanded that as a side effect, and it is the one expansion worth keeping, so it is put back without evaluating anything.
- `autocomplete/{bash,zsh,fish}`: a command typed as `~/bin/app` is run as the path it stands for. `eval` expanded it as a side effect of re-parsing the line; all three dispatch the completion for such a line and then fail to run the command without it. PowerShell resolves the tilde when it looks the command up, so its script does nothing there.
- `autocomplete/*`: one level of quoting comes off each word, the way the shell takes it off before handing a word to a command. `eval` and `Invoke-Expression` used to do that as a side effect of re-parsing the line; dropping them dropped it, and `app sub "hello world" ` asked the app about a word holding the two quote characters. A word whose quote is still open is sent without the opening quote, which all four shells now agree on.
- `autocomplete/powershell_autocomplete.ps1`: uses the real `-Native` completer signature. The old parameter list was shifted by one (`$commandName` was the word being completed and `$wordToComplete` was the `CommandAst`), which worked only because interpolating the AST yields the command line. The words now come from `CommandAst.CommandElements`, and which of them is being completed comes from the cursor rather than from a comparison with `$wordToComplete`, which PowerShell hands over normalized: an unfinished `"hello` arrives as `"hello"`, matches no element as written, and would be sent twice. Reading the cursor also leaves out what follows it, so completing in the middle of a line no longer asks about the words after the cursor.

Scripts generated before this change keep working, with the ambiguity they cannot escape: a command line holding `--` is answered as an ordinary run. Regenerating the script and sourcing it again is what closes #1993 for a given app.

Answering a completion no longer evaluates any part of the command line: `eval` and `Invoke-Expression` re-parsed it, so a `$(...)` typed on the line ran on the tab key. That is the same shape of problem as #1993, and it goes away with them.

No public API changes; `go run scripts/build.go v3diff` is clean.

## Which issue(s) this PR fixes:

Fixes #1993

## Special notes for your reviewer:

- Most of this branch — the code, the tests, the docs and this description — was written by Claude Code (Claude Opus 5), with me driving and reviewing it. I have read every line and take responsibility for it. Nothing here about shell behavior is assumed: the `COMP_WORDS` values, what each shell hands its completion function and what the command ends up receiving were all measured, and the review the branch went through is what turned up the differences the tests now cover.
- The deprecated form keeps today's behavior on a command line holding `--`, which means it still runs the command there. That is not an oversight: it is the #1932 reading, and it is the only reading available without a signal the shell alone can send. The one change is that the flag is no longer swallowed, which also makes an accidental run more likely to fail loudly than to quietly do the real thing.
- Existing `ShellComplete` functions see an unchanged `cmd.Args()`. The word being completed is kept in the arguments when it starts with `-` and left out otherwise, which is the shape the old scripts produced. Functions that branch on whether the last argument starts with `-` therefore behave identically under both forms. The word itself is recorded separately, unexported for now; exposing it would let a `ShellComplete` function tell `-c <TAB>` from `-c<TAB>`, which seems worth a follow-up rather than this PR.
- #2205 touches the same code. It is a different approach to the same `--` handling and has been conflicting since 2025-11; I am happy to close this in favor of a rebase of that one if you prefer, though it does not address the request being imitable in the first place.
- Follow-ups this makes possible, deliberately left out: #2248 (`--pa<TAB>` returns nothing), and the `args[argsLen-2]` indexing in `DefaultCompleteWithFlags`, which is only correct for the root command and so misses flag suggestions after a positional argument on a subcommand. A request naming the word being completed does not go through that indexing at all, so both are now questions about the deprecated form alone.
- Nothing is suggested past a `--` for any command now, where before it was what the default completion func happened to do. That makes it a guarantee of the library rather than a default, and it closes the door on a wrapper handing its completions to the command it runs (`myapp exec -- git pu<TAB>` offering what `git` would offer). No released version has done that — before #2316 the wrapper answered with its own completions, and since then it has run with the flag stripped off — but the deprecated form does now that it passes the flag on, so a script regenerated for this PR loses something a script for this PR would have had. That is deliberate: delegation only works by running the wrapper, which is the tab key running a command, which is what #1993 is about. The docs now say so.
- Still open, and older than this PR: the bash script depends on bash-completion for its word splitting, and its fallback calls another bash-completion function, so on a machine without it the completion returns quietly rather than saying why.
- The CI job installs what ubuntu-24.04 has, which is bash 5.2 and fish 3.7; the shells driven while writing this were bash 5.3, zsh 5.9, fish 4.8.1 and pwsh 7.6.4. The macOS job has no bash-completion and no fish, so it skips those, and `CLI_SHELL_TESTS_REQUIRED` is set only on ubuntu.
- Windows PowerShell 5.1 drops an empty argument on the way to a native command, which is how the word being completed is sent when the cursor sits on a fresh word. PowerShell 7.0 to 7.2 do the same on Windows unless `$PSNativeCommandArgumentPassing` is `Standard`, which the script now asks for; 5.1 has no such setting and is documented instead.
- Still open, and not made worse here: the `cur` that bash filters the candidates against still holds the quoting, so a quoted word is asked about correctly and then filtered against `"hello wo`, which matches nothing. Taking the quotes off `cur` means quoting the candidates back before they are inserted, which is a change of its own.

## Testing

`go test ./...`, `golangci-lint run`, `go run scripts/build.go v3diff` and `gfmrun` all pass.

`completion_shell_test.go` runs the generated scripts in the shells they are written for and checks the request each one builds, with the command it asks recording the arguments it receives. Asserting on the text of a script only says that a line was written, not what the shell does with it, and every difference found while reviewing this branch lived in that gap: a word bash splits on `COMP_WORDBREAKS`, a word arriving with its quotes, a word PowerShell hands over normalized and so sent twice, a command substitution the old scripts executed.

The words bash puts in `COMP_WORDS` are written out per case as measured in bash 5.3 with a completion function that dumps them, rather than worked out in the test: a driver that splits the line itself checks its own idea of what bash does, and one that lets `eval` do it takes the quotes off, joins `--opt=va` back together and runs the command substitution, which is three of the cases gone.

`TestCompletionScriptsSyntax` renders each script for an app named `my-app` and `my.app` and asks the shell to parse it. A shell function name may hold a `-`; a variable name may not, so a script putting the app name in a variable breaks for those apps and breaks the whole file, since sourcing stops at the syntax error before anything is registered.

The zsh run is the one assumption left: driving its completion system needs a pseudo terminal, so `words` and `CURRENT` are filled with zsh's own tokenizer instead. bash gets the words as measured, and fish and PowerShell go through the entry point the shell itself uses.

A shell that is not installed skips, and bash additionally skips without bash-completion, whose word splitting the script depends on. Because a skip is silent, the ubuntu CI job installs bash-completion, zsh and fish and sets `CLI_SHELL_TESTS_REQUIRED=bash,zsh,fish`, which turns "not installed" into a failure for exactly those. pwsh comes with the runner image and is left optional, so a change of image cannot fail the job over a shell nobody asked it to cover.

Other new Go tests:

- `Test_parseShellCompleteRequest`: both request forms, including the word being completed, the terminator, an app owning a `__complete` command, and the #1932 pass-through.
- `TestCompletionRequestNeverRunsAction`: an action that records having run, asserted not to, for a request with and without a `--`. This is the #1993 regression test.
- `TestCompletionRequestAfterDoubleDash`: no suggestion past a `--`, while a `--` being completed still gets flags.
- `TestCompletionDeprecatedRequestPassedOnAfterDoubleDash`: the wrapper receives the flag instead of the wrapper answering with its own completions.
- `TestCompletionRequestKeepsArgsShape`: a `ShellComplete` function sees the same `cmd.Args()` under both forms.
- `TestCompletionRequestStateIsPerRun`: a `Command` answering several requests answers each on its own terms.
- `TestCompletionCustomShellCompleteNotRunPastDoubleDash`: a command carrying its own completion func suggests nothing past a `--`.
- `TestCompletionRequestIgnoredWhenDisabled`: an app that has not enabled shell completion receives `__complete` as the positional argument it is.
- `TestCompletionRequestNestedSubcommand`: a request is answered by the command it names, however deep, including a flag being completed after a positional argument.
- `TestCompletionBeforeNotRunPastDoubleDash`: a `Before` is not run for a request past a `--`, and still is for one the command answers.
- Per-shell assertions that the generated scripts send the new request.

The scripts were also driven in the real shells (bash 5.3, zsh 5.9, fish 4.8.1, pwsh 7.6.4) against a test app whose `exec` action writes a sentinel file. In every shell, `app <TAB>`, `app g<TAB>`, `app -<TAB>` and `app get --<TAB>` produce the expected candidates, and `app exec -- echo hi<TAB>` produces none and leaves the sentinel unwritten. With a script generated before this change, the same app still completes exactly as it does today.

Finally, an app with a custom `ShellComplete` (ghtkn) was built against this branch: its completions are unchanged, and `ghtkn exec -- git push origin main<TAB>` no longer runs `git push origin`.

## Release Notes

```release-note
Shell completion scripts now ask for completions with a `__complete` first argument instead of a trailing `--generate-shell-completion` flag, so pressing tab on a command line containing `--` no longer runs the command. They no longer re-parse the command line to build that request either, so a `$(...)` on it is no longer executed by pressing the tab key. Regenerate the completion script and source it again after upgrading: scripts generated by earlier versions keep working, but on such a line they run the app, since after a `--` the request is a positional argument that reaches the action along with the rest of the line. Enabling shell completion reserves `__complete` as an app's first argument.
```
