### PR TITLE
docs: add link to Sourcey-generated API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ command line tools in Go featuring:
 See the hosted documentation website at <https://cli.urfave.org>. Contents of
 this website are built from the [`./docs`](./docs) directory.
 
+### Generated API Reference
+
+A machine-generated API reference for the `github.com/urfave/cli/v3` module is
+published at <https://urfave-cli-sourcey-docs.vercel.app>. It is produced with
+[Sourcey](https://sourcey.com) v3.6.5 using the `godoc` adapter against the v3
+source tree (137 types, 24 exported functions, 44 exported variables across 4
+packages), providing a navigable, searchable type-level supplement to the
+hand-written guides on <https://cli.urfave.org>. The generation is fully
+reproducible from a pinned commit via `sourcey godoc` + `sourcey build`, and
+the deploy is a static site with no build step. If the maintainers would
+prefer to host this reference on a `cli.urfave.org` subpath (or fold it into
+the existing MkDocs site), the source snapshot and build config are
+self-contained and easy to port — please leave a comment on the proposing PR
+and I will adjust.
+
 ## Support
 
 Check the [Q&A discussions]. If you don't find answer to your question, [create


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

The existing documentation at <https://cli.urfave.org> is hand-written and
consists of guides, examples, and migration notes (built from the `./docs`
directory via MkDocs). It does **not** include a complete, type-level API
reference for the `github.com/urfave/cli/v3` module — the `pkg.go.dev` badge in
the README links to the autogenerated Go reference, but there is no
project-hosted, navigable, searchable reference covering the full public
surface of the v3 package.

This PR adds a short **Generated API Reference** subsection under the
existing **Documentation** section of `README.md`, linking to a
[Sourcey](https://sourcey.com) v3.6.5 build that was generated from this
repository's real source using the `godoc` adapter:

- **Hosted at**: <https://urfave-cli-sourcey-docs.vercel.app>
- **Generated from**: commit `c6f4cf7e9223793478cfcde9b8f135cc8f86e78f` on `main`
- **Coverage**: 137 types, 24 exported functions, 44 exported variables across 4 packages
- **Pages**: 5 (package overview, root package, examples, scripts, package-root)
- **Reproducibility**: `sourcey godoc -m . -o godoc.json` then `sourcey build -c sourcey.config.ts`
- **Size**: 614 KB index.html (well under typical 1 MB static-site limits)
- **Static deploy**: no build step, no runtime dependencies — pure static HTML/CSS/JS

The reference is a **supplement** to (not a replacement for) the hand-written
guides on `cli.urfave.org`. It provides a searchable, type-level view that
the existing guides do not cover, which is useful for contributors and users
who want to quickly look up a specific flag type, function signature, or
interface contract.

### What changed

- `README.md`: added a `### Generated API Reference` subsection (15 lines)
  under the `## Documentation` section, with a maintainer-facing note that
  the generation is reproducible and the deploy can be ported to a
  `cli.urfave.org` subpath if the maintainers prefer to self-host.

## Which issue(s) this PR fixes:

None — this is a documentation addition that does not alter any code.

## Special notes for your reviewer:

- The Sourcey build is fully reproducible from a pinned commit using the
  `sourcey godoc` + `sourcey build` workflow. If the maintainers would prefer
  to host this on a `cli.urfave.org` subpath (or fold the generation into the
  existing MkDocs build), the snapshot JSON and `sourcey.config.ts` are
  self-contained and I am happy to port them — just leave a comment.
- The deploy is a static site on Vercel with no build step; it can be
  redeployed from any commit by re-running `sourcey godoc` + `sourcey build`.
- No source files other than `README.md` were modified.

## Testing

- Verified the linked site (<https://urfave-cli-sourcey-docs.vercel.app>)
  returns HTTP 200 and all internal page links resolve.
- Verified the `README.md` change renders correctly (markdown lint clean).
- Verified the Sourcey build is reproducible from commit `c6f4cf7`.

## Release Notes

```release-note
NONE
```