### PR TITLE
Fix index out of range panic when Run is given no arguments

### DIFF
--- a/command_setup.go
+++ b/command_setup.go
@@ -24,7 +24,7 @@ func (cmd *Command) setupDefaults(osArgs []string) {
 		cmd.ShellComplete = DefaultCompleteWithFlags
 	}
 
-	if cmd.Name == "" && isRoot {
+	if cmd.Name == "" && isRoot && len(osArgs) > 0 {
 		name := filepath.Base(osArgs[0])
 		tracef("setting cmd.Name from first arg basename (cmd=%[1]q)", name)
 		cmd.Name = name

--- a/command_test.go
+++ b/command_test.go
@@ -6450,3 +6450,29 @@ func TestCommand_Walk_NilFn(t *testing.T) {
 	cmd := &Command{Name: "foo"}
 	assert.Nil(t, cmd.Walk(nil))
 }
+
+// TestRunWithNoOsArgs checks that Run does not panic when handed an empty
+// argument slice.
+func TestRunWithNoOsArgs(t *testing.T) {
+	for _, tst := range []struct {
+		name string
+		cmd  *Command
+	}{
+		{name: "plain", cmd: &Command{Name: "foo"}},
+		{name: "shell completion enabled", cmd: &Command{Name: "foo", EnableShellCompletion: true}},
+		{name: "no name", cmd: &Command{}},
+	} {
+		t.Run(tst.name, func(t *testing.T) {
+			called := false
+			tst.cmd.Action = func(context.Context, *Command) error {
+				called = true
+				return nil
+			}
+
+			require.NotPanics(t, func() {
+				require.NoError(t, tst.cmd.Run(buildTestContext(t), []string{}))
+			})
+			assert.True(t, called)
+		})
+	}
+}

--- a/help.go
+++ b/help.go
@@ -476,6 +476,10 @@ func checkShellCompleteFlag(c *Command, arguments []string) (bool, []string) {
 		return false, arguments
 	}
 
+	if len(arguments) == 0 {
+		return false, arguments
+	}
+
 	pos := len(arguments) - 1
 	lastArg := arguments[pos]
 

--- a/help_test.go
+++ b/help_test.go
@@ -1945,6 +1945,15 @@ func Test_checkShellCompleteFlag(t *testing.T) {
 			wantShellCompletion: true,
 			wantArgs:            []string{"foo", "--"},
 		},
+		{
+			name:      "no arguments at all",
+			arguments: []string{},
+			cmd: &Command{
+				EnableShellCompletion: true,
+			},
+			wantShellCompletion: false,
+			wantArgs:            []string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`Command.Run` indexes into the argument slice in two places without first checking that it is non-empty, so passing an empty slice panics instead of returning.

### `setupDefaults`

Reads `osArgs[0]` to derive a default command name:

```go
cmd := &cli.Command{Action: func(context.Context, *cli.Command) error { return nil }}
cmd.Run(context.Background(), []string{})
// panic: runtime error: index out of range [0] with length 0
```

Affects any root command that does not set `Name` explicitly.

### `checkShellCompleteFlag`

Reads `arguments[len(arguments)-1]`:

```go
cmd := &cli.Command{Name: "x", EnableShellCompletion: true}
cmd.Run(context.Background(), nil)
// panic: runtime error: index out of range [-1]
```

Affects any command with `EnableShellCompletion` set, named or not.

## Fix

Guard both index accesses. A command invoked with no arguments now runs its `Action` as it would with any other argument list, and simply keeps an empty `Name` when there is no `argv[0]` to derive one from.

This is a pure robustness fix: in practice callers pass `os.Args`, which is never empty, so no working behaviour changes — the only reachable states previously were the two panics. It matters mostly for tests and for library consumers that build an argument slice programmatically.

## Testing

Adds `TestRunWithNoOsArgs` (named / shell-completion-enabled / unnamed) and a `no arguments at all` case to the existing `Test_checkShellCompleteFlag` table. Both fail on `main` without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)