### PR TITLE
fix: honor BoolWithInverseFlag DefaultText

### DIFF
--- a/flag_bool_with_inverse.go
+++ b/flag_bool_with_inverse.go
@@ -219,7 +219,7 @@ func (bif *BoolWithInverseFlag) Count() int {
 
 // GetDefaultText returns the default text for this flag
 func (bif *BoolWithInverseFlag) GetDefaultText() string {
-	if bif.Required {
+	if bif.DefaultText != "" {
 		return bif.DefaultText
 	}
 	return boolValue{}.ToString(bif.Value)

--- a/flag_bool_with_inverse_test.go
+++ b/flag_bool_with_inverse_test.go
@@ -338,6 +338,12 @@ func TestBoolWithInverseNames(t *testing.T) {
 	require.Equal(t, "bool", d.TypeName())
 }
 
+func TestBoolWithInverseDefaultText(t *testing.T) {
+	require.Equal(t, "false", (&BoolWithInverseFlag{}).GetDefaultText())
+	require.Equal(t, "true", (&BoolWithInverseFlag{Value: true}).GetDefaultText())
+	require.Equal(t, "auto", (&BoolWithInverseFlag{DefaultText: "auto"}).GetDefaultText())
+}
+
 func TestBoolWithInverseString(t *testing.T) {
 	tcs := []struct {
 		testName      string

--- a/flag_test.go
+++ b/flag_test.go
@@ -483,6 +483,11 @@ func TestFlagStringifying(t *testing.T) {
 			expected: "--vividly, --no-vividly\t(default: false)",
 		},
 		{
+			name:     "bool-inv-flag-with-default-text",
+			fl:       &BoolWithInverseFlag{Name: "vividly", DefaultText: "auto"},
+			expected: "--vividly, --no-vividly\t(default: auto)",
+		},
+		{
 			name:     "duration-flag",
 			fl:       &DurationFlag{Name: "scream-for"},
 			expected: "--scream-for duration\t(default: 0s)",


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

- Make `BoolWithInverseFlag.GetDefaultText` honor an explicitly configured `DefaultText` before falling back to the flag's boolean value.
- Cover both the direct default-text behavior and the generated help output while preserving the existing `true`/`false` fallback.

## Which issue(s) this PR fixes:

Fixes #2402

## Testing

- `go test -race ./... -count=1`
- `go vet ./...`
- `make lint`
- `make check-binary-size`
- `make generate v3diff`
- `make diffcheck`

## Release Notes

```release-note
`BoolWithInverseFlag` now honors `DefaultText` in generated help output.
```
