### PR TITLE
test: cover Run-with-no-arguments paths (#2406)

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -6452,15 +6452,19 @@ func TestCommand_Walk_NilFn(t *testing.T) {
 }
 
 // TestRunWithNoOsArgs checks that Run does not panic when handed an empty
-// argument slice.
+// argument slice. In particular, the combination of an empty Name and
+// EnableShellCompletion exercises both the setupDefaults empty-name guard
+// and the buildCompletionCommand("") append together.
 func TestRunWithNoOsArgs(t *testing.T) {
 	for _, tst := range []struct {
-		name string
-		cmd  *Command
+		name     string
+		cmd      *Command
+		wantName string
 	}{
-		{name: "plain", cmd: &Command{Name: "foo"}},
-		{name: "shell completion enabled", cmd: &Command{Name: "foo", EnableShellCompletion: true}},
+		{name: "plain", cmd: &Command{Name: "foo"}, wantName: "foo"},
+		{name: "shell completion enabled", cmd: &Command{Name: "foo", EnableShellCompletion: true}, wantName: "foo"},
 		{name: "no name", cmd: &Command{}},
+		{name: "no name, shell completion enabled", cmd: &Command{EnableShellCompletion: true}},
 	} {
 		t.Run(tst.name, func(t *testing.T) {
 			called := false
@@ -6473,6 +6477,7 @@ func TestRunWithNoOsArgs(t *testing.T) {
 				require.NoError(t, tst.cmd.Run(buildTestContext(t), []string{}))
 			})
 			assert.True(t, called)
+			assert.Equal(t, tst.wantName, tst.cmd.Name)
 		})
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Follow-up to #2401 (index out of range panic fix). Hardens coverage of the Run-with-no-arguments paths:

- `command_test.go`: adds a `TestRunWithNoOsArgs` case combining empty arguments with an empty `Name` and `EnableShellCompletion` — the only path where both new guards fire together (`setupDefaults` empty-name guard plus the shell-completion `buildCompletionCommand("")` append). Verified to panic without the #2401 fix and pass with it.
- `command_test.go`: `TestRunWithNoOsArgs` now asserts `cmd.Name == ""` after `Run` for the unnamed cases, locking in the documented behavior that a root command keeps an empty Name rather than panicking.

## Which issue(s) this PR fixes:

Fixes #2406

## Special notes for your reviewer:

No behavior change; pure test/robustness hardening.

## Testing

- `go test -count=1 -run "TestRunWithNoOsArgs" -race .` passes.
- Verified the new combined case panics without the #2401 guard and passes with it.
- `go vet .`, gofmt, and goimports are clean.
- Full package `go test .` passes.

## Release Notes

```release-note
NONE
```