### PR TITLE
test: add shell-completion case for hidden BoolWithInverseFlag

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -1432,6 +1432,28 @@ func TestDefaultCompleteWithFlags(t *testing.T) {
 			expected: "--excitement\n",
 		},
 		{
+			name: "typical-flag-suggestion-hidden-bool-with-inverse",
+			cmd: &Command{
+				Flags: []Flag{
+					&BoolWithInverseFlag{Name: "excellent", Hidden: true},
+					&BoolWithInverseFlag{Name: "excitement"},
+				},
+				parent: &Command{
+					Name: "cmd",
+					Flags: []Flag{
+						&BoolFlag{Name: "happiness"},
+						&Int64Flag{Name: "everybody-jump-on"},
+					},
+					Commands: []*Command{
+						{Name: "putz"},
+					},
+				},
+			},
+			argv:     []string{"cmd", "--e", completionFlag},
+			env:      map[string]string{"SHELL": "bash"},
+			expected: "--excitement\n",
+		},
+		{
 			name: "flag-suggestion-double-dash-shows-all-flags",
 			cmd: &Command{
 				Flags: []Flag{


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- cleanup

## What this PR does / why we need it:

_(REQUIRED)_

Follow-up from review of #2388.

PR #2388 changed `printFlagSuggestions` in `help.go` to skip flags via the `VisibleFlag`/`IsVisible()` interface instead of the previous `flag.(*BoolFlag)` assertion. The previous check only skipped hidden bool flags, and because the `*BoolFlag` assertion does not match the `*BoolWithInverseFlag` concrete type, hidden `BoolWithInverseFlag`s were also leaked into shell completion suggestions.

That leak is now fixed by the interface-based check, but the regression test table in `TestDefaultCompleteWithFlags` only covered the `BoolFlag` (`hidden-bool`) and `StringFlag` (new in #2388) cases.

This PR adds a `BoolWithInverseFlag` case to the `TestDefaultCompleteWithFlags` table — a hidden `--excellent` `BoolWithInverseFlag` alongside a visible `--excitement` one — to lock in the fix for this type too.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #2405

## Special notes for your reviewer:

Verified the new test catches the regression: with the old `*BoolFlag`-only assertion restored in `help.go`, the case fails with the hidden `--excellent` leaking into the suggestions (`--excellent\n--excitement\n`). With the current interface-based check it passes.

## Testing

Ran the focused test batch:

```
go test -count=1 -run "TestDefaultCompleteWithFlags" -v .
```

All cases pass, including the new `typical-flag-suggestion-hidden-bool-with-inverse`. `make lint` and `go vet ./...` are clean.

## Release Notes

_(REQUIRED)_

```release-note
NONE
```
