### PR TITLE
fix: report the flag name as typed in mutually exclusive flag errors

### DIFF
--- a/command.go
+++ b/command.go
@@ -147,8 +147,8 @@ type Command struct {
 	flagCategories FlagCategories
 	// flags that have been applied in current parse
 	appliedFlags []Flag
-	// flags that have been set
-	setFlags map[Flag]struct{}
+	// flags that have been set, mapped to the name used to set them
+	setFlags map[Flag]string
 	// The parent of this command. This value will be nil for the
 	// command at the root of the graph.
 	parent *Command
@@ -349,7 +349,7 @@ func (cmd *Command) Root() *Command {
 }
 
 func (cmd *Command) set(fName string, f Flag, val string) error {
-	cmd.setFlags[f] = struct{}{}
+	cmd.setFlags[f] = fName
 	cmd.setMultiValueParsingConfig(f)
 	if err := f.Set(fName, val); err != nil {
 		return fmt.Errorf("invalid value %q for flag -%s: %v", val, fName, err)

--- a/command_parse.go
+++ b/command_parse.go
@@ -25,7 +25,7 @@ func flagFromError(err error) (string, error) {
 func (cmd *Command) parseFlags(args Args) (Args, error) {
 	tracef("parsing flags from arguments %[1]q (cmd=%[2]q)", args, cmd.Name)
 
-	cmd.setFlags = map[Flag]struct{}{}
+	cmd.setFlags = map[Flag]string{}
 	cmd.appliedFlags = cmd.allFlags()
 
 	tracef("walking command lineage for persistent flags (cmd=%[1]q)", cmd.Name)

--- a/command_run.go
+++ b/command_run.go
@@ -232,7 +232,7 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 		}
 		// add env set flags here
 		if !isSet && flag.IsSet() {
-			cmd.setFlags[flag] = struct{}{}
+			cmd.setFlags[flag] = flag.Names()[0]
 		}
 	}
 

--- a/command_setup.go
+++ b/command_setup.go
@@ -163,7 +163,7 @@ func (cmd *Command) setupDefaults(osArgs []string) {
 		cmd.Metadata = map[string]any{}
 	}
 
-	cmd.setFlags = map[Flag]struct{}{}
+	cmd.setFlags = map[Flag]string{}
 }
 
 func (cmd *Command) setupCommandGraph() {

--- a/flag_mutex.go
+++ b/flag_mutex.go
@@ -16,19 +16,19 @@ type MutuallyExclusiveFlags struct {
 	Category string
 }
 
-func (grp MutuallyExclusiveFlags) check(_ *Command) error {
+func (grp MutuallyExclusiveFlags) check(cmd *Command) error {
 	e := &mutuallyExclusiveGroup{}
 
 	// Check for the use of a mutually-exclusive flag, starting at
 	// the first group.
-	name, i, ok := grp.findSetFlag(0)
+	name, i, ok := grp.findSetFlag(cmd, 0)
 	if ok {
 		e.flag1Name = name
 		i++
 
 		// Check for the use of a flag in a mutually exclusive
 		// relationship with the one we just found.
-		if name2, _, ok := grp.findSetFlag(i); ok {
+		if name2, _, ok := grp.findSetFlag(cmd, i); ok {
 			e.flag2Name = name2
 			return e
 		}
@@ -46,13 +46,21 @@ func (grp MutuallyExclusiveFlags) check(_ *Command) error {
 // set. If so, return the flag name, position at which it's set, and
 // Boolean true (indicating that a flag was found.) Else, return all
 // zero values.
-func (grp MutuallyExclusiveFlags) findSetFlag(startIdx int) (string, int, bool) {
+func (grp MutuallyExclusiveFlags) findSetFlag(cmd *Command, startIdx int) (string, int, bool) {
 	for i := startIdx; i < len(grp.Flags); i++ {
 		flags := grp.Flags[i]
 
 		for _, flg := range flags {
 			if flg.IsSet() {
-				return flg.Names()[0], i, true
+				// Report the name the user actually typed (e.g. an
+				// alias), falling back to the primary name when the
+				// flag was set by another mechanism such as an
+				// environment variable.
+				name := cmd.setFlags[flg]
+				if name == "" {
+					name = flg.Names()[0]
+				}
+				return name, i, true
 			}
 		}
 	}

--- a/flag_mutex_test.go
+++ b/flag_mutex_test.go
@@ -114,7 +114,7 @@ func TestFlagMutuallyExclusiveFlags(t *testing.T) {
 			switch err.(type) {
 			case (*mutuallyExclusiveGroup), (*mutuallyExclusiveGroupRequiredFlag):
 				if !strings.Contains(err.Error(), test.errStr) {
-					t.Logf("Invalid error string %v", err)
+					t.Errorf("Invalid error string %v", err)
 				}
 			default:
 				t.Errorf("got invalid error type %T", err)


### PR DESCRIPTION
Closes #2404.

The mutually exclusive flag check reported `flg.Names()[0]` — the *primary* name — so a
conflict involving a flag set via an alias referenced the primary name (`option i
cannot be set along with option t`) instead of the alias the user actually typed
(`option i cannot be set along with option ai`).

Changes:

- Track the name used to set each flag (`setFlags` is now `map[Flag]string` instead of
  `map[Flag]struct{}`), populated in `Command.set` from the parsed flag name and, for
  env-var-set flags, the primary name.
- `MutuallyExclusiveFlags.findSetFlag` reports that tracked name, falling back to
  `Names()[0]` when no name was recorded.
- Fix the test assertion that used `t.Logf`, which never fails on a wrong message and
  was masking this discrepancy — it now uses `t.Errorf`.

The existing `errStr` expectations (`option ai`, `option q`) now actually pass: the
`--i 11 --ai 12` case reports `ai` (the alias), and `--i 11 --q` reports `q`.

I was not able to run `go test` locally (no Go toolchain on this machine), so the test
is reasoned through rather than executed — please let CI judge it.
