### PR TITLE
fix: never run command action on shell completion past a double dash

### DIFF
--- a/command.go
+++ b/command.go
@@ -165,6 +165,10 @@ type Command struct {
 	didSetupDefaults bool
 	// whether in shell completion mode
 	shellCompletion bool
+	// whether the shell completion request came after a "--" separator,
+	// after which only positional arguments are accepted and nothing is
+	// suggested. The request is still a completion, never a command run.
+	shellCompletionPastDoubleDash bool
 	// whether global help flag was added
 	globaHelpFlagAdded bool
 	// whether global version flag was added

--- a/command_run.go
+++ b/command_run.go
@@ -125,6 +125,11 @@ func (cmd *Command) run(ctx context.Context, osArgs []string) (_ context.Context
 		// note that we can only do this because the shell autocomplete function
 		// always appends the completion flag at the end of the command
 		tracef("checking osArgs %v (cmd=%[2]q)", osArgs, cmd.Name)
+		// completion request state is per-run: a Command answering several
+		// requests (tests, REPL, embedded use) must not carry one request
+		// into the next
+		cmd.shellCompletion = false
+		cmd.shellCompletionPastDoubleDash = false
 		cmd.shellCompletion, osArgs = checkShellCompleteFlag(cmd, osArgs)
 
 		tracef("setting cmd.shellCompletion=%[1]v from checkShellCompleteFlag (cmd=%[2]q)", cmd.shellCompletion && cmd.EnableShellCompletion, cmd.Name)

--- a/completion_test.go
+++ b/completion_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -288,6 +289,9 @@ func TestCompletionSubcommand(t *testing.T) {
 		msg         string
 		msgArgs     []any
 		notContains bool
+		// wantNoAction asserts that the command action must not run, even
+		// though shell completion is requested (https://github.com/urfave/cli/issues/1993).
+		wantNoAction bool
 	}{
 		{
 			name:     "subcommand general completion",
@@ -352,7 +356,8 @@ func TestCompletionSubcommand(t *testing.T) {
 			msgArgs: []any{
 				"-g",
 			},
-			notContains: true,
+			notContains:  true,
+			wantNoAction: true,
 		},
 		{
 			name:     "subcommand partial double dash flag completion",
@@ -377,6 +382,7 @@ func TestCompletionSubcommand(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
+			actionRan := false
 
 			cmd := &Command{
 				EnableShellCompletion: true,
@@ -389,7 +395,10 @@ func TestCompletionSubcommand(t *testing.T) {
 								Name: "l1",
 							},
 						},
-						Action: func(ctx context.Context, c *Command) error { return nil },
+						Action: func(ctx context.Context, c *Command) error {
+							actionRan = true
+							return nil
+						},
 						Commands: []*Command{
 							{
 								Name: "xyz",
@@ -401,7 +410,10 @@ func TestCompletionSubcommand(t *testing.T) {
 										},
 									},
 								},
-								Action: func(ctx context.Context, c *Command) error { return nil },
+								Action: func(ctx context.Context, c *Command) error {
+									actionRan = true
+									return nil
+								},
 							},
 						},
 					},
@@ -416,8 +428,102 @@ func TestCompletionSubcommand(t *testing.T) {
 			} else {
 				r.Containsf(out.String(), test.contains, test.msg, test.msgArgs...)
 			}
+			if test.wantNoAction {
+				r.False(actionRan, "command action must not run for a completion request")
+			}
 		})
 	}
+}
+
+func TestCompletionAfterDoubleDashNeverRunsAction(t *testing.T) {
+	// Regression test for https://github.com/urfave/cli/issues/1993:
+	// pressing tab on a command line that holds a "--" must never execute
+	// the command action, and nothing is suggested past the "--" because
+	// only positional arguments are accepted after it.
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "root command past double dash",
+			args: []string{"foo", "--", "somearg", completionFlag},
+		},
+		{
+			name: "root command past double dash multiple words",
+			args: []string{"foo", "--", "bar", "baz", completionFlag},
+		},
+		{
+			name: "subcommand past double dash",
+			args: []string{"foo", "sub", "--", "somearg", completionFlag},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			actionRan := false
+
+			cmd := &Command{
+				EnableShellCompletion: true,
+				Writer:                out,
+				Action: func(ctx context.Context, c *Command) error {
+					actionRan = true
+					return nil
+				},
+				Commands: []*Command{
+					{
+						Name: "sub",
+						Action: func(ctx context.Context, c *Command) error {
+							actionRan = true
+							return nil
+						},
+					},
+				},
+			}
+
+			r := require.New(t)
+			r.NoError(cmd.Run(buildTestContext(t), test.args))
+			r.Empty(out.String(), "no suggestions expected past a --")
+			r.False(actionRan, "command action must not run for a completion request")
+		})
+	}
+}
+
+func TestCompletionAfterDoubleDashDoesNotLeakToNextRun(t *testing.T) {
+	// A Command answering several completion requests must answer each one
+	// on its own terms: a request past a "--" must not make the next
+	// request behave as though it were past one too.
+	origArgv := os.Args
+	t.Cleanup(func() { os.Args = origArgv })
+
+	out := &bytes.Buffer{}
+
+	cmd := &Command{
+		EnableShellCompletion: true,
+		Writer:                out,
+		Flags: []Flag{
+			&BoolFlag{
+				Name: "verbose",
+			},
+		},
+		Commands: []*Command{
+			{
+				Name: "sub",
+			},
+		},
+	}
+
+	r := require.New(t)
+
+	os.Args = []string{"foo", "--", "somearg"}
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", "--", "somearg", completionFlag}))
+	r.Empty(out.String())
+
+	out.Reset()
+	os.Args = []string{"foo", "-", completionFlag}
+	r.NoError(cmd.Run(buildTestContext(t), []string{"foo", "-", completionFlag}))
+	r.Contains(out.String(), "-verbose")
 }
 
 func TestCompletionSubcommandCustomShellComplete(t *testing.T) {

--- a/help.go
+++ b/help.go
@@ -487,13 +487,16 @@ func checkShellCompleteFlag(c *Command, arguments []string) (bool, []string) {
 		return false, arguments
 	}
 
-	// If arguments include "--" before the token being completed, shell completion
-	// is disabled because after "--" only positional arguments are accepted.
+	// If the token being completed is preceded by a "--", only positional
+	// arguments are accepted after it, so nothing will be suggested.
 	// https://unix.stackexchange.com/a/11382
 	// Note: The token being completed is at position pos-1 (immediately before completionFlag).
-	// We only check arguments before that position, so completing "--" itself still works.
+	// A "--" at exactly that position is the token being completed, not a
+	// separator, so completing "--" itself still suggests flags.
+	// The request is still recognized as a completion so that the command
+	// action is never executed (https://github.com/urfave/cli/issues/1993).
 	if pos >= 1 && slices.Contains(arguments[:pos-1], "--") {
-		return false, arguments[:pos]
+		c.shellCompletionPastDoubleDash = true
 	}
 
 	return true, arguments[:pos]
@@ -520,6 +523,13 @@ func shouldRunCompletion(cmd *Command) bool {
 }
 
 func runCompletion(ctx context.Context, cmd *Command) {
+	// Nothing is suggested past a "--": after it, only positional arguments
+	// are accepted. The request is still treated as a completion so that the
+	// command action is never executed (https://github.com/urfave/cli/issues/1993).
+	if cmd.Root().shellCompletionPastDoubleDash {
+		tracef("completion requested past double dash; suggesting nothing (cmd=%[1]q)", cmd.Name)
+		return
+	}
 	if cmd.ShellComplete != nil {
 		tracef("running shell completion func for command %[1]q", cmd.Name)
 		cmd.ShellComplete(ctx, cmd)

--- a/help_test.go
+++ b/help_test.go
@@ -2023,6 +2023,7 @@ func Test_checkShellCompleteFlag(t *testing.T) {
 		cmd                 *Command
 		arguments           []string
 		wantShellCompletion bool
+		wantPastDoubleDash  bool
 		wantArgs            []string
 	}{
 		{
@@ -2051,12 +2052,11 @@ func Test_checkShellCompleteFlag(t *testing.T) {
 			wantArgs:            []string{"foo"},
 		},
 		{
-			name:      "arguments include double dash",
-			arguments: []string{"--", "foo", completionFlag},
-			cmd: &Command{
-				EnableShellCompletion: true,
-			},
-			wantShellCompletion: false,
+			name:                "arguments include double dash",
+			arguments:           []string{"--", "foo", completionFlag},
+			cmd:                 &Command{EnableShellCompletion: true},
+			wantShellCompletion: true,
+			wantPastDoubleDash:  true,
 			wantArgs:            []string{"--", "foo"},
 		},
 		{
@@ -2094,6 +2094,7 @@ func Test_checkShellCompleteFlag(t *testing.T) {
 			t.Parallel()
 			shellCompletion, args := checkShellCompleteFlag(tt.cmd, tt.arguments)
 			assert.Equal(t, tt.wantShellCompletion, shellCompletion)
+			assert.Equal(t, tt.wantPastDoubleDash, tt.cmd.shellCompletionPastDoubleDash)
 			assert.Equal(t, tt.wantArgs, args)
 		})
 	}


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Pressing tab on a command line that holds a `--` runs the command action instead of completing. For example, with shell completion enabled, `app -- somearg<TAB>` sends `app -- somearg --generate-shell-completion`, and because everything after `--` is positional, the trailing request flag was left in the arguments and the command was executed — without the user pressing enter.

This PR guarantees that a trailing `--generate-shell-completion` is always treated as a completion request, never as a command run:

- `checkShellCompleteFlag` no longer declines the request when a `--` precedes the token being completed; it records the state on the root command instead.
- `runCompletion` emits nothing past a `--`, since only positional arguments are accepted after it, while completing `--` itself still suggests flags.
- The per-run state is reset on every `run`, so a `Command` answering several completion requests (tests, REPL, embedded use) cannot carry one request into the next.

## Which issue(s) this PR fixes:

Fixes #1993

## Special notes for your reviewer:

This deliberately changes the `--` pass-through behavior for wrapper apps (`myapp exec -- <tool>`): a script generated before this change forwards the trailing request flag through the `--`, and that now resolves as a completion instead of a run. The shell sends the same argv either way, so both readings cannot coexist; the safety requirement in #1993 is chosen here.

## Testing

- Added `TestCompletionAfterDoubleDashNeverRunsAction` (root and subcommand, single and multiple words after `--`) asserting the action never runs and no suggestions are emitted.
- Added `TestCompletionAfterDoubleDashDoesNotLeakToNextRun` asserting per-run state isolation.
- Strengthened `TestCompletionSubcommand` to assert the action does not run, and updated `Test_checkShellCompleteFlag`.
- `go vet ./...`, `make lint`, `go test -race`, and `go run scripts/build.go v3diff` all pass.

## Release Notes

```release-note
Shell completion no longer runs the command action when tab is pressed on a command line containing a double dash (--)
```
