### PR TITLE
Keep arguments after a bare dash

### DIFF
--- a/command_parse.go
+++ b/command_parse.go
@@ -122,7 +122,7 @@ func (cmd *Command) parseFlags(args Args) (Args, error) {
 		// this is same as firstArg == "-"
 		if len(firstArg) == 1 {
 			posArgs = append(posArgs, firstArg)
-			break
+			continue
 		}
 
 		shortOptionHandling := cmd.useShortOptionHandling()

--- a/command_test.go
+++ b/command_test.go
@@ -1156,6 +1156,26 @@ func TestCommand_CommandWithDash(t *testing.T) {
 	require.Equal(t, "-", args.Get(1))
 }
 
+func TestCommand_BareDashKeepsFollowingArgs(t *testing.T) {
+	var args Args
+
+	cmd := &Command{
+		Commands: []*Command{
+			{
+				Name: "cmd",
+				Action: func(_ context.Context, cmd *Command) error {
+					args = cmd.Args()
+					return nil
+				},
+			},
+		},
+	}
+
+	require.NoError(t, cmd.Run(buildTestContext(t), []string{"", "cmd", "-", "foo", "bar"}))
+	require.NotNil(t, args)
+	require.Equal(t, []string{"-", "foo", "bar"}, args.Slice())
+}
+
 func TestCommand_CommandWithNoFlagBeforeTerminator(t *testing.T) {
 	var args Args
 

--- a/command_test.go
+++ b/command_test.go
@@ -1176,6 +1176,56 @@ func TestCommand_BareDashKeepsFollowingArgs(t *testing.T) {
 	require.Equal(t, []string{"-", "foo", "bar"}, args.Slice())
 }
 
+func TestCommand_BareDashThenFlags(t *testing.T) {
+	cases := []struct {
+		name   string
+		argv   []string
+		option string
+		args   []string
+	}{
+		{
+			name:   "flags after a bare dash still parse",
+			argv:   []string{"", "cmd", "-", "--option", "my-option", "foo"},
+			option: "my-option",
+			args:   []string{"-", "foo"},
+		},
+		{
+			name:   "terminator after a bare dash still stops flag parsing",
+			argv:   []string{"", "cmd", "-", "--", "--option", "leftover"},
+			option: "",
+			args:   []string{"-", "--option", "leftover"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var parsedOption string
+			var args Args
+
+			cmd := &Command{
+				Commands: []*Command{
+					{
+						Name: "cmd",
+						Flags: []Flag{
+							&StringFlag{Name: "option", Value: "", Usage: "some option"},
+						},
+						Action: func(_ context.Context, cmd *Command) error {
+							parsedOption = cmd.String("option")
+							args = cmd.Args()
+							return nil
+						},
+					},
+				},
+			}
+
+			require.NoError(t, cmd.Run(buildTestContext(t), tc.argv))
+			require.Equal(t, tc.option, parsedOption)
+			require.NotNil(t, args)
+			require.Equal(t, tc.args, args.Slice())
+		})
+	}
+}
+
 func TestCommand_CommandWithNoFlagBeforeTerminator(t *testing.T) {
 	var args Args
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

`parseFlags` treated a lone `-` as a positional, then `break` out of the rearrangement loop. Everything after `-` was dropped with no error.

Neighboring paths use `continue` (empty arg, other positionals) or keep the remainder (`--`). This matches Go's `flag` package: `-` is an operand, parsing continues.

## Which issue(s) this PR fixes:

Fixes #2418

## Testing

`TestCommand_BareDashKeepsFollowingArgs` failed with `Args() == ["-"]` before the change and passes after. Full `go test -count=1` passes.

## Release Notes

```release-note
Keep arguments that follow a bare `-` instead of silently discarding them.
```