### PR TITLE
Show inherited persistent flags in child help

### DIFF
--- a/command.go
+++ b/command.go
@@ -306,12 +306,25 @@ func (cmd *Command) VisiblePersistentFlags() []Flag {
 		return nil
 	}
 	var flags []Flag
-	for _, fl := range cmd.Root().Flags {
-		pfl, ok := fl.(LocalFlag)
-		if !ok || pfl.IsLocal() {
-			continue
+	lineage := cmd.Lineage()
+	for i := len(lineage) - 1; i > 0; i-- {
+		for _, fl := range lineage[i].allFlags() {
+			pfl, ok := fl.(LocalFlag)
+			if !ok || pfl.IsLocal() {
+				continue
+			}
+			applies := true
+			for _, name := range fl.Names() {
+				if cmd.lFlag(name) != nil {
+					applies = false
+					break
+				}
+			}
+			if !applies {
+				continue
+			}
+			flags = append(flags, fl)
 		}
-		flags = append(flags, fl)
 	}
 	return visibleFlags(flags)
 }

--- a/command.go
+++ b/command.go
@@ -315,7 +315,7 @@ func (cmd *Command) VisiblePersistentFlags() []Flag {
 			}
 			applies := true
 			for _, name := range fl.Names() {
-				if cmd.lFlag(name) != nil {
+				if cmd.lookupFlag(name) != fl {
 					applies = false
 					break
 				}

--- a/help_test.go
+++ b/help_test.go
@@ -908,12 +908,14 @@ func TestShowSubcommandHelp_InheritedPersistentOptions(t *testing.T) {
 	cmd := &Command{
 		Flags: []Flag{
 			&StringFlag{Name: "root-persistent"},
+			&StringFlag{Name: "shared", Usage: "from root"},
 		},
 		Commands: []*Command{
 			{
 				Name: "mid",
 				Flags: []Flag{
 					&StringFlag{Name: "mid-persistent"},
+					&StringFlag{Name: "shared", Usage: "from intermediate"},
 				},
 				Commands: []*Command{
 					{
@@ -930,6 +932,8 @@ func TestShowSubcommandHelp_InheritedPersistentOptions(t *testing.T) {
 	require.NoError(t, cmd.Run(buildTestContext(t), []string{"root", "mid", "leaf", "--help"}))
 	assert.Contains(t, output.String(), "--root-persistent string")
 	assert.Contains(t, output.String(), "--mid-persistent string")
+	assert.Contains(t, output.String(), "from intermediate")
+	assert.NotContains(t, output.String(), "from root")
 }
 
 func TestShowSubcommandHelp_SubcommandUsageText(t *testing.T) {

--- a/help_test.go
+++ b/help_test.go
@@ -904,6 +904,34 @@ GLOBAL OPTIONS:
 	assert.Contains(t, output.String(), expected, "expected output to include global options")
 }
 
+func TestShowSubcommandHelp_InheritedPersistentOptions(t *testing.T) {
+	cmd := &Command{
+		Flags: []Flag{
+			&StringFlag{Name: "root-persistent"},
+		},
+		Commands: []*Command{
+			{
+				Name: "mid",
+				Flags: []Flag{
+					&StringFlag{Name: "mid-persistent"},
+				},
+				Commands: []*Command{
+					{
+						Name: "leaf",
+					},
+				},
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	cmd.Writer = output
+
+	require.NoError(t, cmd.Run(buildTestContext(t), []string{"root", "mid", "leaf", "--help"}))
+	assert.Contains(t, output.String(), "--root-persistent string")
+	assert.Contains(t, output.String(), "--mid-persistent string")
+}
+
 func TestShowSubcommandHelp_SubcommandUsageText(t *testing.T) {
 	cmd := &Command{
 		Commands: []*Command{


### PR DESCRIPTION
## What type of PR is this?

- bug

## Problem

Descendant help lists persistent flags declared on the root command, but omits persistent flags declared on intermediate commands even though the parser accepts them.

## Fix

Traverse the command ancestry when collecting inherited persistent flags for help. Reuse the parser's existing flag lookup so a nearer command still shadows a same-named persistent flag. The regression covers a root → intermediate → leaf command tree and ancestor shadowing.

## User impact

CLI users can now discover all inherited persistent options from a descendant command's --help output without seeing shadowed duplicates.

## Which issue(s) this PR fixes:

Fixes #2420

## Verification

- go test ./... — passed (package, examples, and scripts)
- go vet ./... — passed
- Focused regression — failed on the base revision and passed after the fix, including ancestor shadowing
- git diff --check — passed
- go run scripts/build.go v3diff — generated-doc comparison is clean when run with git diff --no-index; the scripted command itself cannot run because this Windows environment lacks the Unix diff executable.

## Special notes for your reviewer:

The repository's go run scripts/build.go test wrapper runs go test -race; it could not start here because this Windows environment has CGO_ENABLED=0 and no C compiler. The non-race suite above passed.

## Release Notes

```release-note
Show persistent flags inherited from non-root commands in descendant help output.
```