### PR TITLE
fix: preserve whitespace in positional arguments

### DIFF
--- a/command_parse.go
+++ b/command_parse.go
@@ -114,7 +114,9 @@ func (cmd *Command) parseFlags(args Args) (Args, error) {
 				return &stringSliceArgs{posArgs}, nil
 			}
 
-			posArgs = append(posArgs, firstArg)
+			// firstArg is a trimmed copy that classifies the argument; the
+			// argument itself is what the action receives, byte for byte.
+			posArgs = append(posArgs, rargs[0])
 			continue
 		}
 

--- a/command_test.go
+++ b/command_test.go
@@ -1156,6 +1156,22 @@ func TestCommand_CommandWithDash(t *testing.T) {
 	require.Equal(t, "-", args.Get(1))
 }
 
+func TestCommand_PositionalArgsKeepWhitespace(t *testing.T) {
+	var args Args
+
+	cmd := &Command{
+		Name: "prog",
+		Action: func(_ context.Context, cmd *Command) error {
+			args = cmd.Args()
+			return nil
+		},
+	}
+
+	require.NoError(t, cmd.Run(buildTestContext(t), []string{"prog", "  padded  ", "\ttabbed\t"}))
+	require.NotNil(t, args)
+	require.Equal(t, []string{"  padded  ", "\ttabbed\t"}, args.Slice())
+}
+
 func TestCommand_CommandWithNoFlagBeforeTerminator(t *testing.T) {
 	var args Args
 


### PR DESCRIPTION
`parseFlags` computes `firstArg := strings.TrimSpace(rargs[0])` to classify each argument, which is correct - but the positional branch then stores the trimmed copy instead of the original argument, so any positional carrying deliberate whitespace is silently rewritten:

```go
cmd := &cli.Command{Name: "prog", Action: ...}
cmd.Run(ctx, []string{"prog", "  padded  "})
// cmd.Args().Slice() == ["padded"], not ["  padded  "]
```

A filename with a leading space, a message string, a pattern argument - all reach the action modified, with no error. The empty-string branch a few lines above already appends `rargs[0]` untrimmed, so this change makes the non-empty branch consistent with its sibling: classify with the trimmed copy, append the original.

One line changed in `command_parse.go`, plus a regression test.

Note: the lone-`-` branch nearby has the same trimmed append, but that line is already being rewritten by #2419 (the bare-dash fix), so this PR deliberately does not touch it.
