### PR TITLE
fix: complete subcommand flags after positional arguments

### DIFF
--- a/completion_partial_regression_test.go
+++ b/completion_partial_regression_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func partialCompletionCommand(output *bytes.Buffer, ran *bool) *Command {
+	command := func(name string) *Command {
+		return &Command{
+			Name: name,
+			Flags: []Flag{
+				&StringFlag{Name: "param-" + name + "-one"},
+				&StringFlag{Name: "param-" + name + "-two"},
+				&StringFlag{Name: "param-" + name + "-hidden", Hidden: true},
+				&BoolFlag{Name: "unrelated-" + name},
+			},
+			Action: func(context.Context, *Command) error { *ran = true; return nil },
+		}
+	}
+	root, child, nested := command("app"), command("sub"), command("nested")
+	root.Writer, root.ErrWriter = output, output
+	root.EnableShellCompletion = true
+	root.Commands = []*Command{child}
+	child.Commands = []*Command{nested}
+	return root
+}
+
+func TestPartialFlagCompletionAfterPositionalArgument(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	for _, scope := range []struct {
+		name string
+		path []string
+	}{
+		{"app", nil},
+		{"sub", []string{"sub"}},
+		{"nested", []string{"sub", "nested"}},
+	} {
+		for _, positional := range [][]string{nil, {"value"}, {"first", "second"}} {
+			t.Run(scope.name+"/"+strings.Join(positional, "_"), func(t *testing.T) {
+				var output bytes.Buffer
+				ran := false
+				cmd := partialCompletionCommand(&output, &ran)
+				args := append([]string{"app"}, scope.path...)
+				args = append(args, positional...)
+				args = append(args, "--pa", completionFlag)
+				os.Args = args
+				if err := cmd.Run(context.Background(), args); err != nil {
+					t.Fatal(err)
+				}
+				want := "--param-" + scope.name + "-one\n--param-" + scope.name + "-two\n"
+				if got := output.String(); got != want {
+					t.Errorf("completion for %q = %q, want %q", args, got, want)
+				}
+				if ran {
+					t.Error("completion executed the command action")
+				}
+			})
+		}
+	}
+}
+
+func TestPartialFlagCompletionAfterDoubleDash(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	for _, path := range [][]string{nil, {"sub"}, {"sub", "nested"}} {
+		t.Run(strings.Join(path, "/"), func(t *testing.T) {
+			var output bytes.Buffer
+			ran := false
+			cmd := partialCompletionCommand(&output, &ran)
+			args := append([]string{"app"}, path...)
+			args = append(args, "--", "--pa", completionFlag)
+			os.Args = args
+			if err := cmd.Run(context.Background(), args); err != nil {
+				t.Fatal(err)
+			}
+			if output.Len() != 0 || ran {
+				t.Errorf("completion after --: output=%q action=%v", output.String(), ran)
+			}
+		})
+	}
+}
+
+func TestPartialFlagCustomCompletionArgs(t *testing.T) {
+	var output bytes.Buffer
+	ran := false
+	cmd := partialCompletionCommand(&output, &ran)
+	var got []string
+	cmd.Commands[0].ShellComplete = func(_ context.Context, cmd *Command) {
+		got = append([]string(nil), cmd.Args().Slice()...)
+	}
+	args := []string{"app", "sub", "value", "--pa", completionFlag}
+	if err := cmd.Run(context.Background(), args); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"value", "--pa"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("custom completion args = %q, want %q", got, want)
+	}
+	if ran {
+		t.Error("custom completion executed the action")
+	}
+}
+
+func TestPartialFlagCompletionDisabled(t *testing.T) {
+	var output bytes.Buffer
+	ran := false
+	cmd := partialCompletionCommand(&output, &ran)
+	cmd.EnableShellCompletion = false
+	args := []string{"app", "sub", "value", "--pa", completionFlag}
+	if err := cmd.Run(context.Background(), args); err == nil {
+		t.Fatal("disabled completion accepted an undefined flag")
+	}
+	if ran || strings.Contains(output.String(), "--param-sub-one\n--param-sub-two\n") {
+		t.Fatalf("disabled completion: output=%q action=%v", output.String(), ran)
+	}
+}

--- a/help.go
+++ b/help.go
@@ -257,12 +257,13 @@ func DefaultCompleteWithFlags(ctx context.Context, cmd *Command) {
 	}
 	argsLen := len(args)
 	lastArg := ""
-	// parent command will have --generate-shell-completion so we need
-	// to account for that
-	if argsLen > 1 {
-		lastArg = args[argsLen-2]
-	} else if argsLen > 0 {
+	// os.Args retains the completion marker, but a child's parsed arguments
+	// have already had it removed.
+	if argsLen > 0 {
 		lastArg = args[argsLen-1]
+		if lastArg == completionFlag && argsLen > 1 {
+			lastArg = args[argsLen-2]
+		}
 	}
 
 	if lastArg == completionFlag {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fix the remaining partial-flag completion case after a positional argument in a child command. For example, current main completes `app sub --pa`, but `app sub value --pa` suggests child commands instead of matching flags.

`DefaultCompleteWithFlags` reads raw `os.Args` for the root command and parsed arguments for a child. Only the raw arguments still contain the trailing completion marker, so always selecting the penultimate argument skips the flag being completed in the child case.

- `help.go`: start with the final argument and step back only when that argument is the completion marker.
- `completion_partial_regression_test.go`: cover root, child, and nested commands with zero, one, and two positional arguments, plus hidden flags, custom-completer arguments, disabled completion, and requests after `--`.

The completion request format, flag parsing, and custom completion handlers are unchanged.

## Which issue(s) this PR fixes:

Fixes #2248.

## Testing

- The completed regression suite fails for the four child/nested positional cases on unchanged `5081218` and passes with this change. The already-working root and no-positional cases stay unchanged.
- Go 1.27.0: `make all`, `make lint`, `make v3diff`, and post-commit `make diffcheck` pass.
- Go 1.26.5: `make vet test check-binary-size` passes.
- Built the same CLI probe against the baseline and this branch and compared nine completion inputs. Matching flags replace the incorrect command suggestions; both binaries preserve ordinary action execution and produce no output/action for completion after `--`.

The README `gfmrun` target found zero executable blocks; the compiled CLI probe supplies the execution check above. macOS and Windows are left to CI.

## Release Notes

```release-note
Fix flag-name completion after positional arguments in subcommands and nested commands.
```
