### PR TITLE
Fix a year-less timestamp layout losing January 1

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -2718,6 +2718,36 @@ func TestTimestampFlagApply_ShortenedLayouts(t *testing.T) {
 	}
 }
 
+func TestTimestampFlagApply_YearlessLayoutJanuaryFirst(t *testing.T) {
+	year := time.Now().UTC().Year()
+
+	for _, tc := range []struct {
+		layout   string
+		value    string
+		expected time.Time
+	}{
+		{layout: "01-02", value: "01-01", expected: time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC)},
+		{layout: "01-02", value: "03-04", expected: time.Date(year, time.March, 4, 0, 0, 0, 0, time.UTC)},
+		{layout: "Jan _2 15:04:05", value: "Jan  1 06:07:08", expected: time.Date(year, time.January, 1, 6, 7, 8, 0, time.UTC)},
+	} {
+		t.Run(tc.layout+" "+tc.value, func(t *testing.T) {
+			var got time.Time
+			cmd := &Command{
+				Flags: []Flag{
+					&TimestampFlag{Name: "time", Config: TimestampConfig{Layouts: []string{tc.layout}}},
+				},
+				Action: func(_ context.Context, cmd *Command) error {
+					got = cmd.Timestamp("time")
+					return nil
+				},
+			}
+
+			assert.NoError(t, cmd.Run(buildTestContext(t), []string{"", "--time", tc.value}))
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
 func TestTimestampFlagApplyValue(t *testing.T) {
 	expectedResult, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
 	fl := TimestampFlag{Name: "time", Aliases: []string{"t"}, Config: TimestampConfig{Layouts: []string{time.RFC3339}}, Value: expectedResult}

--- a/flag_timestamp.go
+++ b/flag_timestamp.go
@@ -63,6 +63,7 @@ func (t *timestampValue) Set(value string) error {
 		return errors.New("got nil/empty layouts slice")
 	}
 
+	matchedLayout := ""
 	for _, layout := range t.layouts {
 		var locErr error
 
@@ -78,6 +79,7 @@ func (t *timestampValue) Set(value string) error {
 		}
 
 		err = nil
+		matchedLayout = layout
 		break
 	}
 
@@ -90,7 +92,8 @@ func (t *timestampValue) Set(value string) error {
 	n := time.Now().In(timestamp.Location())
 
 	// If format is missing date (or year only), set it explicitly to current
-	if timestamp.Truncate(time.Hour*24).UnixNano() == defaultTS.Truncate(time.Hour*24).UnixNano() {
+	// A layout that carries a date parses "January 1" to the same instant a date-less layout does, so ask the layout.
+	if !layoutHasDate(matchedLayout) && timestamp.Truncate(time.Hour*24).UnixNano() == defaultTS.Truncate(time.Hour*24).UnixNano() {
 		timestamp = time.Date(
 			n.Year(),
 			n.Month(),
@@ -119,6 +122,14 @@ func (t *timestampValue) Set(value string) error {
 	}
 	t.hasBeenSet = true
 	return nil
+}
+
+// layoutHasDate reports whether layout carries month/day components, probed by
+// round-tripping a reference date that is not January 1.
+func layoutHasDate(layout string) bool {
+	ref := time.Date(2, time.March, 4, 5, 6, 7, 0, time.UTC)
+	p, err := time.Parse(layout, ref.Format(layout))
+	return err == nil && (p.Month() != time.January || p.Day() != 1)
 }
 
 // String returns a readable representation of this value (for usage defaults)


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

A `TimestampFlag` whose layout carries a month and day but no year returns **today's date** instead of the parsed date, but only when the value is January 1.

```
Config: TimestampConfig{Layouts: []string{"01-02"}, Timezone: time.UTC}

--time 01-01   before: 2026-09-08T00:00:00Z   after: 2026-01-01T00:00:00Z
--time 01-02   2026-01-02T00:00:00Z  (both)
--time 03-04   2026-03-04T00:00:00Z  (both)
--time 12-31   2026-12-31T00:00:00Z  (both)
```

`timestampValue.Set` decides "this layout has no date" by comparing the parsed instant against `defaultTS`, a probe parsed from `time.TimeOnly`, which lands on year-0 January 1 (`flag_timestamp.go:90-93`). A layout that *does* carry a date parses `01-01` onto that exact same day, so the two cases are indistinguishable and the date-less branch fires, overwriting month and day with `time.Now()`.

The fix asks the layout rather than the parsed value. `layoutHasDate` round-trips a reference date that is deliberately not January 1 (`0002-03-04`) through `Format`/`Parse`: a date-less layout drops it and comes back as January 1, a layout with a date returns March 4.

- `flag_timestamp.go` — capture the layout that matched in the parse loop, add the `layoutHasDate` guard to the first branch, add the helper.
- `flag_test.go` — `TestTimestampFlagApply_YearlessLayoutJanuaryFirst`, three rows.

**The one-sentence version:** the very next branch (`flag_timestamp.go:104`, `else if timestamp.Year() == 0`) already handles "layout has a date but no year" correctly — January 1 is the single input that never reaches it.

`matchedLayout` is load-bearing: the loop otherwise discards the layout and the check cannot be made without it. The helper is unexported, so `make generate` produces no change to `godoc-current.txt`.

## Which issue(s) this PR fixes:

None — found by reading `flag_timestamp.go`. I did not open one first since #2400 and #2401 landed the same way, but happy to file one if you would prefer.

## Special notes for your reviewer:

`time.Stamp`-style layouts (`"Jan _2 15:04:05"`, i.e. syslog and journal timestamps) are the canonical reason to use a year-less layout, and they are affected too — that row is in the test.

One honest limitation: `flag_timestamp.go:92` calls `time.Now()` directly, so on January 1 itself the buggy code returns the right answer by coincidence and the two January rows would pass against the bug. That day is unobservable by construction, not a gap in the test. The March 4 control row and the mutation checks below still discriminate on every other day.

I also considered detecting date components by scanning the layout string for `1`/`01`/`Jan`/`2`/`02`/`_2` tokens, and rejected it — the round-trip probe is shorter and does not have to enumerate Go's layout vocabulary. If a layout is lossy enough that `Format`/`Parse` does not round-trip, the `err == nil` guard makes `layoutHasDate` return false, which is exactly today's behaviour, so an exotic layout degrades to the status quo rather than regressing.

## Testing

`TestTimestampFlagApply_YearlessLayoutJanuaryFirst` drives the production chain — `cmd.Run` → `Action` → `cmd.Timestamp("time")` — with two January 1 rows and a March 4 control.

- On `main` the two January rows fail (`expected: 2026-01-01`, `actual: 2026-09-08`) and the control passes.
- Mutation-checked both directions, failing disjoint tests: forcing `layoutHasDate` to `false` (restoring current behaviour) fails only the new test, and forcing it to `true` fails only the pre-existing `TestTimestampFlagApply_ShortenedLayouts`. Both sides of the boundary are pinned.
- `make test` passes (`-race`, coverage 99.3%). `make vet`, `make lint`, `make ensure-goimports`, `make generate` + `make diffcheck`, `make v3diff`, `make check-binary-size` (1.8MB) all clean, and `golangci-lint run ./...` reports 0 issues.
- Existing timestamp coverage still passes, including `time.Kitchen`, `time.Stamp`, `StampMilli/Micro/Nano`, `TimeOnly`, `"15:04"` and `time.RFC3339`.

## Release Notes

```release-note
Fixed `TimestampFlag` returning the current date instead of the parsed date when the layout has no year and the value is January 1.
```

---

AI assistance disclosure: this patch was found and written with Claude Code. Every number above is verbatim from running it against `main` and against this branch.
