### PR TITLE
docs: add go-size-analyzer, module version, and reflection

### DIFF
--- a/docs/v3/binary-size.md
+++ b/docs/v3/binary-size.md
@@ -51,3 +51,127 @@ only import `github.com/urfave/cli/v3` do not pull in that package.
 Shell completion support is part of the core package. Leave
 `EnableShellCompletion` disabled unless the application needs shell completion,
 then measure the result with the commands above.
+
+
+## Deeper Analysis with go-size-analyzer
+ 
+The commands above show symbol-level sizes, but they do not clearly show which
+packages contribute most to the binary. [go-size-analyzer](https://github.com/Zxilly/go-size-analyzer)
+provides a package-level breakdown.
+ 
+Install it with:
+ 
+ 
+```sh-session
+go install github.com/Zxilly/go-size-analyzer/cmd/gsa@latest
+```
+ 
+Then analyze a binary:
+ 
+```sh-session
+gsa myapp
+```
+ 
+For example, a minimal `urfave/cli/v3` binary showed:
+ 
+```
+21.58%  runtime                  1.0 MB
+ 6.57%  reflect                  315 kB
+ 6.25%  .rodata                  300 kB
+ 5.87%  github.com/urfave/cli/v3 282 kB
+ 5.74%  text/template            275 kB
+```
+ 
+This helps identify which packages are worth investigating. Packages such as
+`runtime` are fundamental to a Go binary and are not normally removable.
+For an interactive view, use:
+ 
+```sh-session
+gsa --tui myapp
+```
+ 
+> **Note:** analyze an unstripped binary when possible. Stripping debug
+> information can make package attribution less accurate.
+ 
+## Dependency Versions and Multiple Modules
+ 
+A repository may contain multiple Go modules, each with its own `go.mod`.
+Check the modules and their selected versions with:
+ 
+```sh-session
+go list -m all
+```
+ 
+For a specific dependency:
+ 
+```sh-session
+go list -m -json github.com/urfave/cli/v3
+```
+ 
+Different `go.mod` files do not automatically cause multiple versions of the
+same module to be included in a binary. Go normally selects a single version
+of a module path for a build.
+ 
+However, when comparing builds across multiple modules, it is important to
+check the actual selected version rather than relying only on the version
+written in `go.mod`. For example, the documentation module uses:
+ 
+```go
+replace github.com/urfave/cli/v3 => ../
+```
+ 
+so it builds against the local `urfave/cli/v3` checkout.
+ 
+## Reflection and Templates
+ 
+Reflection and runtime type inspection can contribute to binary size because
+additional type information and supporting code may remain reachable.
+ 
+In the example binary, `go-size-analyzer` reported:
+ 
+```
+reflect       315 kB
+text/template 275 kB
+```
+ 
+These numbers show their contribution to the analyzed binary, but do not by
+themselves prove that all of this code comes from a single feature.
+`urfave/cli/v3` uses templates for help rendering, making `text/template` one
+of the packages worth investigating when analyzing binary size.
+ 
+## Hiding Built-in Help
+ 
+Disabling built-in help does not currently reduce the binary size.
+ 
+Two otherwise identical binaries were built:
+ 
+```go
+&cli.Command{}
+```
+ 
+and:
+ 
+```go
+&cli.Command{
+    HideHelp:        true,
+    HideHelpCommand: true,
+}
+```
+ 
+Both were approximately 4.6 MB, and `go-size-analyzer` reported the same
+sizes for the relevant packages:
+ 
+| Package                     | Normal | Hidden |
+|------------------------------|--------|--------|
+| `reflect`                    | 315 kB | 315 kB |
+| `text/template`              | 275 kB | 275 kB |
+| `github.com/urfave/cli/v3`   | 282 kB | 282 kB |
+ 
+`HideHelp` and `HideHelpCommand` are runtime options, so hiding help does not
+remove the help implementation from the compiled binary. If reducing this
+overhead is important, a compile-time approach — such as separate build
+configurations or changes to the library — would be required.
+
+
+
+


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?
- Documentation


## What this PR does / why we need it:
Extends `docs/v3/binary-size.md` with the remaining topics requested in
#2365 that weren't covered by #2366:

- Added a section on using `go-size-analyzer` to get a package-level
  breakdown of binary size (install steps + example output).
- Added a section on checking selected dependency versions across
  multi-module repos with `go list -m all` / `go list -m -json`, and
  clarified that differing `go.mod` files don't automatically cause
  duplicate module versions in a build.
- Added a section explaining why `reflect` and `text/template` show up as
  significant contributors to binary size in `urfave/cli/v3` apps (help
  rendering uses templates internally).
- Added a section testing whether `HideHelp` / `HideHelpCommand` reduce
  binary size. They don't — verified with two otherwise identical builds
  producing the same size and identical `reflect`/`text/template` symbol
  footprint via `go-size-analyzer`. Documented this as a known limitation
  since these are runtime, not compile-time, options.


## Which issue(s) this PR fixes:

#2365

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

This is my first contribution to this project. I'd appreciate feedback on
whether the level of detail/tone fits the rest of the docs, and whether the
"Hiding Built-in Help" finding (that it doesn't reduce size) is presented
clearly — I wanted to document it as a tested result rather than a guess.

## Testing

All example output and size numbers were captured from real local builds
of a minimal `urfave/cli/v3` test app (one command, one string flag),
using `go build`, `go tool nm -size`, and `go-size-analyzer`/`gsa`, rather
than estimated or copied from elsewhere.

## Release Notes

```release-note
NONE
```
